### PR TITLE
feat: auto-discover devices added after startup (#101)

### DIFF
--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -67,6 +67,12 @@ DEFAULT_API_TEMPERATURE_UNIT: Final = "auto"
 # confirmations clear the window early.
 OPTIMISTIC_GRACE_CAP_SECONDS: Final = 15
 
+# How often (seconds) the coordinator re-checks the Govee account device list to
+# pick up devices added after startup (issue #101). Throttled well above the
+# poll interval to respect the 100/min, 10k/day API rate limits — a new device
+# appears within this window without a manual reload.
+DEVICE_REDISCOVERY_INTERVAL: Final = 300
+
 # BLE constants
 # Govee AWS/BLE advert manufacturer ID. Verified against
 # Bluetooth-Devices/govee-ble (used by H5127 and related). Additional IDs

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -51,6 +51,7 @@ from .api.mqtt_control import command_to_mqtt
 from .const import (
     CONF_ENABLE_MQTT_CONTROL,
     DEFAULT_ENABLE_MQTT_CONTROL,
+    DEVICE_REDISCOVERY_INTERVAL,
     DOMAIN,
     OPTIMISTIC_GRACE_CAP_SECONDS,
 )
@@ -252,6 +253,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         self._sensor_reading_changed_at: dict[str, datetime] = {}
         self._leak_hubs: dict[str, dict[str, Any]] = {}
         self._sno_to_sensor_id: dict[tuple[str, int], str] = {}
+        # Last time the account device list was re-checked for newly added
+        # devices (#101). Seeded to "now" so the first re-check waits a full
+        # interval rather than firing right after setup discovery.
+        self._last_rediscovery_check: float = time.monotonic()
         # Per-device queued button presses (supports multiple presses per tick)
         self._pending_button_presses: dict[str, int] = {}
         self._bff_poll_unsub: CALLBACK_TYPE | None = None
@@ -629,6 +634,52 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             raise ConfigEntryAuthFailed("Invalid API key") from err
         except GoveeApiError as err:
             raise UpdateFailed(f"Failed to discover devices: {err}") from err
+
+    async def _async_maybe_rediscover_devices(self) -> None:
+        """Re-check the account device list and reload when new devices appear.
+
+        Device discovery is otherwise one-shot at setup, so a device added to
+        the Govee account after Home Assistant started stays invisible until a
+        manual reload (issue #101). Here we re-fetch the device list on a slow
+        cadence (``DEVICE_REDISCOVERY_INTERVAL``, to respect the API rate
+        limits); if any genuinely new device id appears, we schedule a config
+        entry reload, which re-runs the existing, tested discovery + platform
+        setup so the new entities are created.
+
+        Only additions trigger a reload — removals stay tied to reload/restart
+        and the existing orphan-cleanup pass, to keep entity churn minimal. The
+        method never raises: a discovery hiccup must not fail the state poll.
+        """
+        now = time.monotonic()
+        if now - self._last_rediscovery_check < DEVICE_REDISCOVERY_INTERVAL:
+            return
+        self._last_rediscovery_check = now
+
+        try:
+            devices = await self._api_client.get_devices()
+        except Exception as err:
+            # Non-fatal: the regular state poll continues on the known devices.
+            _LOGGER.debug("Periodic device re-discovery failed: %s", err)
+            return
+
+        # Apply the same group filter discovery uses, so a group device left
+        # disabled doesn't look "new" on every pass and reload-loop.
+        candidate_ids = {
+            device.device_id
+            for device in devices
+            if not (device.is_group and not self._enable_groups)
+        }
+        new_ids = candidate_ids - set(self._devices)
+        if not new_ids:
+            return
+
+        _LOGGER.info(
+            "Detected %d new Govee device(s) since startup (%s) — reloading the "
+            "integration to add them (#101)",
+            len(new_ids),
+            ", ".join(sorted(new_ids)),
+        )
+        self.hass.config_entries.async_schedule_reload(self._config_entry.entry_id)
 
     async def _start_mqtt(self) -> None:
         """Start MQTT client for real-time updates."""
@@ -1286,6 +1337,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
 
         Called by DataUpdateCoordinator on poll interval.
         """
+        # Pick up devices added to the account since setup (#101). Throttled and
+        # failure-isolated inside the method so it never disrupts the state poll.
+        await self._async_maybe_rediscover_devices()
+
         if not self._devices:
             return self._states
 

--- a/custom_components/govee/quality_scale.yaml
+++ b/custom_components/govee/quality_scale.yaml
@@ -116,7 +116,10 @@ rules:
     comment: Use case examples could be expanded
   dynamic-devices:
     status: done
-    comment: Devices discovered and updated via API polling
+    comment: >-
+      Devices added to the account after startup are picked up by a throttled
+      re-check of the device list in the poll loop, which schedules a config
+      entry reload when new devices appear (issue #101).
   entity-category:
     status: done
     comment: Diagnostic entities use EntityCategory.DIAGNOSTIC

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2314,3 +2314,117 @@ class TestBffThermoTickleOnly:
 
         coord._api_client.get_device_state.assert_called_once()
         assert result.sensor_humidity == 84.0
+
+
+class TestPeriodicRediscovery:
+    """New devices added after startup are picked up via reload (issue #101)."""
+
+    def _coord(self):
+        import custom_components.govee.coordinator as coord_mod
+
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=None,
+            poll_interval=60,
+        )
+        coord._enable_groups = False
+        return coord, coord_mod
+
+    @staticmethod
+    def _device(device_id, is_group=False):
+        return GoveeDevice(
+            device_id=device_id,
+            sku="H6001",
+            name=device_id,
+            device_type="devices.types.light",
+            capabilities=(),
+            is_group=is_group,
+        )
+
+    @pytest.mark.asyncio
+    async def test_schedules_reload_on_new_device(self):
+        import time
+        from unittest.mock import AsyncMock
+
+        coord, _ = self._coord()
+        dev_a = self._device("A")
+        coord._devices = {"A": dev_a}
+        coord._last_rediscovery_check = time.monotonic() - 10_000  # force elapsed
+        coord._api_client.get_devices = AsyncMock(
+            return_value=[dev_a, self._device("B")]
+        )
+
+        await coord._async_maybe_rediscover_devices()
+
+        coord.hass.config_entries.async_schedule_reload.assert_called_once_with(
+            "test_entry"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_reload_when_device_set_unchanged(self):
+        import time
+        from unittest.mock import AsyncMock
+
+        coord, _ = self._coord()
+        dev_a = self._device("A")
+        coord._devices = {"A": dev_a}
+        coord._last_rediscovery_check = time.monotonic() - 10_000
+        coord._api_client.get_devices = AsyncMock(return_value=[dev_a])
+
+        await coord._async_maybe_rediscover_devices()
+
+        coord.hass.config_entries.async_schedule_reload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_throttle_skips_when_recent(self):
+        import time
+        from unittest.mock import AsyncMock
+
+        coord, _ = self._coord()
+        coord._devices = {"A": self._device("A")}
+        coord._last_rediscovery_check = time.monotonic()  # just checked
+        coord._api_client.get_devices = AsyncMock(return_value=[])
+
+        await coord._async_maybe_rediscover_devices()
+
+        coord._api_client.get_devices.assert_not_called()
+        coord.hass.config_entries.async_schedule_reload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure_is_isolated(self):
+        import time
+        from unittest.mock import AsyncMock
+
+        coord, _ = self._coord()
+        coord._devices = {"A": self._device("A")}
+        coord._last_rediscovery_check = time.monotonic() - 10_000
+        coord._api_client.get_devices = AsyncMock(side_effect=RuntimeError("boom"))
+
+        # Must not raise.
+        await coord._async_maybe_rediscover_devices()
+
+        coord.hass.config_entries.async_schedule_reload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_group_is_not_treated_as_new(self):
+        import time
+        from unittest.mock import AsyncMock
+
+        coord, _ = self._coord()
+        dev_a = self._device("A")
+        coord._devices = {"A": dev_a}
+        coord._enable_groups = False
+        coord._last_rediscovery_check = time.monotonic() - 10_000
+        # A new group device, but groups are disabled -> not "new", no reload.
+        coord._api_client.get_devices = AsyncMock(
+            return_value=[dev_a, self._device("11825917", is_group=True)]
+        )
+
+        await coord._async_maybe_rediscover_devices()
+
+        coord.hass.config_entries.async_schedule_reload.assert_not_called()


### PR DESCRIPTION
## Problem
Device discovery was one-shot at setup, so devices added to the account after HA started stayed invisible until a manual reload (#101 — 8 new H5059 sensors didn't appear until reload).

## Fix
A throttled device-list re-check in the poll loop: every `DEVICE_REDISCOVERY_INTERVAL` (300s, above the poll cadence to respect the 100/min, 10k/day limits) re-fetch the device list; if a genuinely new device id appears, **schedule a config-entry reload**, which re-runs the existing, tested discovery + platform setup.

Deliberately reuses the proven reload path rather than refactoring dynamic entity addition across all ~10 platforms — far smaller regression surface for the same result. Only additions trigger a reload; the group filter prevents reload-loops on disabled groups; the re-check is failure-isolated so a discovery hiccup never fails the state poll. Also corrects the `quality_scale.yaml` dynamic-devices comment.

## Tests
`TestPeriodicRediscovery`: reload on new device, no-op when unchanged, throttle, failure isolation, disabled-group ignore. Full suite + flake8 + mypy green.

Closes #101.

https://claude.ai/code/session_01QVkrSto5stGSV1NNS5pmKM
