### PR TITLE
feat: H1370 ceiling-fan oscillation + reverse airflow (#105)

### DIFF
--- a/custom_components/govee/fan.py
+++ b/custom_components/govee/fan.py
@@ -38,6 +38,7 @@ from .models import (
     WorkModeCommand,
 )
 from .models.device import (
+    INSTANCE_FAN_OSCILLATE,
     INSTANCE_FAN_SPEED_MODE,
     INSTANCE_FAN_TOGGLE,
     INSTANCE_REVERSE_AIRFLOW,
@@ -312,12 +313,15 @@ class GoveeCeilingFanEntity(GoveeEntity, FanEntity, RestoreEntity):
         )
         if device.supports_reverse_airflow:
             features |= FanEntityFeature.DIRECTION
+        if device.supports_fan_oscillation:
+            features |= FanEntityFeature.OSCILLATE
         self._attr_supported_features = features
 
         # Optimistic state — Govee does not report fan state on poll.
         self._is_on = False
         self._speed_value: int | None = None
         self._direction = DIRECTION_FORWARD
+        self._oscillating = False
 
     async def async_added_to_hass(self) -> None:
         """Restore optimistic state on startup."""
@@ -337,6 +341,9 @@ class GoveeCeilingFanEntity(GoveeEntity, FanEntity, RestoreEntity):
         direction = last_state.attributes.get("direction")
         if direction in (DIRECTION_FORWARD, DIRECTION_REVERSE):
             self._direction = direction
+        oscillating = last_state.attributes.get("oscillating")
+        if oscillating is not None:
+            self._oscillating = bool(oscillating)
 
     @property
     def is_on(self) -> bool:
@@ -361,6 +368,13 @@ class GoveeCeilingFanEntity(GoveeEntity, FanEntity, RestoreEntity):
         if not self._device.supports_reverse_airflow:
             return None
         return self._direction
+
+    @property
+    def oscillating(self) -> bool | None:
+        """Return whether the fan is oscillating (optimistic)."""
+        if not self._device.supports_fan_oscillation:
+            return None
+        return self._oscillating
 
     async def async_turn_on(
         self,
@@ -421,4 +435,15 @@ class GoveeCeilingFanEntity(GoveeEntity, FanEntity, RestoreEntity):
         )
         if success:
             self._direction = DIRECTION_REVERSE if reverse else DIRECTION_FORWARD
+            self.async_write_ha_state()
+
+    async def async_oscillate(self, oscillating: bool) -> None:
+        """Start or stop oscillation (fanOscillateToggle)."""
+        _LOGGER.debug("Setting ceiling fan oscillation: %s", oscillating)
+        success = await self.coordinator.async_control_device(
+            self._device_id,
+            ToggleCommand(toggle_instance=INSTANCE_FAN_OSCILLATE, enabled=oscillating),
+        )
+        if success:
+            self._oscillating = oscillating
             self.async_write_ha_state()

--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -80,6 +80,11 @@ INSTANCE_FAN_SPEED = "fanSpeed"
 INSTANCE_FAN_TOGGLE = "fanToggle"
 INSTANCE_FAN_SPEED_MODE = "fanSpeedMode"
 INSTANCE_REVERSE_AIRFLOW = "reverseAirflowToggle"
+# Ceiling-fan oscillation. Distinct from the standalone fan's
+# ``oscillationToggle`` (INSTANCE_OSCILLATION) — the H1370 light/fan combo uses
+# ``fanOscillateToggle`` (issue #105). Kept separate so the two fan code paths
+# don't cross-wire.
+INSTANCE_FAN_OSCILLATE = "fanOscillateToggle"
 INSTANCE_PURIFIER_MODE = "purifierMode"
 INSTANCE_THERMOSTAT_TOGGLE = "thermostatToggle"
 INSTANCE_HUMIDITY = "humidity"
@@ -551,6 +556,18 @@ class GoveeDevice:
         """Check if the integrated ceiling fan supports reverse airflow."""
         return any(
             cap.type == CAPABILITY_TOGGLE and cap.instance == INSTANCE_REVERSE_AIRFLOW
+            for cap in self.capabilities
+        )
+
+    @property
+    def supports_fan_oscillation(self) -> bool:
+        """Check if the integrated ceiling fan supports oscillation (H1370, #105).
+
+        Keyed on ``fanOscillateToggle`` — the combo-fan instance — NOT the
+        standalone fan's ``oscillationToggle`` (see supports_oscillation).
+        """
+        return any(
+            cap.type == CAPABILITY_TOGGLE and cap.instance == INSTANCE_FAN_OSCILLATE
             for cap in self.capabilities
         )
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -407,6 +407,66 @@ def _h1310_device():
     )
 
 
