### PR TITLE
fix(#129): honor device-reported temperature unit on heaters

### DIFF
--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -50,15 +50,26 @@ FAHRENHEIT_REPORTING_SKUS: Final = frozenset(
 )
 
 
-def resolve_fahrenheit_conversion(sku: str, api_unit: str) -> bool:
+def resolve_fahrenheit_conversion(
+    sku: str, api_unit: str, device_unit_hint: str | None = None
+) -> bool:
     """Whether a Developer-API ``sensor_temperature`` should be treated as °F.
 
     Shared by the sensor entity (which converts °F→°C for display) and the
     coordinator's BFF reading path (which must store the value in the SAME
     unit the entity expects, so a true-°C BFF reading round-trips correctly
     instead of being double-converted) — issues #96, #83.
+
+    ``device_unit_hint`` is explicit unit metadata reported by the device
+    itself — heaters (e.g. H713B) carry a ``unit`` field in their
+    temperature_setting STRUCT state and report ``sensorTemperature`` in that
+    same unit. In "auto" mode the device's own metadata beats the static SKU
+    allowlist, so Fahrenheit-configured heaters normalize out-of-the-box
+    without a per-SKU entry (issue #129).
     """
     if api_unit == "auto":
+        if device_unit_hint is not None:
+            return device_unit_hint.lower() == "fahrenheit"
         return sku.upper() in FAHRENHEIT_REPORTING_SKUS
     return api_unit == "fahrenheit"
 

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -2189,6 +2189,13 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                     state.heater_temperature = existing_state.heater_temperature
                 if existing_state.heater_auto_stop is not None:
                     state.heater_auto_stop = existing_state.heater_auto_stop
+                if (
+                    existing_state.heater_temperature_unit is not None
+                    and state.heater_temperature_unit is None
+                ):
+                    state.heater_temperature_unit = (
+                        existing_state.heater_temperature_unit
+                    )
 
                 # Stand-alone thermometer/hygrometer readings (H5179, H5109,
                 # H5110, HS5108, HS5106): battery-powered sensors push to the

--- a/custom_components/govee/models/state.py
+++ b/custom_components/govee/models/state.py
@@ -213,6 +213,13 @@ class GoveeDeviceState:
     heater_temperature: int | None = None  # Target temperature in Celsius
     heater_auto_stop: int | None = None  # Auto-stop setting (0=Maintain, 1=Auto-stop)
     fan_speed: int | None = None  # Fan speed mode value (1=Low, 2=Medium, 3=High)
+    # Unit reported by the temperature_setting STRUCT state ("Celsius" /
+    # "Fahrenheit"). Heaters like the H713B run in °F internally and report
+    # sensorTemperature in the SAME unit — but the property capability itself
+    # carries no unit metadata. Capturing the STRUCT's unit lets the
+    # temperature sensor entity normalize without a SKU allowlist entry
+    # (issue #129).
+    heater_temperature_unit: str | None = None
 
     # Purifier state
     purifier_mode: int | None = (
@@ -438,12 +445,31 @@ class GoveeDeviceState:
                 # preserve the user's choice instead of resetting it to 0
                 # (issue #29).
                 if instance == "targetTemperature" and isinstance(value, dict):
+                    unit = value.get("unit")
+                    if isinstance(unit, str) and unit:
+                        self.heater_temperature_unit = unit
+                    # The capability definition names the field ``temperature``
+                    # (and commands are sent that way), but the polled STATE
+                    # carries it as ``targetTemperature`` on devices like the
+                    # H713B — accept both shapes (issue #129).
                     temp_val = value.get("temperature")
+                    if temp_val is None:
+                        temp_val = value.get("targetTemperature")
                     if temp_val is not None:
                         try:
-                            self.heater_temperature = int(temp_val)
+                            temp_int = int(temp_val)
                         except (TypeError, ValueError):
                             pass
+                        else:
+                            # heater_temperature is canonical °C (commands are
+                            # always sent with unit=Celsius) — normalize a
+                            # Fahrenheit-reporting device on read (issue #129).
+                            if (
+                                isinstance(unit, str)
+                                and unit.lower() == "fahrenheit"
+                            ):
+                                temp_int = round((temp_int - 32) * 5 / 9)
+                            self.heater_temperature = temp_int
                     auto_stop = value.get("autoStop")
                     if auto_stop is not None:
                         try:

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -306,6 +306,9 @@ class GoveeTemperatureSensor(_BffThermometerAvailabilityMixin, SensorEntity):
         # tagged °C — surfacing e.g. 101°F as 213.5°F (issues #72, #78, #96).
         # "auto" (default) converts those SKUs out-of-the-box; "fahrenheit"
         # forces conversion for any SKU; "celsius" trusts the API value as-is.
+        # Heaters additionally report their own unit in the
+        # temperature_setting STRUCT — in "auto" mode that explicit metadata
+        # beats the SKU allowlist (H713B, issue #129).
         config_entry = self.coordinator.config_entry
         api_unit = (
             config_entry.options.get(
@@ -315,7 +318,11 @@ class GoveeTemperatureSensor(_BffThermometerAvailabilityMixin, SensorEntity):
             if config_entry is not None
             else DEFAULT_API_TEMPERATURE_UNIT
         )
-        if resolve_fahrenheit_conversion(self._device.sku, api_unit):
+        if resolve_fahrenheit_conversion(
+            self._device.sku,
+            api_unit,
+            getattr(state, "heater_temperature_unit", None),
+        ):
             return (value - 32.0) * (5.0 / 9.0)
 
         return value

--- a/tests/test_heater_autostop.py
+++ b/tests/test_heater_autostop.py
@@ -181,3 +181,71 @@ class TestLightFilterExcludesAppliances:
             ),
         )
         assert device.is_light_device is True
+
+
+class TestFahrenheitHeaterStructParsing:
+    """Heaters that run in °F report the temperature_setting STRUCT with
+    ``unit: Fahrenheit`` and the ``targetTemperature`` field name (H713B,
+    issue #129)."""
+
+    def test_parses_fahrenheit_state_shape_h713b(self):
+        # Verbatim shape from H713B diagnostics: field is named
+        # ``targetTemperature`` (not ``temperature``) and unit is Fahrenheit.
+        state = GoveeDeviceState.create_empty("dev1")
+        state.update_from_api(
+            {
+                "capabilities": [
+                    {
+                        "type": "devices.capabilities.temperature_setting",
+                        "instance": "targetTemperature",
+                        "state": {
+                            "value": {
+                                "unit": "Fahrenheit",
+                                "targetTemperature": 41,
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+        # 41°F == 5°C — heater_temperature is canonical Celsius.
+        assert state.heater_temperature == 5
+        assert state.heater_temperature_unit == "Fahrenheit"
+
+    def test_celsius_struct_stays_unconverted(self):
+        state = GoveeDeviceState.create_empty("dev1")
+        state.update_from_api(
+            {
+                "capabilities": [
+                    {
+                        "type": "devices.capabilities.temperature_setting",
+                        "instance": "targetTemperature",
+                        "state": {
+                            "value": {
+                                "temperature": 22,
+                                "autoStop": 1,
+                                "unit": "Celsius",
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+        assert state.heater_temperature == 22
+        assert state.heater_temperature_unit == "Celsius"
+
+    def test_unit_absent_defaults_to_no_conversion(self):
+        state = GoveeDeviceState.create_empty("dev1")
+        state.update_from_api(
+            {
+                "capabilities": [
+                    {
+                        "type": "devices.capabilities.temperature_setting",
+                        "instance": "targetTemperature",
+                        "state": {"value": {"temperature": 18}},
+                    }
+                ]
+            }
+        )
+        assert state.heater_temperature == 18
+        assert state.heater_temperature_unit is None

--- a/tests/test_thermometer.py
+++ b/tests/test_thermometer.py
@@ -618,3 +618,32 @@ class TestDeveloperThermometerBattery:
         await sensor_mod.async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
 
         assert not [e for e in added if type(e).__name__ == "GoveeThermoBatterySensor"]
+
+
+class TestResolveFahrenheitDeviceUnitHint:
+    """auto mode: explicit device-reported unit metadata beats the static
+    SKU allowlist (H713B heater, issue #129)."""
+
+    def test_auto_with_fahrenheit_hint_converts(self):
+        from custom_components.govee.const import resolve_fahrenheit_conversion
+
+        assert resolve_fahrenheit_conversion("H713B", "auto", "Fahrenheit") is True
+
+    def test_auto_with_celsius_hint_beats_allowlist(self):
+        from custom_components.govee.const import resolve_fahrenheit_conversion
+
+        # H5179 is in FAHRENHEIT_REPORTING_SKUS, but the device itself says
+        # Celsius — explicit metadata wins.
+        assert resolve_fahrenheit_conversion("H5179", "auto", "Celsius") is False
+
+    def test_auto_without_hint_uses_allowlist(self):
+        from custom_components.govee.const import resolve_fahrenheit_conversion
+
+        assert resolve_fahrenheit_conversion("H5179", "auto", None) is True
+        assert resolve_fahrenheit_conversion("H713B", "auto", None) is False
+
+    def test_explicit_override_ignores_hint(self):
+        from custom_components.govee.const import resolve_fahrenheit_conversion
+
+        assert resolve_fahrenheit_conversion("H713B", "celsius", "Fahrenheit") is False
+        assert resolve_fahrenheit_conversion("H713B", "fahrenheit", "Celsius") is True


### PR DESCRIPTION
Fixes #129.

## Problem

H713B (and other °F-configured heaters) report `sensorTemperature` in Fahrenheit while the sensor entity's native unit is tagged Celsius — 80 °F (26.7 °C real) surfaced as **80 °C**. The unit metadata IS available: the `temperature_setting` STRUCT state carries an explicit `"unit"` field, but `auto` mode only consulted the static SKU allowlist.

Two adjacent parsing bugs: the polled STRUCT state names the field `targetTemperature` (not `temperature`) on the H713B, so `heater_temperature` stayed `None`; and the STRUCT's `unit` field was ignored entirely.

## Changes

- **models/state.py** — capture the STRUCT's unit into `heater_temperature_unit`; accept both `temperature` and `targetTemperature` field names; normalize the target to canonical °C on read (commands already send `unit: "Celsius"`).
- **const.py** — `resolve_fahrenheit_conversion()` gains an optional `device_unit_hint`; in `auto` mode explicit device-reported metadata beats the SKU allowlist. Thermometers never set the hint, so their behavior is unchanged.
- **sensor.py** — pass the hint from device state (via `getattr` so stub states in existing tests keep working).
- **coordinator.py** — preserve `heater_temperature_unit` across polls like the other heater fields.
- **tests** — 3 new STRUCT-parsing tests (verbatim H713B diagnostics shape) + 4 new `resolve_fahrenheit_conversion` hint tests.

## Verification

- Full test suite: **1474 passed** (python:3.13, pytest-homeassistant-custom-component), coverage 70.9 %.
- Live on a real H713B (HA 2026.6.4, option left at `auto`): sensor went from bogus `80 °C` to **27.2 °C**, matching the Govee app; target-temperature number now populated from the API STRUCT (41 °F → 5 °C) instead of relying on RestoreEntity.

Diagnostics excerpt from the device (also in #129):

```json
{"instance": "targetTemperature", "state": {"value": {"unit": "Fahrenheit", "targetTemperature": 41}}},
{"instance": "sensorTemperature", "state": {"value": 80}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)