### PR TITLE
fix: pass hass to validate_api_key to prevent RuntimeError during setup

### DIFF
--- a/custom_components/govee/api/client.py
+++ b/custom_components/govee/api/client.py
@@ -461,11 +461,12 @@ class GoveeApiClient:
             raise GoveeConnectionError(f"Connection error: {err}") from err
 
 
-async def validate_api_key(api_key: str) -> bool:
+async def validate_api_key(api_key: str, hass: HomeAssistant) -> bool:
     """Validate a Govee API key by making a test request.
 
     Args:
         api_key: API key to validate.
+        hass: Home Assistant instance for session management.
 
     Returns:
         True if valid.
@@ -474,7 +475,7 @@ async def validate_api_key(api_key: str) -> bool:
         GoveeAuthError: Invalid API key.
         GoveeApiError: Other errors.
     """
-    async with GoveeApiClient(api_key) as client:
+    async with GoveeApiClient(api_key, hass=hass) as client:
         # get_devices will raise GoveeAuthError if key is invalid
         await client.get_devices()
         return True

--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -128,7 +128,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = format_error
             else:
                 try:
-                    await validate_api_key(cleaned_key)
+                    await validate_api_key(cleaned_key, self.hass)
                     self._api_key = cleaned_key
 
                     # Proceed to optional account step for MQTT
@@ -437,7 +437,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = format_error
             else:
                 try:
-                    await validate_api_key(cleaned_key)
+                    await validate_api_key(cleaned_key, self.hass)
 
                     # Update existing entry
                     entry = self.hass.config_entries.async_get_entry(
@@ -496,7 +496,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = format_error
             else:
                 try:
-                    await validate_api_key(cleaned_key)
+                    await validate_api_key(cleaned_key, self.hass)
 
                     # Build updated data
                     new_data: dict[str, Any] = {


### PR DESCRIPTION
## Problem

`validate_api_key()` in `api/client.py` creates a `GoveeApiClient(api_key)` without passing `hass`. The client`s `_ensure_client()` enforces that either `session` or `hass` must be provided to obtain an aiohttp session ([HA Platinum rule `inject-websession`](https://github.com/home-assistant/core/blob/dev/script/hassfest/quality_scale.py)). 

Without it, a `RuntimeError` is raised at config-flow validation time, which gets caught by the generic exception handler and surfaces as **"Unexpected error occurred"** in the HA UI.

Closes #80. (Alternative to incomplete #77 which only changes the signature but never updates the call sites.)

## Fix

1. **`api/client.py`** — Accept `hass: HomeAssistant` in `validate_api_key` and pass it through to `GoveeApiClient`
2. **`config_flow.py`** — Update all 3 call sites (`user`, `reauth_confirm`, `reconfigure`) to pass `self.hass`

## Testing

- Add integration via UI with a valid Govee API key → setup completes successfully
- Reconfigure existing integration → API key validation succeeds
- Re-auth flow → API key validation succeeds