### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ever wanted your Govee lights to actually *talk* to Home Assistant? This integra
 
 ### 1. Grab Your API Key
 
-In the **Govee Home** app: **Profile** → **Settings** → **About Us** → **Apply for API Key**
+In the **Govee Home** app: **Profile** → **Settings** → **Apply for API Key**
 
 Check your email in ~5 minutes.
 


### PR DESCRIPTION
"Apply for API Key" has been moved out from "About us" in the app (v7.3.02)