### PR TITLE
fix: Recognize devices.types.air_purifier as fan entity

### DIFF
--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -31,6 +31,7 @@ DEVICE_TYPE_HEATER = "devices.types.heater"
 DEVICE_TYPE_HUMIDIFIER = "devices.types.humidifier"
 DEVICE_TYPE_FAN = "devices.types.fan"
 DEVICE_TYPE_PURIFIER = "devices.types.purifier"
+DEVICE_TYPE_AIR_PURIFIER = "devices.types.air_purifier"
 
 # Instance constants
 INSTANCE_POWER = "powerSwitch"
@@ -290,8 +291,8 @@ class GoveeDevice:
 
     @property
     def is_fan(self) -> bool:
-        """Check if device is a fan."""
-        return self.device_type == DEVICE_TYPE_FAN
+        """Check if device is a fan or air purifier (uses same work mode controls)."""
+        return self.device_type in (DEVICE_TYPE_FAN, DEVICE_TYPE_AIR_PURIFIER)
 
     @property
     def is_heater(self) -> bool:
@@ -301,7 +302,7 @@ class GoveeDevice:
     @property
     def is_purifier(self) -> bool:
         """Check if device is an air purifier."""
-        return self.device_type == DEVICE_TYPE_PURIFIER
+        return self.device_type in (DEVICE_TYPE_PURIFIER, DEVICE_TYPE_AIR_PURIFIER)
 
     @property
     def supports_oscillation(self) -> bool:


### PR DESCRIPTION
## Summary
- Air purifiers like the H7126 report as `devices.types.air_purifier`, which was not matched by `is_fan` or `is_purifier`
- This caused no fan entity to be created, despite the device having compatible `workMode` capabilities (gearMode with Sleep/Low/High and Auto)
- Added `DEVICE_TYPE_AIR_PURIFIER` constant and updated `is_fan` and `is_purifier` to recognize it

## Test plan
- [ ] Verify H7126 (or similar air purifier with `devices.types.air_purifier` type) creates a fan entity
- [ ] Verify fan speed control works (Sleep/Low/High)
- [ ] Verify Auto preset mode works
- [ ] Verify existing `devices.types.fan` devices are unaffected