### PR TITLE
feat: Add direct BLE support for Govee BLE lights

### DIFF
--- a/custom_components/govee/__init__.py
+++ b/custom_components/govee/__init__.py
@@ -44,6 +44,8 @@ from .const import (
 )
 from .coordinator import GoveeCoordinator
 from .services import async_setup_services, async_unload_services
+from .coordinator_ble import GoveeBLECoordinator
+from .const import CONF_CONNECTION_TYPE, CONNECTION_TYPE_BLE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,6 +64,28 @@ PLATFORMS: list[Platform] = [
 # Type alias for runtime data
 type GoveeConfigEntry = ConfigEntry[GoveeCoordinator]
 
+_BLE_PLATFORMS: list[Platform] = [Platform.LIGHT]
+
+
+async def _async_setup_ble_entry(
+    hass: HomeAssistant, entry: GoveeConfigEntry
+) -> bool:
+    """Set up a BLE-direct Govee light entry."""
+    from homeassistant.exceptions import ConfigEntryNotReady
+    from homeassistant.components import bluetooth
+
+    address = entry.data.get("address", "")
+    if not bluetooth.async_ble_device_from_address(hass, address, False):
+        raise ConfigEntryNotReady(
+            f"Could not find Govee BLE device with address {address}"
+        )
+
+    coordinator = GoveeBLECoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, _BLE_PLATFORMS)
+    return True
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: GoveeConfigEntry) -> bool:
     """Set up Govee from a config entry.
@@ -78,6 +102,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoveeConfigEntry) -> boo
         ConfigEntryNotReady: Temporary setup failure.
     """
     _LOGGER.info("Setting up Govee integration (entry_id=%s)", entry.entry_id)
+
+    # Route BLE entries to a separate lightweight setup path
+    if entry.data.get(CONF_CONNECTION_TYPE) == CONNECTION_TYPE_BLE:
+        return await _async_setup_ble_entry(hass, entry)
+
     _LOGGER.debug("Entry options: %s", entry.options)
 
     api_key = entry.data[CONF_API_KEY]