+def _h1370_device():
+    """Build an H1370-shaped ceiling-fan-with-light device (issue #105).
+
+    Like the H1310 but its oscillation uses ``fanOscillateToggle`` (not the
+    standalone fan's ``oscillationToggle``) and it adds main/background light
+    zone toggles.
+    """
+    from custom_components.govee.models import GoveeDevice, GoveeCapability
+    from custom_components.govee.models.device import (
+        CAPABILITY_ON_OFF,
+        CAPABILITY_TOGGLE,
+        CAPABILITY_MODE,
+        INSTANCE_POWER,
+        INSTANCE_FAN_TOGGLE,
+        INSTANCE_FAN_SPEED_MODE,
+        INSTANCE_REVERSE_AIRFLOW,
+        INSTANCE_FAN_OSCILLATE,
+    )
+
+    on_off = {"name": "on", "value": 1}
+    off = {"name": "off", "value": 0}
+    return GoveeDevice(
+        device_id="AA:BB:CC:DD:EE:FF:13:70",
+        sku="H1370",
+        name="Office Fan",
+        device_type="devices.types.light",
+        capabilities=(
+            GoveeCapability(
+                type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}
+            ),
+            GoveeCapability(
+                type=CAPABILITY_TOGGLE,
+                instance=INSTANCE_FAN_TOGGLE,
+                parameters={"dataType": "ENUM", "options": [on_off, off]},
+            ),
+            GoveeCapability(
+                type=CAPABILITY_MODE,
+                instance=INSTANCE_FAN_SPEED_MODE,
+                parameters={
+                    "dataType": "ENUM",
+                    "options": [
+                        {"name": f"Speed {i}", "value": i} for i in range(1, 7)
+                    ],
+                },
+            ),
+            GoveeCapability(
+                type=CAPABILITY_TOGGLE,
+                instance=INSTANCE_REVERSE_AIRFLOW,
+                parameters={"dataType": "ENUM", "options": [on_off, off]},
+            ),
+            GoveeCapability(
+                type=CAPABILITY_TOGGLE,
+                instance=INSTANCE_FAN_OSCILLATE,
+                parameters={"dataType": "ENUM", "options": [on_off, off]},
+            ),
+        ),
+        is_group=False,
+    )
+
+
 class TestGoveeCeilingFanEntity:
     """Test GoveeCeilingFanEntity (H1310) — issue #74."""
 
@@ -526,3 +586,80 @@ class TestGoveeCeilingFanEntity:
         assert cmd.toggle_instance == INSTANCE_REVERSE_AIRFLOW
         assert cmd.enabled is True
         assert fan_entity.current_direction == DIRECTION_REVERSE
