### PR TITLE
fix(light): restore color light entity for outlet extenders w/ nightlight (#59)

### DIFF
--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -674,15 +674,23 @@ class GoveeDevice:
 
     @property
     def is_light_device(self) -> bool:
-        """Check if device is a light (not a plug, fan, or other appliance)."""
+        """Check if device is a light (not a plain plug, fan, or other appliance).
+
+        An outlet extender that exposes an RGB / tunable-white nightlight
+        (e.g. H5089) IS a light for that nightlight, so a plug is only
+        excluded when it has no color capability. Plain plugs (on/off only)
+        stay switch-only. Fixes #59 — the #54 appliance filter over-reached
+        and removed the H5089's color light entity.
+        """
         if (
             self.is_fan
-            or self.is_plug
             or self.is_heater
             or self.is_purifier
             or self.is_humidifier
             or self.is_kettle
         ):
+            return False
+        if self.is_plug and not (self.supports_rgb or self.supports_color_temp):
             return False
         return (
             self.device_type == DEVICE_TYPE_LIGHT

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -246,6 +246,39 @@ class TestGoveeDevice:
         """Test plug detection."""
         assert mock_plug_device.is_plug is True
 
+    def test_plain_plug_not_light_device(self, mock_plug_device):
+        """A plain plug (on/off only) must NOT be a light device (guards #54)."""
+        assert mock_plug_device.is_plug is True
+        assert mock_plug_device.supports_rgb is False
+        assert mock_plug_device.is_light_device is False
+
+    def test_socket_with_color_nightlight_is_light_device(self):
+        """An outlet extender with an RGB nightlight (H5089) IS a light (#59).
+
+        The #54 appliance filter excluded all sockets, removing the H5089's
+        color light entity. A socket with color capability must be a light.
+        """
+        device = GoveeDevice(
+            device_id="03:9C:DC:06:75:4B:10:7C",
+            sku="H5089",
+            name="Smart Outlet Extender",
+            device_type="devices.types.socket",
+            capabilities=(
+                GoveeCapability(
+                    type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}
+                ),
+                GoveeCapability(
+                    type=CAPABILITY_COLOR_SETTING,
+                    instance=INSTANCE_COLOR_RGB,
+                    parameters={},
+                ),
+            ),
+            is_group=False,
+        )
+        assert device.is_plug is True
+        assert device.supports_rgb is True
+        assert device.is_light_device is True
+
     def test_is_group(self, mock_group_device):
         """Test group device detection."""
         assert mock_group_device.is_group is True


### PR DESCRIPTION
Fixes #59. The #54 appliance filter added `is_plug` to `is_light_device`'s exclusion, removing the H5089's RGB nightlight light entity (color control went unavailable). Now plugs are excluded from the light platform only when they have no color capability; plain on/off plugs stay switch-only (#54 preserved).

Tests: 762 passed. mypy + flake8 clean.