@@ -226,6 +255,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: GoveeConfigEntry) -> bo
     Returns:
         True if unload was successful.
     """
+    # BLE entries only loaded LIGHT platform
+    if entry.data.get(CONF_CONNECTION_TYPE) == CONNECTION_TYPE_BLE:
+        return await hass.config_entries.async_unload_platforms(entry, _BLE_PLATFORMS)
+
     # Unload platforms
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/custom_components/govee/api/ble_direct.py
+++ b/custom_components/govee/api/ble_direct.py
@@ -1,0 +1,197 @@
+"""Direct BLE API for Govee lights.
+
+Implements the Govee BLE protocol for direct local control
+of Govee BLE lights without cloud connectivity.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import IntEnum
+
+import bleak_retry_connector
+from bleak import BleakClient, BLEDevice
+from bleak.backends.characteristic import BleakGATTCharacteristic
+
+_LOGGER = logging.getLogger(__name__)
+
+WRITE_CHARACTERISTIC_UUID = "00010203-0405-0607-0809-0a0b0c0d2b11"
+READ_CHARACTERISTIC_UUID = "00010203-0405-0607-0809-0a0b0c0d2b10"
+
+BLE_DISCOVERY_NAMES: tuple[str, ...] = ("Govee_", "ihoment_", "GBK_")
+
+
+class LedPacketHead(IntEnum):
+    COMMAND = 0x33
+    REQUEST = 0xAA
+
+
+class LedPacketCmd(IntEnum):
+    POWER = 0x01
+    BRIGHTNESS = 0x04
+    COLOR = 0x05
+    SEGMENT = 0xA5
+
+
+class LedColorType(IntEnum):
+    SEGMENTS = 0x15
+    SINGLE = 0x02
+    LEGACY = 0x0D
+
+
+@dataclass
+class LedPacket:
+    head: LedPacketHead
+    cmd: LedPacketCmd
+    payload: bytes | list = b""
+
+
+def _generate_checksum(frame: bytes) -> bytes:
+    checksum = 0
+    for b in frame:
+        checksum ^= b
+    return bytes([checksum & 0xFF])
+
+
+def _generate_frame(packet: LedPacket) -> bytes:
+    cmd = packet.cmd & 0xFF
+    frame = bytes([packet.head, cmd]) + bytes(packet.payload)
+    frame += bytes([0] * (19 - len(frame)))
+    frame += _generate_checksum(frame)
+    return frame
+
+
+def _verify_checksum(frame: bytes) -> bool:
+    return frame[-1:] == _generate_checksum(frame[:-1])
+
+
+class GoveeBLEClient:
+    """Direct BLE client for a single Govee BLE light.
+
+    Buffers commands and transmits them in one connection pass.
+    Reconnects automatically via bleak_retry_connector.
+    """
+
+    state: bool | None = None
+    brightness: int | None = None
+    color: tuple[int, int, int] | None = None
+
+    def __init__(
+        self,
+        ble_device: BLEDevice,
+        update_callback,
+        segmented: bool = False,
+    ) -> None:
+        self._ble_device = ble_device
+        self._segmented = segmented
+        self._packet_buffer: list[LedPacket] = []
+        self._client: BleakClient | None = None
+        self._update_callback = update_callback
+
+    @property
+    def address(self) -> str:
+        return self._ble_device.address
+
+    async def _ensure_connected(self) -> None:
+        if self._client is not None and self._client.is_connected:
+            return
+        await self._connect()
+
+    async def _connect(self) -> None:
+        self._client = await bleak_retry_connector.establish_connection(
+            BleakClient, self._ble_device, self.address
+        )
+        await self._client.start_notify(READ_CHARACTERISTIC_UUID, self._handle_receive)
+
+    async def _transmit_packet(self, packet: LedPacket) -> None:
+        frame = _generate_frame(packet)
+        await self._client.write_gatt_char(WRITE_CHARACTERISTIC_UUID, frame, False)
+
+    async def _handle_request_response(self, packet: LedPacket) -> None:
+        match packet.cmd:
+            case LedPacketCmd.POWER:
+                self.state = packet.payload[0] == 0x01
+            case LedPacketCmd.BRIGHTNESS:
+                raw = packet.payload[0]
+                self.brightness = int(raw / 100 * 255) if self._segmented else raw
+            case LedPacketCmd.COLOR:
+                self.color = (packet.payload[1], packet.payload[2], packet.payload[3])
+            case LedPacketCmd.SEGMENT:
+                self.color = (packet.payload[2], packet.payload[3], packet.payload[4])
+
+    async def _handle_receive(
+        self, characteristic: BleakGATTCharacteristic, frame: bytearray
+    ) -> None:
+        if not _verify_checksum(bytes(frame)):
+            _LOGGER.warning("BLE packet checksum mismatch for %s", self.address)
+            return
+        packet = LedPacket(
+            head=frame[0],
+            cmd=frame[1],
+            payload=bytes(frame[2:-1]),
+        )
+        if packet.head == LedPacketHead.REQUEST:
+            await self._handle_request_response(packet)
+            await self._update_callback()
+
+    def _queue(
+        self,
+        cmd: LedPacketCmd,
+        payload: bytes | list = b"",
+        request: bool = False,
+        repeat: int = 3,
+    ) -> None:
+        head = LedPacketHead.REQUEST if request else LedPacketHead.COMMAND
+        packet = LedPacket(head, cmd, payload)
+        self._packet_buffer.extend([packet] * repeat)
+
+    async def send_buffer(self) -> None:
+        """Flush all buffered packets over BLE."""
+        if not self._packet_buffer:
+            return
+        await self._ensure_connected()
+        for packet in self._packet_buffer:
+            await self._transmit_packet(packet)
+        self._packet_buffer.clear()
+
+    # -- State request helpers --
+
+    def request_state(self) -> None:
+        self._queue(LedPacketCmd.POWER, request=True)
+
+    def request_brightness(self) -> None:
+        self._queue(LedPacketCmd.BRIGHTNESS, request=True)
+
+    def request_color(self) -> None:
+        if self._segmented:
+            self._queue(LedPacketCmd.SEGMENT, b"\x01", request=True)
+        else:
+            self._queue(LedPacketCmd.COLOR, request=True)
+
+    # -- Command helpers --
+
+    def set_state(self, state: bool) -> None:
+        if self.state == state:
+            return
+        self._queue(LedPacketCmd.POWER, [0x01 if state else 0x00])
+        self.request_state()
+
+    def set_brightness(self, brightness: int) -> None:
+        if self.brightness == brightness:
+            return
+        payload = round(brightness / 255 * 100) if self._segmented else round(brightness)
+        self._queue(LedPacketCmd.BRIGHTNESS, [payload])
+        self.request_brightness()
+
+    def set_color(self, red: int, green: int, blue: int) -> None:
+        if self.color == (red, green, blue):
+            return
+        if self._segmented:
+            self._queue(
+                LedPacketCmd.COLOR,
+                [LedColorType.SEGMENTS, 0x01, red, green, blue, 0, 0, 0, 0, 0, 0xFF, 0xFF],
+            )
+        else:
+            self._queue(LedPacketCmd.COLOR, [LedColorType.SINGLE, red, green, blue])
+            self._queue(LedPacketCmd.COLOR, [LedColorType.LEGACY, red, green, blue])
+        self.request_color()