+
+
+class TestGoveeCeilingFanOscillation:
+    """H1370 ceiling-fan oscillation via fanOscillateToggle (issue #105)."""
+
+    @pytest.fixture
+    def device(self):
+        return _h1370_device()
+
+    @pytest.fixture
+    def mock_coordinator(self, device):
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        coordinator.get_state = MagicMock(return_value=MagicMock(online=True))
+        coordinator.async_control_device = AsyncMock(return_value=True)
+        return coordinator
+
+    @pytest.fixture
+    def fan_entity(self, mock_coordinator, device):
+        from custom_components.govee.fan import GoveeCeilingFanEntity
+
+        entity = GoveeCeilingFanEntity(mock_coordinator, device)
+        entity.async_write_ha_state = MagicMock()
+        return entity
+
+    def test_detection(self, device):
+        """H1370 is a ceiling fan that also oscillates and reverses."""
+        assert device.supports_ceiling_fan is True
+        assert device.supports_fan_oscillation is True
+        assert device.supports_reverse_airflow is True
+        # Must NOT be confused with the standalone-fan oscillationToggle.
+        assert device.supports_oscillation is False
+
+    def test_h1310_has_no_fan_oscillation(self):
+        """The H1310 (no fanOscillateToggle) must not report oscillation."""
+        device = _h1310_device()
+        assert device.supports_fan_oscillation is False
+
+    def test_supported_features_includes_oscillate(self, fan_entity):
+        from homeassistant.components.fan import FanEntityFeature
+
+        assert fan_entity.supported_features & FanEntityFeature.OSCILLATE
+
+    def test_h1310_entity_has_no_oscillate_feature(self, mock_coordinator):
+        from homeassistant.components.fan import FanEntityFeature
+        from custom_components.govee.fan import GoveeCeilingFanEntity
+
+        device = _h1310_device()
+        mock_coordinator.devices = {device.device_id: device}
+        entity = GoveeCeilingFanEntity(mock_coordinator, device)
+        assert not (entity.supported_features & FanEntityFeature.OSCILLATE)
+        assert entity.oscillating is None
+
+    @pytest.mark.asyncio
+    async def test_oscillate_on_sends_toggle(self, fan_entity, mock_coordinator):
+        from custom_components.govee.models import ToggleCommand
+        from custom_components.govee.models.device import INSTANCE_FAN_OSCILLATE
+
+        await fan_entity.async_oscillate(True)
+
+        cmd = mock_coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, ToggleCommand)
+        assert cmd.toggle_instance == INSTANCE_FAN_OSCILLATE
+        assert cmd.enabled is True
+        assert fan_entity.oscillating is True
+
+    @pytest.mark.asyncio
+    async def test_oscillate_off_sends_toggle(self, fan_entity, mock_coordinator):
+        from custom_components.govee.models import ToggleCommand
+
+        fan_entity._oscillating = True
+        await fan_entity.async_oscillate(False)
+
+        cmd = mock_coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, ToggleCommand)
+        assert cmd.enabled is False
+        assert fan_entity.oscillating is False


### PR DESCRIPTION
## Problem
H1370 light/fan combo (#105). It's already detected via capability-based discovery (`fanToggle`+`fanSpeedMode`), so light + fan-speed work — but its oscillation uses `fanOscillateToggle`, which the code didn't recognize (only the standalone fan's `oscillationToggle`).

## Fix
- `INSTANCE_FAN_OSCILLATE = "fanOscillateToggle"` + a combo-fan `supports_fan_oscillation` predicate, kept separate from the standalone-fan oscillation path.
- `GoveeCeilingFanEntity`: add `FanEntityFeature.OSCILLATE`, an optimistic `oscillating` property (restored across restarts like direction), and `async_oscillate` → `ToggleCommand(fanOscillateToggle)`. Mirrors the existing reverse-airflow handling.

Reverse airflow already worked. Dual light zones (main/background) left to the single light entity pending reporter UX confirmation.

## Tests
`_h1370_device()` fixture + oscillation tests (feature gating, ToggleCommand payload, optimistic round-trip; regression that H1310 exposes no oscillation). Full suite + flake8 + mypy green.

Closes #105.

https://claude.ai/code/session_01QVkrSto5stGSV1NNS5pmKM
