### PR TITLE
fix: H5110/H5179 humidity 10× scaling regression (#102)

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -885,16 +885,19 @@ class GoveeAuthClient:
                         "name": device.get("deviceName", sku),
                     }
 
-                # Collect live temperature/humidity from lastDeviceData for
-                # non-leak, Developer-API thermometers (e.g. H5110/H5075 via an
-                # H5151 gateway, H5179). The Developer /device/state endpoint
-                # returns a stale cached reading for these BLE-bridged sensors
-                # and only refreshes lazily — but calling this BFF endpoint
-                # tickles Govee's cloud into refreshing, and lastDeviceData is
-                # the live value the app uses (issue #83, confirmed by @davcamer).
-                # Scale: tem = hundredths of °C (2800 -> 28.00); hum = tenths of
-                # % (393 -> 39.3) — note hum differs from the H5301/H5310 path.
-                # H5301/H5310 are skipped here; the dedicated thermo path owns them.
+                # Note which non-leak, Developer-API thermometers (e.g. H5110/
+                # H5075 via an H5151/H5044 gateway, H5179) the BFF list carries a
+                # reading for. The Developer /device/state endpoint returns a
+                # stale cached reading for these BLE-bridged sensors and only
+                # refreshes lazily — but calling THIS BFF endpoint tickles Govee's
+                # cloud into refreshing it (issue #83, confirmed by @davcamer).
+                # We return the raw tem/hum so the coordinator knows which devices
+                # to keep the tickle running for, but the values are NOT applied:
+                # the BFF scale varies by gateway/firmware (e.g. hum is hundredths
+                # for H5110-via-H5044/H5151 and H5179, not the tenths once assumed),
+                # and a fixed divisor mis-scaled humidity 10x (issue #102). The
+                # correctly scaled, unit-handled value comes from the Developer
+                # poll. H5301/H5310 are skipped; the dedicated thermo path owns them.
                 thermo_readings: dict[str, dict[str, Any]] = {}
                 for device in devices:
                     sku = device.get("sku", "")

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -49,13 +49,10 @@ from .ble_advertisement import BleAdvertisementHandler
 from .ble_advertisement import sku_from_ble_name as _sku_from_ble_name  # noqa: F401
 from .api.mqtt_control import command_to_mqtt
 from .const import (
-    CONF_API_TEMPERATURE_UNIT,
     CONF_ENABLE_MQTT_CONTROL,
-    DEFAULT_API_TEMPERATURE_UNIT,
     DEFAULT_ENABLE_MQTT_CONTROL,
     DOMAIN,
     OPTIMISTIC_GRACE_CAP_SECONDS,
-    resolve_fahrenheit_conversion,
 )
 from .models import (
     GoveeDevice,
@@ -745,15 +742,19 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                     len({s.hub_device_id for s in self._leak_sensors.values()}),
                 )
 
-            # Apply initial BFF live readings to Developer-API thermometers we
-            # actually discovered (e.g. H5110 via H5151). The Developer
-            # /device/state value is stale for these BLE-bridged sensors (#83).
+            # Track which Developer-API thermometers (e.g. H5110 via H5151/H5044)
+            # the BFF list carries a reading for. We DON'T apply the BFF value:
+            # the BFF `tem`/`hum` scale varies by gateway/firmware (tenths vs
+            # hundredths) and a fixed divisor mis-scaled humidity 10x (#102).
+            # The BFF call is kept purely as a *tickle* — it nudges Govee's cloud
+            # to refresh the Developer `/device/state` reading, which the regular
+            # poll then picks up correctly (and with the right °C/°F handling).
+            # This set only gates whether the 5-min tickle poll runs (#83).
             self._thermo_bff_devices = set(thermo_readings) & set(self._devices)
-            for device_id in self._thermo_bff_devices:
-                self._apply_bff_thermo_reading(device_id, thermo_readings[device_id])
             if self._thermo_bff_devices:
                 _LOGGER.info(
-                    "BFF live readings available for %d thermometer device(s)",
+                    "BFF tickle enabled for %d thermometer device(s); readings "
+                    "come from the Developer API poll",
                     len(self._thermo_bff_devices),
                 )
 