--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -11,12 +11,17 @@ import logging
 from typing import Any
 
 import voluptuous as vol
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfoBleak,
+    async_discovered_service_info,
+)
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
 )
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
@@ -99,12 +104,54 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._password: str | None = None
         self._client_id: str | None = None
         self._iot_credentials: GoveeIotCredentials | None = None
+        self._ble_discovery_info = None
 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Get the options flow for this handler."""
         return GoveeOptionsFlow(config_entry)
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> ConfigFlowResult:
+        """Handle Bluetooth discovery of a Govee BLE device."""
+        await self.async_set_unique_id(discovery_info.address)
+        self._abort_if_unique_id_configured()
+        self._ble_discovery_info = discovery_info
+        self.context["title_placeholders"] = {"name": discovery_info.name}
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm BLE device discovery and ask about segmented mode."""
+        assert hasattr(self, "_ble_discovery_info"), "No BLE discovery info"
+        info = self._ble_discovery_info
+
+        if user_input is not None:
+            from .const import (
+                CONF_BLE_SEGMENTED,
+                CONF_CONNECTION_TYPE,
+                CONNECTION_TYPE_BLE,
+            )
+            from homeassistant.const import CONF_ADDRESS, CONF_NAME
+
+            return self.async_create_entry(
+                title=info.name,
+                data={
+                    CONF_CONNECTION_TYPE: CONNECTION_TYPE_BLE,
+                    CONF_ADDRESS: info.address.upper(),
+                    CONF_NAME: info.name,
+                    CONF_BLE_SEGMENTED: user_input["segmented"],
+                },
+            )
+
+        return self.async_show_form(
+            step_id="bluetooth_confirm",
+            data_schema=vol.Schema({vol.Required("segmented", default=True): bool}),
+            description_placeholders={"name": info.name, "address": info.address},
+        )
 
     async def async_step_user(
         self,

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -55,3 +55,16 @@ SUFFIX_HEATER_TEMPERATURE: Final = "_heater_temperature"
 SUFFIX_HEATER_FAN_SPEED: Final = "_heater_fan_speed"
 SUFFIX_HEATER_AUTO_STOP: Final = "_heater_auto_stop"
 SUFFIX_PURIFIER_MODE_SELECT: Final = "_purifier_mode_select"
+
+# -- BLE device support --
+
+# Distinguishes cloud entries from BLE-direct entries in config data
+CONF_CONNECTION_TYPE: Final = "connection_type"
+CONNECTION_TYPE_CLOUD: Final = "cloud"
+CONNECTION_TYPE_BLE: Final = "ble"
+
+# BLE device config keys (stored in config entry data for BLE entries)
+CONF_BLE_SEGMENTED: Final = "ble_segmented"
+
+# BLE advertising name prefixes used for Bluetooth discovery
+BLE_DISCOVERY_NAMES: Final[tuple[str, ...]] = ("Govee_", "ihoment_", "GBK_")

--- a/custom_components/govee/coordinator_ble.py
+++ b/custom_components/govee/coordinator_ble.py
@@ -1,0 +1,93 @@
+"""BLE DataUpdateCoordinator for Govee BLE lights."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+
+from homeassistant.components import bluetooth
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .api.ble_direct import GoveeBLEClient
+from .const import CONF_BLE_SEGMENTED, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class GoveeBLEState:
+    """Snapshot of BLE device state."""
+
+    state: bool | None = None
+    brightness: int | None = None
+    color: tuple[int, int, int] | None = None
+
+
+class GoveeBLECoordinator(DataUpdateCoordinator[GoveeBLEState]):
+    """Coordinator for a single Govee BLE light.
+
+    Each BLE config entry gets its own coordinator instance.
+    State is fetched by polling (every 15s) and pushed immediately
+    when the device responds to a command request.
+    """
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        self.device_name: str = config_entry.data[CONF_NAME]
+        self.device_address: str = config_entry.data[CONF_ADDRESS]
+        segmented: bool = config_entry.data.get(CONF_BLE_SEGMENTED, True)
+
+        ble_device = bluetooth.async_ble_device_from_address(
+            hass, self.device_address, connectable=False
+        )
+        assert ble_device, f"BLE device {self.device_address} not found"
+
+        self._ble_client = GoveeBLEClient(ble_device, self._async_push_update, segmented)
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN}_ble ({self.device_address})",
+            update_method=self._async_update_data,
+            update_interval=timedelta(seconds=15),
+        )
+
+    def _snapshot(self) -> GoveeBLEState:
+        return GoveeBLEState(
+            state=self._ble_client.state,
+            brightness=self._ble_client.brightness,
+            color=self._ble_client.color,
+        )
+
+    async def _async_push_update(self) -> None:
+        """Called by BLE client when device pushes a state response."""
+        self.async_set_updated_data(self._snapshot())
+
+    async def _async_update_data(self) -> GoveeBLEState:
+        """Poll all state from the device."""
+        self._ble_client.request_state()
+        self._ble_client.request_brightness()
+        self._ble_client.request_color()
+        await self._ble_client.send_buffer()
+        return self._snapshot()
+
+    # -- Control API --
+
+    async def async_set_state(self, state: bool) -> None:
+        self._ble_client.set_state(state)
+
+    async def async_set_brightness(self, brightness: int) -> None:
+        self._ble_client.set_brightness(brightness)
+
+    async def async_set_color(self, red: int, green: int, blue: int) -> None:
+        self._ble_client.set_color(red, green, blue)
+
+    async def async_send_buffer(self) -> None:
+        await self._ble_client.send_buffer()
+
+    async def async_shutdown(self) -> None:
+        """Clean up — BLE client holds no persistent connection."""
+        pass

--- a/custom_components/govee/light.py
+++ b/custom_components/govee/light.py
@@ -60,6 +60,12 @@ async def async_setup_entry(
     """Set up Govee lights from a config entry."""
     coordinator: GoveeCoordinator = entry.runtime_data
 
+    from .coordinator_ble import GoveeBLECoordinator
+    from .platforms.ble_light import GoveeBLELightEntity
+    if isinstance(coordinator, GoveeBLECoordinator):
+        async_add_entities([GoveeBLELightEntity(coordinator)])
+        return
+
     entities: list[LightEntity] = []
 
     # Get per-device segment modes

--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -1,18 +1,24 @@
 {
   "domain": "govee",
-  "name": "Govee Cloud Integration",
+  "name": "Govee",
   "codeowners": ["@lasswellt"],
+  "bluetooth": [
+    {"local_name": "Govee_*", "connectable": false},
+    {"local_name": "ihoment_*", "connectable": false},
+    {"local_name": "GBK_*", "connectable": false}
+  ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["bluetooth"],
   "documentation": "https://github.com/lasswellt/govee-homeassistant/blob/master/README.md",
   "homekit": {},
   "integration_type": "hub",
-  "iot_class": "cloud_push",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/lasswellt/govee-homeassistant/issues",
   "loggers": ["custom_components.govee", "aiohttp", "aiomqtt"],
   "requirements": [
     "aiohttp-retry>=2.8.3",
     "aiomqtt>=2.0.0",
+    "bleak-retry-connector>=3.0.0",
     "cryptography>=41.0.0"
   ],
   "ssdp": [],

--- a/custom_components/govee/platforms/ble_light.py
+++ b/custom_components/govee/platforms/ble_light.py
@@ -1,0 +1,84 @@
+"""BLE light entity for Govee BLE lights within the govee integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from ..const import DOMAIN
+from ..coordinator_ble import GoveeBLECoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+_HA_MAX = 255
+
+
+def _remap(value: float, in_min: float, in_max: float, out_min: float, out_max: float) -> float:
+    return out_min + (value - in_min) / (in_max - in_min) * (out_max - out_min)
+
+
+class GoveeBLELightEntity(CoordinatorEntity[GoveeBLECoordinator], LightEntity):
+    """Light entity for a directly-connected Govee BLE device.
+
+    Registered under the govee domain so cloud and BLE devices
+    appear under the same integration in the UI.
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = None  # use device name
+    _attr_supported_color_modes = {ColorMode.RGB}
+    _attr_color_mode = ColorMode.RGB
+
+    def __init__(self, coordinator: GoveeBLECoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = coordinator.device_address
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.device_address)},
+            name=coordinator.device_name,
+            manufacturer="Govee",
+            model=coordinator.device_name,
+            serial_number=coordinator.device_address,
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        return self.coordinator.data.state if self.coordinator.data else None
+
+    @property
+    def brightness(self) -> int | None:
+        return self.coordinator.data.brightness if self.coordinator.data else None
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        return self.coordinator.data.color if self.coordinator.data else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self.coordinator.async_set_state(True)
+
+        if ATTR_BRIGHTNESS in kwargs:
+            raw = kwargs[ATTR_BRIGHTNESS]
+            mapped = round(_remap(raw, 1, _HA_MAX, 0, _HA_MAX))
+            await self.coordinator.async_set_brightness(mapped)
+
+        if ATTR_RGB_COLOR in kwargs:
+            r, g, b = kwargs[ATTR_RGB_COLOR]
+            await self.coordinator.async_set_color(r, g, b)
+
+        await self.coordinator.async_send_buffer()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.async_set_state(False)
+        await self.coordinator.async_send_buffer()


### PR DESCRIPTION
**Summary**
Adds direct Bluetooth (BLE) control for Govee BLE lights (Govee_*, ihoment_*, GBK_*) as a second connection mode alongside the existing cloud integration BLE devices are auto-discovered via HA's Bluetooth integration and each get their own lightweight config entry under the govee domain Implements the Govee BLE wire protocol (packet framing, XOR checksum, segmented/legacy brightness and color encoding) in api/ble_direct.py Cloud devices and BLE devices coexist under a single integration — no separate govee_light_ble custom component needed 

**Changes**

- api/ble_direct.py (new) — BLE protocol client implementing packet framing, XOR checksum, and command buffering (GoveeBLEClient)
- coordinator_ble.py (new) — per-device GoveeBLECoordinator with 15s polling and push updates when device responds to commands
- platforms/ble_light.py (new) — GoveeBLELightEntity supporting RGB color, brightness, and on/off via BLE
- manifest.json — added bluetooth dependency, three BLE device name discovery filters (Govee_*, ihoment_*, GBK_*), and bleak-retry-connector>=3.0.0 requirement
- const.py — added CONF_CONNECTION_TYPE, CONNECTION_TYPE_BLE, CONF_BLE_SEGMENTED, and BLE_DISCOVERY_NAMES
- __init__.py — added _BLE_PLATFORMS, _async_setup_ble_entry(), and routing logic to fork BLE vs cloud setup at entry load time
- light.py — added GoveeBLECoordinator type check at platform setup to register GoveeBLELightEntity and return early for BLE entries
- config_flow.py — added async_step_bluetooth for auto-discovery and async_step_bluetooth_confirm prompting the user for segmented mode

**Notes**
The segmented option during BLE setup controls which BLE protocol variant is used — modern RGBIC strips require segmented mode (0–100 brightness scale, 0xA5 color read command); legacy bulbs/strips do not BLE entries only load the light platform — cloud-only platforms (fan, sensor, select, etc.) are skipped govee_light_ble custom component can be removed after this is merged