### PR TITLE
fix: convert H5179 thermometer Fahrenheit readings via option

### DIFF
--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -34,6 +34,7 @@ from .api.auth import _derive_client_id
 from .api.client import validate_api_key
 from .const import (
     CONF_API_KEY,
+    CONF_API_TEMPERATURE_UNIT,
     CONF_EMAIL,
     CONF_ENABLE_DIY_SCENES,
     CONF_ENABLE_GROUPS,
@@ -44,6 +45,7 @@ from .const import (
     CONF_POLL_INTERVAL,
     CONF_SEGMENT_MODE,
     CONFIG_VERSION,
+    DEFAULT_API_TEMPERATURE_UNIT,
     DEFAULT_ENABLE_DIY_SCENES,
     DEFAULT_ENABLE_GROUPS,
     DEFAULT_ENABLE_SCENES,
@@ -696,6 +698,12 @@ class GoveeOptionsFlow(OptionsFlow):
                             DEFAULT_EXPOSE_TRANSPORT_ENTITIES,
                         ),
                     ): bool,
+                    vol.Optional(
+                        CONF_API_TEMPERATURE_UNIT,
+                        default=options.get(
+                            CONF_API_TEMPERATURE_UNIT, DEFAULT_API_TEMPERATURE_UNIT
+                        ),
+                    ): vol.In(["celsius", "fahrenheit"]),
                 }
             ),
         )

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -18,6 +18,11 @@ CONF_ENABLE_SEGMENTS: Final = "enable_segments"
 CONF_SEGMENT_MODE: Final = "segment_mode"
 CONF_EXPOSE_TRANSPORT_ENTITIES: Final = "expose_transport_entities"
 
+# Some Govee thermometer/hygrometer SKUs (or account settings) report
+# temperatures in Fahrenheit via the Cloud API, but do not include unit
+# metadata. Home Assistant needs the integration to normalize the value.
+CONF_API_TEMPERATURE_UNIT: Final = "api_temperature_unit"  # "celsius" | "fahrenheit"
+
 # Defaults
 DEFAULT_POLL_INTERVAL: Final = 60  # seconds
 DEFAULT_ENABLE_GROUPS: Final = False
@@ -26,6 +31,7 @@ DEFAULT_ENABLE_DIY_SCENES: Final = True
 DEFAULT_ENABLE_SEGMENTS: Final = True
 DEFAULT_SEGMENT_MODE: Final = "individual"  # "disabled", "grouped", or "individual"
 DEFAULT_EXPOSE_TRANSPORT_ENTITIES: Final = False
+DEFAULT_API_TEMPERATURE_UNIT: Final = "celsius"
 
 # Optimistic state handling
 # Grace window (seconds) during which API polls do NOT overwrite optimistic

--- a/custom_components/govee/models/state.py
+++ b/custom_components/govee/models/state.py
@@ -125,7 +125,7 @@ class GoveeDeviceState:
 
     # Read-only sensor properties (devices.capabilities.property) for
     # stand-alone sensors like H5109/H5179. None until first poll lands.
-    sensor_temperature: float | None = None  # Celsius (always; entity converts)
+    sensor_temperature: float | None = None  # Raw from API (°C or °F; entity may normalize)
     sensor_humidity: float | None = None  # Relative humidity 0-100 %
 
     # Last activated scene (for restoring after music mode off)

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -26,7 +26,11 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    CONF_API_TEMPERATURE_UNIT,
+    DEFAULT_API_TEMPERATURE_UNIT,
+    DOMAIN,
+)
 from .coordinator import GoveeCoordinator
 from .entity import GoveeEntity
 from .models import GoveeDevice
@@ -182,7 +186,24 @@ class GoveeTemperatureSensor(GoveeEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         state = self.device_state
-        return state.sensor_temperature if state else None
+        if not state or state.sensor_temperature is None:
+            return None
+
+        value = float(state.sensor_temperature)
+
+        # Some thermometer/hygrometer devices report temperature in Fahrenheit
+        # via the Govee Cloud API, but without unit metadata. Normalize to
+        # Celsius here so HA displays the correct value under a Celsius native
+        # unit (and can still convert if the user's system is Fahrenheit).
+        api_unit = self.coordinator.config_entry.options.get(
+            CONF_API_TEMPERATURE_UNIT,
+            DEFAULT_API_TEMPERATURE_UNIT,
+        )
+        if api_unit == "fahrenheit":
+            # Avoid HA-version-specific helpers; keep conversion local.
+            return (value - 32.0) * (5.0 / 9.0)
+
+        return value
 
 
 class GoveeHumiditySensor(GoveeEntity, SensorEntity):

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -79,6 +79,7 @@
         "description": "If you have RGBIC devices, per-device segment settings will appear after submitting.",
         "data": {
           "poll_interval": "Polling interval (seconds)",
+          "api_temperature_unit": "Temperature unit from Govee API (thermometers)",
           "enable_groups": "Enable group devices",
           "enable_scenes": "Enable scene selector",
           "enable_diy_scenes": "Enable DIY scene selector",

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -79,6 +79,7 @@
         "description": "If you have RGBIC devices, per-device segment settings will appear after submitting.",
         "data": {
           "poll_interval": "Polling interval (seconds)",
+          "api_temperature_unit": "Temperature unit from Govee API (thermometers)",
           "enable_groups": "Enable group devices",
           "enable_scenes": "Enable scene selector",
           "enable_diy_scenes": "Enable DIY scene selector",


### PR DESCRIPTION
Fixes #72.

Some thermometer/hygrometer devices (e.g. H5179) appear to report `sensorTemperature` in Fahrenheit via the cloud API even when the app/HA are configured for Celsius. The integration currently assumes Celsius and exposes the raw number as °C, leading to values like ~70°C.

### Changes
- Add an Options Flow setting: `api_temperature_unit` (celsius|fahrenheit)
- When set to `fahrenheit`, convert the API value to Celsius in `GoveeTemperatureSensor.native_value`
- Add UI strings for the new option

### Notes
- Conversion is done with a local formula to avoid HA-version-specific helper imports.

### How to use
Settings → Devices & services → Govee → Configure → set "Temperature unit from Govee API (thermometers)" to `fahrenheit`.