@@ -987,7 +988,7 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 (
                     sensor_data,
                     _hub_data,
-                    thermo_readings,
+                    _thermo_readings,
                 ) = await auth_client.fetch_bff_leak_sensors(
                     self._iot_credentials.token
                 )
@@ -1034,69 +1035,17 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 )
                 state.is_wet = True
 
-        # Apply refreshed BFF live readings to Developer-API thermometers and
-        # push to HA so the sensor entities pick them up (#83). Only fires an
-        # update when a reading actually changed (avoids 5-min churn).
-        thermo_changed = False
-        for device_id in self._thermo_bff_devices:
-            reading = thermo_readings.get(device_id)
-            if reading and self._apply_bff_thermo_reading(device_id, reading):
-                thermo_changed = True
-        if thermo_changed:
-            self.async_set_updated_data(self._states)
+        # The BFF device-list call above already tickled Govee's cloud into
+        # refreshing the Developer `/device/state` reading for these BLE-bridged
+        # thermometers; the regular Developer poll picks up the fresh, correctly
+        # scaled value. We deliberately do NOT apply the BFF `tem`/`hum` here —
+        # its scale varies by gateway and a fixed divisor over-scaled humidity
+        # 10x on every BFF cycle (#102). The reading is discarded (`_thermo_
+        # readings`); the tickle alone is what these thermometers need (#83).
 
         # Notify leak sensor entities only (avoids churning unrelated
         # light / switch entities that also subscribe to the coordinator).
         async_dispatcher_send(self.hass, f"{DOMAIN}_leak_update")
-
-    def _apply_bff_thermo_reading(
-        self, device_id: str, reading: dict[str, Any]
-    ) -> bool:
-        """Apply a BFF ``lastDeviceData`` reading to a thermometer's state (#83).
-
-        BFF scale: ``tem`` is hundredths of °C (2800 -> 28.00), ``hum`` is
-        tenths of % (393 -> 39.3) — confirmed against a real H5110 via H5151.
-
-        Temperature is stored in the SAME unit the entity expects as its raw
-        ``sensor_temperature``: the entity converts °F→°C for SKUs the #96
-        Fahrenheit logic flags, so for those we store the BFF °C back-converted
-        to °F (it round-trips to the right °C); otherwise we store °C directly.
-        Returns True if a reading actually changed.
-        """
-        device = self._devices.get(device_id)
-        state = self._states.get(device_id)
-        if device is None or state is None:
-            return False
-
-        tem = reading.get("tem")
-        hum = reading.get("hum")
-        if tem is None and hum is None:
-            return False
-
-        existing = dataclasses.replace(state)
-
-        if tem is not None:
-            temp_celsius = tem / 100.0
-            api_unit = (
-                self._config_entry.options.get(
-                    CONF_API_TEMPERATURE_UNIT, DEFAULT_API_TEMPERATURE_UNIT
-                )
-                if self._config_entry is not None
-                else DEFAULT_API_TEMPERATURE_UNIT
-            )
-            if resolve_fahrenheit_conversion(device.sku, api_unit):
-                state.sensor_temperature = temp_celsius * 9.0 / 5.0 + 32.0
-            else:
-                state.sensor_temperature = temp_celsius
-
-        if hum is not None:
-            state.sensor_humidity = hum / 10.0
-
-        self._note_sensor_reading_change(device_id, state, existing)
-        return (
-            state.sensor_temperature != existing.sensor_temperature
-            or state.sensor_humidity != existing.sensor_humidity
-        )
 
     @property
     def _water_detectors(self) -> list[GoveeDevice]:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2214,63 +2214,103 @@ class TestBffThermometerDiscovery:
         device_reg.async_get_or_create.assert_not_called()
 
 
-class TestBffThermoLiveReadings:
-    """BFF live tem/hum applied to Developer-API thermometers (issue #83)."""
+class TestBffThermoTickleOnly:
+    """BFF list is a *tickle* for Developer-API thermometers (issues #83, #102).
 
-    def _coord(self, options=None):
+    The BFF ``tem``/``hum`` are NOT applied to state: their scale varies by
+    gateway/firmware and a fixed ``/10`` divisor over-scaled humidity 10x
+    (#102). The reading is used only to gate the tickle poll; the correctly
+    scaled, unit-handled value comes from the Developer ``/device/state`` poll.
+    """
+
+    def _coord(self):
         import custom_components.govee.coordinator as coord_mod
 
