### PR TITLE
feat: Make fan preset and speed mapping fully capability-driven

### DIFF
--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -95,6 +95,7 @@ from .models.commands import (
     DIYSceneCommand,
     ModeCommand,
     MusicModeCommand,
+    OscillationCommand,
     PowerCommand,
     RangeCommand,
     SceneCommand,
@@ -3345,6 +3346,8 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             state.heater_auto_stop = command.auto_stop
         elif isinstance(command, WorkModeCommand):
             state.apply_optimistic_work_mode(command.work_mode, command.mode_value)
+        elif isinstance(command, OscillationCommand):
+            state.apply_optimistic_oscillation(command.oscillating)
         elif isinstance(command, MusicModeCommand):
             # Look up mode name from device capabilities for display
             device = self._devices.get(device_id)

--- a/custom_components/govee/fan.py
+++ b/custom_components/govee/fan.py
@@ -38,24 +38,29 @@ from .models import (
     WorkModeCommand,
 )
 from .models.device import (
+    CAPABILITY_WORK_MODE,
     INSTANCE_FAN_OSCILLATE,
     INSTANCE_FAN_SPEED_MODE,
     INSTANCE_FAN_TOGGLE,
     INSTANCE_REVERSE_AIRFLOW,
+    INSTANCE_WORK_MODE,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
-# Preset modes: Normal uses gearMode (manual speed), Auto uses auto mode
+# Stable user-facing preset labels.
 PRESET_MODE_NORMAL = "Normal"
 PRESET_MODE_AUTO = "Auto"
-FAN_PRESET_MODES = [PRESET_MODE_NORMAL, PRESET_MODE_AUTO]
 
-# Work mode constants
-WORK_MODE_GEAR = 1  # Manual speed control
-WORK_MODE_AUTO = 3  # Automatic mode
+# Capability fallback defaults when workMode metadata is unavailable.
+DEFAULT_WORK_MODE_MANUAL = 1
+DEFAULT_WORK_MODE_AUTO = 3
+# Backward-compatible aliases used by tests and existing imports.
+WORK_MODE_GEAR = DEFAULT_WORK_MODE_MANUAL
+WORK_MODE_AUTO = DEFAULT_WORK_MODE_AUTO
+MANUAL_MODE_NAMES = {"manual", "gearmode", "fanspeed"}
 
 
 async def async_setup_entry(
@@ -120,43 +125,30 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
         self._attr_name = None  # Use device name
 
         # Detect speed count from device capabilities
-        gear_speeds = [
-            opt
-            for opt in device.get_fan_speed_options()
-            if opt["work_mode"] == WORK_MODE_GEAR
-        ]
-        self._fan_speeds = (
-            [opt["mode_value"] for opt in gear_speeds] if gear_speeds else [1, 2, 3]
-        )
+        self._manual_preset_name = PRESET_MODE_NORMAL
+        self._manual_work_mode = DEFAULT_WORK_MODE_MANUAL
+        self._auto_work_mode = DEFAULT_WORK_MODE_AUTO
+        self._preset_work_modes: dict[str, int] = {}
+        self._preset_commands: dict[str, tuple[int, int]] = {}
+        self._last_mode_values: dict[int, int] = {}
+        self._speed_work_modes: set[int] = set()
+        self._speedless_work_modes: set[int] = set()
+        self._work_mode_speed_values: dict[int, list[int]] = {}
+        self._work_mode_speed_sets: dict[int, set[int]] = {}
+
+        self._init_work_mode_mappings(device)
+
+        self._fan_speed_set = set(self._fan_speeds)
         self._attr_speed_count = len(self._fan_speeds)
+        self._attr_percentage_step = 100 / len(self._fan_speeds)
 
         # Build supported features based on device capabilities
         features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
 
-        # Map preset name -> work_mode value for non-gear, non-Auto top-level
-        # work modes (e.g. H7124's Sleep/Turbo, H7126's Custom). Normal
-        # (gearMode) and Auto are always offered for backward compatibility.
-        self._preset_work_modes: dict[str, int] = {}
         if device.supports_work_mode:
             features |= FanEntityFeature.SET_SPEED
             features |= FanEntityFeature.PRESET_MODE
-            extra_presets: list[str] = []
-            for opt in device.get_fan_speed_options():
-                wm = opt.get("work_mode")
-                name = str(opt.get("name", ""))
-                if wm is None or wm in (WORK_MODE_GEAR, WORK_MODE_AUTO) or not name:
-                    continue
-                # Skip work modes whose name collides with a built-in preset
-                # (e.g. H7106 exposes its own "Auto" work mode with a value !=
-                # WORK_MODE_AUTO). Without this the built-in "Auto" is offered
-                # twice, which crashes the HomeKit bridge with a duplicate-IID
-                # error (issue #120).
-                if name.lower() in (p.lower() for p in FAN_PRESET_MODES):
-                    continue
-                if name not in self._preset_work_modes:
-                    self._preset_work_modes[name] = int(wm)
-                    extra_presets.append(name)
-            self._attr_preset_modes = FAN_PRESET_MODES + extra_presets
+            self._attr_preset_modes = list(self._preset_commands)
 
         # Reverse lookup work_mode value -> preset name (issue #114).
         self._work_mode_to_preset: dict[int, str] = {
@@ -167,6 +159,204 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
             features |= FanEntityFeature.OSCILLATE
 
         self._attr_supported_features = features
+
+    def _init_work_mode_mappings(self, device: GoveeDevice) -> None:
+        """Build work mode mappings and discrete speed levels from capabilities."""
+        work_mode_options: list[dict[str, Any]] = []
+        mode_value_options: list[dict[str, Any]] = []
+        for cap in device.capabilities:
+            if cap.type != CAPABILITY_WORK_MODE or cap.instance != INSTANCE_WORK_MODE:
+                continue
+            for field in cap.parameters.get("fields", []):
+                if field.get("fieldName") == "workMode":
+                    work_mode_options = field.get("options", [])
+                elif field.get("fieldName") == "modeValue":
+                    mode_value_options = field.get("options", [])
+            break
+
+        mode_values_by_name = {
+            str(opt.get("name", "")).strip().lower(): opt
+            for opt in mode_value_options
+            if opt.get("name")
+        }
+        mode_value_speeds_by_name: dict[str, list[int]] = {}
+        for mode_name, mode_opt in mode_values_by_name.items():
+            speeds: list[int] = []
+            for opt in mode_opt.get("options", []):
+                raw_value = opt.get("value")
+                if raw_value is None:
+                    continue
+                try:
+                    speed_value = int(raw_value)
+                except (TypeError, ValueError):
+                    continue
+                if speed_value > 0:
+                    speeds.append(speed_value)
+            if speeds:
+                mode_value_speeds_by_name[mode_name] = sorted(set(speeds))
+
+        # Discover manual mode and its display name from workMode options.
+        manual_name = ""
+        for opt in work_mode_options:
+            opt_name = str(opt.get("name", "")).strip()
+            opt_value = opt.get("value")
+            if opt_value is None:
+                continue
+            if opt_name.lower() in MANUAL_MODE_NAMES:
+                self._manual_work_mode = int(opt_value)
+                manual_name = opt_name
+                break
+
+        if manual_name.lower() == "fanspeed":
+            self._manual_preset_name = manual_name
+        self._speed_work_modes = {self._manual_work_mode}
+        self._speedless_work_modes = set()
+
+        # Discover auto mode ID from workMode options.
+        for opt in work_mode_options:
+            if (
+                str(opt.get("name", "")).strip().lower() == PRESET_MODE_AUTO.lower()
+                and opt.get("value") is not None
+            ):
+                self._auto_work_mode = int(opt["value"])
+                break
+
+        # Build authoritative manual speeds from modeValue nested options.
+        manual_sub_options = (
+            mode_values_by_name.get(manual_name.lower(), {}).get("options", [])
+            if manual_name
+            else []
+        )
+        manual_speeds: list[int] = []
+        for opt in manual_sub_options:
+            raw_value = opt.get("value")
+            if raw_value is None:
+                continue
+            try:
+                speed_value = int(raw_value)
+            except (TypeError, ValueError):
+                continue
+            if speed_value > 0:
+                manual_speeds.append(speed_value)
+        if not manual_speeds:
+            for opt in device.get_fan_speed_options():
+                if opt.get("work_mode") != self._manual_work_mode:
+                    continue
+                raw_value = opt.get("mode_value")
+                if raw_value is None:
+                    continue
+                try:
+                    speed_value = int(raw_value)
+                except (TypeError, ValueError):
+                    continue
+                if speed_value > 0:
+                    manual_speeds.append(speed_value)
+        self._fan_speeds = sorted(set(manual_speeds)) if manual_speeds else [1, 2, 3]
+        self._work_mode_speed_values[self._manual_work_mode] = self._fan_speeds
+        self._work_mode_speed_sets[self._manual_work_mode] = set(self._fan_speeds)
+        middle_speed_index = (len(self._fan_speeds) - 1) // 2
+        default_manual_mode_value = self._fan_speeds[middle_speed_index]
+        self._last_manual_mode_value = default_manual_mode_value
+
+        # Build ordered preset map from workMode options with de-duplication.
+        seen: set[str] = set()
+        self._preset_work_modes[self._manual_preset_name] = self._manual_work_mode
+        # Default to a typical manual speed for safer transitions from non-manual modes.
+        self._preset_commands[self._manual_preset_name] = (
+            self._manual_work_mode,
+            default_manual_mode_value,
+        )
+        seen.add(self._manual_preset_name.lower())
+
+        auto_name = ""
+        auto_mode_value_opt: dict[str, Any] = {}
+        for opt in work_mode_options:
+            if str(opt.get("name", "")).strip().lower() != PRESET_MODE_AUTO.lower():
+                continue
+            auto_name = str(opt.get("name", "")).strip() or PRESET_MODE_AUTO
+            auto_mode_value_opt = mode_values_by_name.get(auto_name.lower(), {})
+            break
+        if auto_name and auto_name.lower() not in seen:
+            auto_mode_value = self._extract_mode_value(auto_mode_value_opt)
+            auto_mode_value = max(auto_mode_value, 0)
+            self._preset_work_modes[auto_name] = self._auto_work_mode
+            self._preset_commands[auto_name] = (self._auto_work_mode, int(auto_mode_value))
+            if mode_value_speeds_by_name.get(auto_name.lower()):
+                self._speed_work_modes.add(self._auto_work_mode)
+                self._work_mode_speed_values[self._auto_work_mode] = mode_value_speeds_by_name[auto_name.lower()]
+                self._work_mode_speed_sets[self._auto_work_mode] = set(mode_value_speeds_by_name[auto_name.lower()])
+            else:
+                self._speedless_work_modes.add(self._auto_work_mode)
+            seen.add(auto_name.lower())
+
+        for opt in work_mode_options:
+            preset_name = str(opt.get("name", "")).strip()
+            work_mode = opt.get("value")
+            if not preset_name or work_mode is None:
+                continue
+            if preset_name.lower() in MANUAL_MODE_NAMES:
+                continue
+            if preset_name.lower() == PRESET_MODE_AUTO.lower():
+                continue
+            if preset_name.lower() in seen:
+                continue
+
+            preset_name_lower = preset_name.lower()
+            mode_value_opt = mode_values_by_name.get(preset_name_lower, {})
+            mode_value = self._extract_mode_value(mode_value_opt)
+            mode_speeds = mode_value_speeds_by_name.get(preset_name_lower, [])
+            work_mode = int(work_mode)
+            if mode_speeds:
+                mode_value = max(mode_value, min(mode_speeds))
+                self._speed_work_modes.add(work_mode)
+                self._work_mode_speed_values[work_mode] = mode_speeds
+                self._work_mode_speed_sets[work_mode] = set(mode_speeds)
+            else:
+                mode_value = max(mode_value, 0)
+                self._speedless_work_modes.add(work_mode)
+
+            self._preset_work_modes[preset_name] = work_mode
+            self._preset_commands[preset_name] = (work_mode, int(mode_value))
+            seen.add(preset_name.lower())
+
+        if PRESET_MODE_AUTO.lower() not in seen:
+            self._preset_work_modes[PRESET_MODE_AUTO] = self._auto_work_mode
+            self._preset_commands[PRESET_MODE_AUTO] = (
+                self._auto_work_mode,
+                0,
+            )
+            self._speedless_work_modes.add(self._auto_work_mode)
+
+        self._last_mode_values.clear()
+        for work_mode, mode_value in self._preset_commands.values():
+            self._last_mode_values.setdefault(work_mode, mode_value)
+
+    @staticmethod
+    def _extract_mode_value(mode_value_opt: dict[str, Any]) -> int:
+        """Extract a usable modeValue from a modeValue option definition."""
+        mode_value = mode_value_opt.get("defaultValue")
+        if mode_value is None and mode_value_opt.get("options"):
+            first = mode_value_opt["options"][0]
+            mode_value = first.get("value")
+        if mode_value is None:
+            mode_value = mode_value_opt.get("value", 0)
+        try:
+            return int(mode_value)
+        except (TypeError, ValueError):
+            return 0
+
+    def _manual_mode_value_from_state(self) -> int | None:
+        """Return modeValue when state is in manual mode and value is a valid speed."""
+        state = self.device_state
+        manual_speed_set = self._work_mode_speed_sets[self._manual_work_mode]
+        if (
+            state
+            and state.work_mode == self._manual_work_mode
+            and state.mode_value is not None
+            and state.mode_value in manual_speed_set
+        ):
+            return int(state.mode_value)
+        return None
 
     @property
     def is_on(self) -> bool | None:
@@ -179,20 +369,31 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
         """Return the current speed as a percentage.
 
         Maps mode_value to percentage using the device's speed list.
-        Only applies when in gearMode (work_mode=1).
+        Applies to manual mode and other speed-bearing work modes discovered from presets.
         """
         state = self.device_state
         if state is None:
             return None
 
-        # Only return percentage when in manual gear mode
-        if state.work_mode == WORK_MODE_GEAR and state.mode_value is not None:
-            try:
-                return ordered_list_item_to_percentage(
-                    self._fan_speeds, state.mode_value
-                )
-            except ValueError:
-                _LOGGER.debug("Unknown mode_value: %s", state.mode_value)
+        # Return percentage for speed-bearing modes (manual + presets that expose speed).
+        if state.work_mode in self._speed_work_modes:
+            work_mode = int(state.work_mode)
+            speed_values = self._work_mode_speed_values[work_mode]
+            speed_set = self._work_mode_speed_sets[work_mode]
+            mode_value: int | None
+            if state.mode_value is None:
+                mode_value = None
+            else:
+                try:
+                    mode_value = int(state.mode_value)
+                except (TypeError, ValueError):
+                    mode_value = None
+
+            if mode_value not in speed_set:
+                mode_value = self._last_mode_values.get(work_mode)
+
+            if mode_value in speed_set:
+                return ordered_list_item_to_percentage(speed_values, mode_value)
 
         return None
 
@@ -200,21 +401,18 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
     def preset_mode(self) -> str | None:
         """Return the current preset mode.
 
-        Maps work_mode to preset:
-        - 1 (gearMode) -> Normal
-        - 3 (Auto) -> Auto
-        - other top-level work modes (Sleep/Turbo/Custom) -> their own preset
-          (issue #114)
+        Maps the current work_mode to capability-discovered preset IDs/names.
+        Manual/Auto work_mode values are device-specific and not hardcoded.
         """
         state = self.device_state
         if state is None or state.work_mode is None:
             return None
 
-        if state.work_mode == WORK_MODE_AUTO:
-            return PRESET_MODE_AUTO
+        if state.work_mode == self._manual_work_mode:
+            return self._manual_preset_name
         if state.work_mode in self._work_mode_to_preset:
             return self._work_mode_to_preset[state.work_mode]
-        return PRESET_MODE_NORMAL
+        return self._manual_preset_name
 
     @property
     def oscillating(self) -> bool | None:
@@ -258,34 +456,84 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
             await self.async_turn_off()
             return
 
-        mode_value = percentage_to_ordered_list_item(self._fan_speeds, percentage)
-
+        work_mode = self._manual_work_mode
+        state = self.device_state
+        if (
+            state
+            and state.work_mode is not None
+            and int(state.work_mode) in self._speed_work_modes
+        ):
+            work_mode = int(state.work_mode)
+        speed_values = self._work_mode_speed_values[work_mode]
+        mode_value = percentage_to_ordered_list_item(speed_values, percentage)
         _LOGGER.debug(
-            "Setting fan speed: percentage=%d, mode_value=%d",
+            "Setting fan speed: percentage=%d, work_mode=%d, mode_value=%d",
             percentage,
+            work_mode,
             mode_value,
         )
 
         await self.coordinator.async_control_device(
             self._device_id,
-            WorkModeCommand(work_mode=WORK_MODE_GEAR, mode_value=mode_value),
+            WorkModeCommand(work_mode=work_mode, mode_value=mode_value),
         )
+        if work_mode == self._manual_work_mode:
+            self._last_manual_mode_value = mode_value
+        self._last_mode_values[work_mode] = mode_value
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        if preset_mode == PRESET_MODE_AUTO:
-            work_mode = WORK_MODE_AUTO
-            mode_value = 0  # Not used in auto mode
-        elif preset_mode in self._preset_work_modes:
-            # Sleep / Turbo / Custom etc. — top-level work mode, no speed value
-            # (issue #114).
-            work_mode = self._preset_work_modes[preset_mode]
-            mode_value = 0
+        manual_mode_value = self._manual_mode_value_from_state()
+        if manual_mode_value is not None:
+            self._last_manual_mode_value = manual_mode_value
+            self._last_mode_values[self._manual_work_mode] = manual_mode_value
+
+        state = self.device_state
+        if (
+            state
+            and state.work_mode is not None
+            and state.mode_value is not None
+            and int(state.work_mode) in self._preset_work_modes.values()
+        ):
+            # Capture the current mode's value before switching away so
+            # returning to this preset restores the user's last selection.
+            state_work_mode = int(state.work_mode)
+            state_mode_value = int(state.mode_value)
+            if state_work_mode in self._speed_work_modes:
+                mode_speeds = self._work_mode_speed_values.get(state_work_mode, self._fan_speeds)
+                mode_speed_set = self._work_mode_speed_sets.get(state_work_mode, set(mode_speeds))
+                if state_mode_value in mode_speed_set:
+                    self._last_mode_values[state_work_mode] = state_mode_value
+            elif state_work_mode in self._speedless_work_modes:
+                self._last_mode_values[state_work_mode] = 0
+            else:
+                self._last_mode_values[state_work_mode] = state_mode_value
+
+        if preset_mode in self._preset_commands:
+            work_mode, mode_value = self._preset_commands[preset_mode]
+            if preset_mode == self._manual_preset_name:
+                mode_value = self._last_manual_mode_value
+                if manual_mode_value is not None:
+                    mode_value = manual_mode_value
+                # Optimistically persist the selected manual speed.
+                self._last_manual_mode_value = mode_value
+            elif work_mode in self._speedless_work_modes:
+                mode_value = 0
+            elif work_mode in self._speed_work_modes:
+                mode_value = self._last_mode_values.get(work_mode, mode_value)
+                mode_value = max(
+                    mode_value,
+                    min(self._work_mode_speed_values.get(work_mode, self._fan_speeds)),
+                )
+            else:
+                mode_value = self._last_mode_values.get(work_mode, mode_value)
         else:
-            # Normal mode - use current speed or default to medium
-            work_mode = WORK_MODE_GEAR
-            state = self.device_state
-            mode_value = state.mode_value if state and state.mode_value else 2
+            # Manual mode fallback - use current speed or typical available speed
+            work_mode = self._manual_work_mode
+            mode_value = self._last_manual_mode_value
+            if manual_mode_value is not None:
+                mode_value = manual_mode_value
+            self._last_manual_mode_value = mode_value
 
         _LOGGER.debug(
             "Setting preset mode: preset=%s, work_mode=%d, mode_value=%d",
@@ -298,6 +546,9 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
             self._device_id,
             WorkModeCommand(work_mode=work_mode, mode_value=mode_value),
         )
+        if work_mode == self._manual_work_mode:
+            self._last_manual_mode_value = mode_value
+        self._last_mode_values[work_mode] = mode_value
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Oscillate the fan."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,13 +18,14 @@ from custom_components.govee.models import (
     GoveeCapability,
     GoveeDevice,
     GoveeDeviceState,
-    PowerCommand,
     BrightnessCommand,
     ColorCommand,
     ColorTempCommand,
+    OscillationCommand,
+    PowerCommand,
+    RGBColor,
     RangeCommand,
     SceneCommand,
-    RGBColor,
     WorkModeCommand,
 )
 from custom_components.govee.models.device import (
@@ -519,6 +520,22 @@ class TestOptimisticUpdates:
             RangeCommand(range_instance="fanSpeed", value=3),
         )
         assert sample_state.configured_humidity == 55
+
+    def test_apply_optimistic_oscillation_command(self, sample_state):
+        """OscillationCommand updates fan oscillation state optimistically."""
+        from custom_components.govee.coordinator import GoveeCoordinator
+
+        sample_state.oscillating = False
+
+        coord = object.__new__(GoveeCoordinator)
+        coord._states = {sample_state.device_id: sample_state}
+
+        coord._apply_optimistic_update(
+            sample_state.device_id,
+            OscillationCommand(oscillating=True),
+        )
+        assert sample_state.oscillating is True
+        assert sample_state.source == "optimistic"
 
 
 class TestDeviceStateCreation:

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -671,13 +671,7 @@ class TestGoveeCeilingFanOscillation:
 
 
 def _h7106_device():
-    """H7106-shaped fan whose workMode list has its own "Auto" (value != 3).
-
-    Reproduces issue #120: the device advertises a top-level work mode literally
-    named "Auto" with a value other than WORK_MODE_AUTO (3). Before the fix this
-    was appended as an extra preset on top of the built-in "Auto", producing a
-    duplicate that crashes the HomeKit bridge with a duplicate-IID error.
-    """
+    """H7106-shaped fan where FanSpeed is manual and Auto is not value 3."""
     from custom_components.govee.models import GoveeDevice, GoveeCapability
     from custom_components.govee.models.device import (
         CAPABILITY_ON_OFF,
@@ -692,23 +686,39 @@ def _h7106_device():
             {
                 "fieldName": "workMode",
                 "options": [
-                    {"name": "gearMode", "value": 1},
-                    {"name": "Auto", "value": 6},  # device's own "Auto", != 3
+                    {"name": "FanSpeed", "value": 1},
+                    {"name": "Auto", "value": 2},
                     {"name": "Sleep", "value": 5},
+                    {"name": "Nature", "value": 6},
+                    {"name": "Custom", "value": 7},
                 ],
             },
             {
                 "fieldName": "modeValue",
                 "options": [
                     {
-                        "name": "gearMode",
+                        "name": "FanSpeed",
                         "options": [
-                            {"name": "Low", "value": 1},
-                            {"name": "High", "value": 2},
+                            {"value": 1},
+                            {"value": 2},
+                            {"value": 3},
+                            {"value": 4},
+                            {"value": 5},
+                            {"value": 6},
+                            {"value": 7},
+                            {"value": 8},
                         ],
                     },
                     {"defaultValue": 0, "name": "Auto"},
-                    {"defaultValue": 0, "name": "Sleep"},
+                    {
+                        "name": "Sleep",
+                        "options": [{"value": 1}, {"value": 2}, {"value": 3}],
+                    },
+                    {
+                        "name": "Nature",
+                        "options": [{"value": 1}, {"value": 2}, {"value": 3}],
+                    },
+                    {"defaultValue": 0, "name": "Custom"},
                 ],
             },
         ],
@@ -732,7 +742,7 @@ def _h7106_device():
 
 
 class TestFanDuplicatePreset:
-    """Issue #120: a device "Auto"/"Normal" work mode must not duplicate built-ins."""
+    """Capability-driven fan mode handling for H7106-like devices."""
 
     @pytest.fixture
     def h7106_entity(self):
@@ -746,16 +756,409 @@ class TestFanDuplicatePreset:
 
     def test_no_duplicate_auto_preset(self, h7106_entity):
         modes = h7106_entity.preset_modes
-        # Built-in Auto/Normal present exactly once; the device's colliding
-        # "Auto" is dropped, while the unique "Sleep" still surfaces.
+        # Presets come directly from capabilities with no duplicates.
         assert modes.count(PRESET_MODE_AUTO) == 1
-        assert modes.count(PRESET_MODE_NORMAL) == 1
+        assert "FanSpeed" in modes
         assert "Sleep" in modes
-        # No name appears twice (the HomeKit IID-collision precondition).
+        assert "Nature" in modes
+        assert "Custom" in modes
         assert len(modes) == len(set(modes))
 
-    def test_collided_auto_not_in_work_mode_map(self, h7106_entity):
-        # The dropped "Auto" must not leak into the preset->work_mode map, so
-        # selecting "Auto" maps to the built-in WORK_MODE_AUTO, not value 6.
-        assert "Auto" not in h7106_entity._preset_work_modes
+    def test_preset_modes_map_to_discovered_work_modes(self, h7106_entity):
+        assert h7106_entity._auto_work_mode == 2
+        assert h7106_entity._preset_work_modes.get("Auto") == 2
+        assert h7106_entity._manual_work_mode == 1
+        assert h7106_entity._manual_preset_name == "FanSpeed"
         assert h7106_entity._preset_work_modes.get("Sleep") == 5
+
+    def test_speed_count_and_percentage_step_from_fanspeed_modevalue(self, h7106_entity):
+        assert h7106_entity.speed_count == 8
+        assert h7106_entity.percentage_step == pytest.approx(12.5)
+
+    @pytest.mark.asyncio
+    async def test_set_preset_auto_uses_discovered_work_mode(self, h7106_entity):
+        await h7106_entity.async_set_preset_mode("Auto")
+        cmd = h7106_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("preset_mode", "work_mode"),
+        [("Sleep", 5), ("Nature", 6)],
+    )
+    async def test_set_non_manual_preset_restores_last_mode_value_after_mode_switch(
+        self, h7106_entity, preset_mode, work_mode
+    ):
+        state = h7106_entity.coordinator.get_state.return_value
+        state.work_mode = work_mode
+        state.mode_value = 3
+
+        await h7106_entity.async_set_preset_mode("FanSpeed")
+        state.work_mode = 1
+        state.mode_value = 4
+
+        await h7106_entity.async_set_preset_mode(preset_mode)
+
+        cmd = h7106_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == work_mode
+        assert cmd.mode_value == 3
+
+    @pytest.mark.asyncio
+    async def test_set_percentage_in_sleep_uses_sleep_speed_range(self, h7106_entity):
+        state = h7106_entity.coordinator.get_state.return_value
+        state.work_mode = 5
+        state.mode_value = 2
+
+        await h7106_entity.async_set_percentage(100)
+
+        cmd = h7106_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 5
+        assert cmd.mode_value == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("percentage", "expected_mode_value"),
+        [(1, 1), (50, 2), (100, 3)],
+    )
+    async def test_set_percentage_in_sleep_maps_across_sleep_speed_range(
+        self, h7106_entity, percentage, expected_mode_value
+    ):
+        state = h7106_entity.coordinator.get_state.return_value
+        state.work_mode = 5
+        state.mode_value = 2
+
+        await h7106_entity.async_set_percentage(percentage)
+
+        cmd = h7106_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 5
+        assert cmd.mode_value == expected_mode_value
+
+
+def _h7107_device():
+    """H7107-shaped fan where manual FanSpeed work mode is not value 1."""
+    from custom_components.govee.models import GoveeDevice, GoveeCapability
+    from custom_components.govee.models.device import (
+        CAPABILITY_ON_OFF,
+        CAPABILITY_WORK_MODE,
+        INSTANCE_POWER,
+        INSTANCE_WORK_MODE,
+    )
+
+    workmode = {
+        "dataType": "STRUCT",
+        "fields": [
+            {
+                "fieldName": "workMode",
+                "options": [
+                    {"name": "Auto", "value": 2},
+                    {"name": "Sleep", "value": 3},
+                    {"name": "FanSpeed", "value": 4},
+                    {"name": "Nature", "value": 5},
+                    {"name": "Custom", "value": 6},
+                ],
+            },
+            {
+                "fieldName": "modeValue",
+                "options": [
+                    {
+                        "name": "FanSpeed",
+                        "options": [{"value": i} for i in range(1, 13)],
+                    },
+                    {"defaultValue": 0, "name": "Auto"},
+                    {"defaultValue": 0, "name": "Sleep"},
+                    {"defaultValue": 0, "name": "Nature"},
+                    {"defaultValue": 0, "name": "Custom"},
+                ],
+            },
+        ],
+    }
+    return GoveeDevice(
+        device_id="AA:BB:CC:DD:EE:FF:71:07",
+        sku="H7107",
+        name="Bedroom Tower Fan",
+        device_type="devices.types.fan",
+        capabilities=(
+            GoveeCapability(
+                type=CAPABILITY_ON_OFF,
+                instance=INSTANCE_POWER,
+                parameters={},
+            ),
+            GoveeCapability(
+                type=CAPABILITY_WORK_MODE,
+                instance=INSTANCE_WORK_MODE,
+                parameters=workmode,
+            ),
+        ),
+    )
+
+
+def _h7107_whitespace_device():
+    """H7107 variant with whitespace/misaligned option names."""
+    from custom_components.govee.models import GoveeDevice, GoveeCapability
+    from custom_components.govee.models.device import (
+        CAPABILITY_ON_OFF,
+        CAPABILITY_WORK_MODE,
+        INSTANCE_POWER,
+        INSTANCE_WORK_MODE,
+    )
+
+    workmode = {
+        "dataType": "STRUCT",
+        "fields": [
+            {
+                "fieldName": "workMode",
+                "options": [
+                    {"name": "Auto ", "value": 2},
+                    {"name": "FanSpeed ", "value": 4},
+                ],
+            },
+            {
+                "fieldName": "modeValue",
+                "options": [
+                    {
+                        "name": "FanSpeed",
+                        # Duplicates are intentional to verify de-duplication.
+                        "options": [{"value": 5}, {"value": 1}, {"value": 3}, {"value": 3}, {"value": 2}],
+                    },
+                    {"defaultValue": 0, "name": "Auto"},
+                ],
+            },
+        ],
+    }
+    return GoveeDevice(
+        device_id="AA:BB:CC:DD:EE:FF:71:70",
+        sku="H7107",
+        name="Whitespace Fan",
+        device_type="devices.types.fan",
+        capabilities=(
+            GoveeCapability(type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}),
+            GoveeCapability(type=CAPABILITY_WORK_MODE, instance=INSTANCE_WORK_MODE, parameters=workmode),
+        ),
+    )
+
+
+class TestFanSpeedManualModeDiscovery:
+    @pytest.fixture
+    def h7107_entity(self):
+        device = _h7107_device()
+        state = MagicMock()
+        state.work_mode = 4
+        state.mode_value = 6
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        coordinator.get_state = MagicMock(return_value=state)
+        coordinator.async_control_device = AsyncMock(return_value=True)
+        return GoveeFanEntity(coordinator, device)
+
+    def test_speed_count_and_presets_use_capabilities(self, h7107_entity):
+        assert h7107_entity.speed_count == 12
+        assert 0 not in h7107_entity._fan_speeds
+        assert min(h7107_entity._fan_speeds) == 1
+        assert h7107_entity.percentage_step == pytest.approx(100 / 12)
+        assert h7107_entity.preset_modes == [
+            "FanSpeed",
+            "Auto",
+            "Sleep",
+            "Nature",
+            "Custom",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_set_percentage_uses_detected_manual_work_mode(self, h7107_entity):
+        await h7107_entity.async_set_percentage(100)
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 4
+        assert cmd.mode_value == 12
+
+    @pytest.mark.asyncio
+    async def test_set_percentage_from_auto_uses_manual_mode(self, h7107_entity):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 2
+        state.mode_value = 0
+
+        await h7107_entity.async_set_percentage(100)
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 4
+        assert cmd.mode_value == 12
+
+    @pytest.mark.asyncio
+    async def test_set_manual_preset_reuses_valid_mode_value_outside_manual_mode(
+        self, h7107_entity
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 2
+        state.mode_value = 6
+
+        await h7107_entity.async_set_preset_mode("FanSpeed")
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 4
+        assert cmd.mode_value == 6
+
+    @pytest.mark.asyncio
+    async def test_set_manual_preset_defaults_to_typical_speed_when_mode_value_invalid(
+        self, h7107_entity
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 2
+        state.mode_value = 0
+
+        await h7107_entity.async_set_preset_mode("FanSpeed")
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 4
+        assert cmd.mode_value == 6
+
+    @pytest.mark.asyncio
+    async def test_set_auto_preset_uses_zero_mode_value(
+        self, h7107_entity
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 4
+        state.mode_value = 8
+
+        await h7107_entity.async_set_preset_mode("Auto")
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 2
+        assert cmd.mode_value == 0
+
+    @pytest.mark.asyncio
+    async def test_set_auto_preset_uses_zero_mode_value_when_state_invalid(
+        self, h7107_entity
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 2
+        state.mode_value = 0
+
+        await h7107_entity.async_set_preset_mode("Auto")
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 2
+        assert cmd.mode_value == 0
+
+    @pytest.mark.asyncio
+    async def test_set_custom_preset_uses_zero_mode_value(self, h7107_entity):
+        await h7107_entity.async_set_preset_mode("Custom")
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 6
+        assert cmd.mode_value == 0
+
+    @pytest.mark.asyncio
+    async def test_set_manual_preset_restores_last_manual_speed_after_mode_switch(
+        self, h7107_entity
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 4
+        state.mode_value = 8
+
+        await h7107_entity.async_set_preset_mode("Auto")
+        state.work_mode = 2
+        state.mode_value = 1
+
+        await h7107_entity.async_set_preset_mode("FanSpeed")
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 4
+        assert cmd.mode_value == 8
+
+    @pytest.mark.asyncio
+    async def test_set_auto_preset_keeps_zero_mode_value(
+        self, h7107_entity
+    ):
+        h7107_entity._preset_commands["Auto"] = (2, 0)
+
+        await h7107_entity.async_set_preset_mode("Auto")
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 2
+        assert cmd.mode_value == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("preset_mode", "work_mode"),
+        [("Sleep", 3), ("Nature", 5)],
+    )
+    async def test_set_non_manual_preset_without_speed_options_keeps_zero_mode_value(
+        self, h7107_entity, preset_mode, work_mode
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = work_mode
+        state.mode_value = 8
+
+        await h7107_entity.async_set_preset_mode("FanSpeed")
+        state.work_mode = 4
+        state.mode_value = 6
+
+        await h7107_entity.async_set_preset_mode(preset_mode)
+
+        cmd = h7107_entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == work_mode
+        assert cmd.mode_value == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "work_mode",
+        [3, 5],
+    )
+    async def test_speed_percentage_returns_none_for_modes_without_speed_options(
+        self, h7107_entity, work_mode
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = work_mode
+        state.mode_value = 8
+        await h7107_entity.async_set_preset_mode("FanSpeed")
+        assert h7107_entity._last_mode_values[work_mode] == 0
+        assert h7107_entity.percentage is None
+
+    def test_percentage_returns_none_for_speedless_mode_without_switch(self, h7107_entity):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 3
+        state.mode_value = 0
+
+        assert h7107_entity.percentage is None
+
+    @pytest.mark.asyncio
+    async def test_speed_percentage_returns_none_without_cached_value_for_speed_mode(
+        self, h7107_entity
+    ):
+        state = h7107_entity.coordinator.get_state.return_value
+        state.work_mode = 3
+        state.mode_value = 0
+        h7107_entity._last_mode_values.pop(3, None)
+
+        assert h7107_entity.percentage is None
+
+
+class TestFanModeNameWhitespaceHandling:
+    def test_mode_names_are_stripped_and_manual_speeds_are_sorted_unique(self):
+        device = _h7107_whitespace_device()
+        state = MagicMock(work_mode=4, mode_value=5)
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        coordinator.get_state = MagicMock(return_value=state)
+        coordinator.async_control_device = AsyncMock(return_value=True)
+
+        entity = GoveeFanEntity(coordinator, device)
+
+        assert entity._manual_work_mode == 4
+        assert entity._auto_work_mode == 2
+        assert entity._fan_speeds == [1, 2, 3, 5]
+        assert entity._fan_speeds.count(3) == 1
+        assert entity.speed_count == 4

--- a/tests/test_issue_114.py
+++ b/tests/test_issue_114.py
@@ -574,6 +574,19 @@ class TestH7124FanPresets:
         assert cmd.work_mode == 7
         assert cmd.mode_value == 0
 
+    @pytest.mark.asyncio
+    async def test_set_percentage_from_turbo_uses_manual_mode(self, fan):
+        state = fan.coordinator.get_state.return_value
+        state.work_mode = 7
+        state.mode_value = 0
+
+        await fan.async_set_percentage(100)
+
+        cmd = fan.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == 1
+        assert cmd.mode_value == 3
+
 
 # --------------------------------------------------------------------------- #
 # Dehumidifier setpoint + Medium (H7152)


### PR DESCRIPTION
This PR refactors `GoveeFanEntity` to make preset modes, speed levels, and work-mode handling **fully capability-driven**.

Instead of relying on hardcoded assumptions (`work_mode=1` for manual/gearMode, `work_mode=3` for Auto, fixed preset names, etc.), the code now parses the device’s `CAPABILITY_WORK_MODE` structure (both `workMode` options and nested `modeValue` options). This approach resolves the same class of problems that #114 and #120 originally targeted, but does so in a more general and robust way that works across a much wider variety of Govee fan models.

### Key improvements

- Dynamically discovers the actual manual speed mode name (`FanSpeed`, `gearMode`, `manual`, …) and its `work_mode` ID.
- Discovers the correct Auto work-mode value and all additional presets (Sleep, Nature, Custom, Turbo, …).
- Builds the authoritative list of discrete speeds, `preset_modes`, and percentage step directly from capabilities.
- Distinguishes speed-bearing modes (manual + Sleep/Nature) from speedless modes (Auto/Custom/Turbo).
- Remembers the last valid `mode_value` per work mode so switching presets (especially to/from Sleep/Nature) preserves the user’s chosen speed.
- `percentage` property and `async_set_percentage` now work correctly for any speed-bearing mode.
- Robust handling of real-world variations (whitespace in option names, zero/invalid speeds, deduplication, non-standard IDs).

This implementation takes loose inspiration from the capability-driven direction first explored in disforw/goveelife#150, but is a complete reimplementation with significantly expanded robustness, state preservation, test coverage, and device compatibility.

### Result

Fan support is now far more reliable and future-proof across the diverse range of Govee tower/pedestal fans.

Fan correctly sets the values between mode switching and can state correctly presents and set for use in scenes.
<img width="580" height="701" alt="image" src="https://github.com/user-attachments/assets/de3d2aa2-f3aa-47a3-9214-26643305f514" />

Modes are now populated by their actual name. Functionality matches hardware changing of modes where speed is persisted per mode.
<img width="567" height="700" alt="image" src="https://github.com/user-attachments/assets/f25c41df-f83b-41e2-947d-2f68293c6eac" />

`Auto`, `Custom` don't have a speed to set.
<img width="571" height="692" alt="image" src="https://github.com/user-attachments/assets/be2527b7-347d-425b-8c66-e5fd0f540620" />

Also when exposed through HomeKit bridge, the toggles show up only for the number of modes available (no duplicate "auto" like in #120)

![image](https://github.com/user-attachments/assets/b7d44957-2c51-4d38-8ee0-286d03182491)