-        coord = object.__new__(coord_mod.GoveeCoordinator)
-        coord._sensor_reading_changed_at = {}
-        coord._devices = {}
-        coord._states = {}
-        from types import SimpleNamespace
-
-        coord._config_entry = SimpleNamespace(options=options or {})
-        return coord
-
-    def _add_device(self, coord, device_id, sku):
-        coord._devices[device_id] = GoveeDevice.synthetic_thermometer(
-            device_id, sku, sku
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=MagicMock(token="tok"),
+            poll_interval=60,
         )
-        coord._states[device_id] = GoveeDeviceState.create_empty(device_id)
+        coord.async_update_listeners = MagicMock()
+        coord.async_set_updated_data = MagicMock()
+        coord._schedule_bff_poll = MagicMock()
+        return coord, coord_mod
 
-    def test_celsius_sku_stores_celsius_and_tenths_humidity(self):
-        # H5052 not in FAHRENHEIT_REPORTING_SKUS -> auto = no conversion.
-        coord = self._coord()
-        self._add_device(coord, "D1", "H5052")
+    @pytest.mark.asyncio
+    async def test_poll_does_not_overwrite_developer_reading(self, monkeypatch):
+        """The 5-min BFF poll must leave the Developer-API reading intact (#102)."""
+        coord, coord_mod = self._coord()
+        did = "AA:BB:CC:DD:EE:FF:00:22"
+        coord._devices[did] = GoveeDevice.synthetic_thermometer(did, "H5110", "Garage")
+        state = GoveeDeviceState.create_empty(did)
+        # The correct values the Developer /device/state poll wrote.
+        state.sensor_temperature = 75.02
+        state.sensor_humidity = 83.0
+        coord._states[did] = state
+        coord._thermo_bff_devices = {did}
 
-        changed = coord._apply_bff_thermo_reading("D1", {"tem": 2800, "hum": 393})
+        inner = MagicMock()
+        # raw hum=8300 (hundredths) -> the old /10 bug surfaced 830.0.
+        inner.fetch_bff_leak_sensors = _make_async(
+            ([], {}, {did: {"tem": 7502, "hum": 8300}})
+        )
+        monkeypatch.setattr(coord_mod, "GoveeAuthClient", lambda **kw: _AsyncCM(inner))
+        monkeypatch.setattr(coord_mod, "async_dispatcher_send", MagicMock())
 
-        assert changed is True
-        assert coord._states["D1"].sensor_temperature == 28.0
-        assert coord._states["D1"].sensor_humidity == 39.3
+        await coord._poll_bff_leak_state()
 
-    def test_fahrenheit_sku_auto_stores_fahrenheit_roundtrip(self):
-        # H5110 IS in FAHRENHEIT_REPORTING_SKUS; auto -> entity will convert
-        # °F->°C, so we must store °F (28.00°C -> 82.4°F).
-        coord = self._coord()
-        self._add_device(coord, "D1", "H5110")
+        assert coord._states[did].sensor_humidity == 83.0
+        assert coord._states[did].sensor_temperature == 75.02
+        coord.async_set_updated_data.assert_not_called()
 
-        coord._apply_bff_thermo_reading("D1", {"tem": 2800, "hum": 393})
+    @pytest.mark.asyncio
+    async def test_discover_keeps_tickle_without_leak_sensors(self, monkeypatch):
+        """A bridged thermometer with no leak sensors still starts the tickle
+        poll, and the BFF value is not applied at discovery time (#83/#102)."""
+        coord, coord_mod = self._coord()
+        did = "AA:BB:CC:DD:EE:FF:00:22"
+        coord._devices[did] = GoveeDevice.synthetic_thermometer(did, "H5110", "Garage")
+        coord._states[did] = GoveeDeviceState.create_empty(did)
 
-        assert coord._states["D1"].sensor_temperature == 82.4
+        inner = MagicMock()
+        inner.fetch_bff_leak_sensors = _make_async(
+            ([], {}, {did: {"tem": 7502, "hum": 8300}})
+        )
+        inner.bff_device_census = MagicMock(return_value=[])
+        inner.bff_response_skeleton = MagicMock(return_value=None)
+        monkeypatch.setattr(coord_mod, "GoveeAuthClient", lambda **kw: _AsyncCM(inner))
 
-    def test_celsius_option_forces_no_conversion(self):
-        coord = self._coord(options={"api_temperature_unit": "celsius"})
-        self._add_device(coord, "D1", "H5110")
+        await coord._discover_leak_sensors()
 
-        coord._apply_bff_thermo_reading("D1", {"tem": 2800})
+        # Gate set so the 5-min tickle poll runs (#83) ...
+        assert coord._thermo_bff_devices == {did}
+        coord._schedule_bff_poll.assert_called_once()
+        # ... but the BFF reading is never written to state (#102).
+        assert coord._states[did].sensor_humidity is None
+        assert coord._states[did].sensor_temperature is None
 
-        assert coord._states["D1"].sensor_temperature == 28.0
+    @pytest.mark.asyncio
+    async def test_developer_poll_not_skipped_for_bridged_thermo(self, monkeypatch):
+        """Bridged thermometers (in _thermo_bff_devices, not _bff_thermometer_ids)
+        keep getting their Developer /device/state poll, which owns the value."""
+        coord, coord_mod = self._coord()
+        did = "AA:BB:CC:DD:EE:FF:00:22"
+        device = GoveeDevice.synthetic_thermometer(did, "H5110", "Garage")
+        coord._devices[did] = device
+        coord._thermo_bff_devices = {did}
+        coord._states[did] = GoveeDeviceState.create_empty(did)
+        from unittest.mock import AsyncMock
 
-    def test_no_tem_hum_is_noop(self):
-        coord = self._coord()
-        self._add_device(coord, "D1", "H5052")
+        fresh = GoveeDeviceState.create_empty(did)
+        fresh.sensor_humidity = 84.0
+        coord._api_client.get_device_state = AsyncMock(return_value=fresh)
 
-        assert coord._apply_bff_thermo_reading("D1", {}) is False
-        assert coord._states["D1"].sensor_temperature is None
+        result = await coord._fetch_device_state(did, device)
 
-    def test_unknown_device_is_noop(self):
-        coord = self._coord()
-        assert coord._apply_bff_thermo_reading("missing", {"tem": 2800}) is False
+        coord._api_client.get_device_state.assert_called_once()
+        assert result.sensor_humidity == 84.0


### PR DESCRIPTION
## Problem
H5110/H5179 humidity reads **10× high** (e.g. 83% → 830%) on alternating updates since v2026.6.13. Multiple reporters (#102: k-perri, SnoElement, thrstnbecker).

## Root cause
The #83 BFF "tickle" added `_apply_bff_thermo_reading`, which overwrote the Developer-API temperature/humidity with a BFF value scaled by a hard-coded `hum/10`. Ground-truth diagnostics show raw BFF `hum` is **hundredths** (8300 → should be 83.0), so `/10` yielded 830.0 — alternating with the correct Developer-API value on each regular poll. The BFF scale varies by gateway/firmware, so no fixed divisor is safe.

## Fix
Make the BFF list **tickle-only** for these Developer-API thermometers: keep calling it (it nudges Govee's cloud to refresh `/device/state`) but stop applying its `tem`/`hum`. The Developer poll owns the correctly scaled, unit-handled (#96/#97) value. The `_thermo_bff_devices` gate is kept so the 5-min tickle still starts for accounts with bridged thermometers but no leak sensors (preserves the #83 fix).

## Tests
Rewrote `TestBffThermoLiveReadings` → `TestBffThermoTickleOnly`: BFF poll no longer overwrites the Developer reading, tickle still starts without leak sensors, bridged thermometers keep their Developer poll. Full suite + flake8 + mypy green.

Closes #102. Also resolves the remaining humidity-scale follow-up on #83.

https://claude.ai/code/session_01QVkrSto5stGSV1NNS5pmKM
