### PR TITLE
Merge BFF device-list MQTT topics for gateway-attached devices (e.g. H5901)

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -539,6 +539,71 @@ class GoveeAuthClient:
             )
             raise GoveeApiError(f"Connection error getting IoT key: {err}") from err
 
+    @staticmethod
+    def _extract_topics_from_devices(devices: list[Any]) -> dict[str, str]:
+        """Map device_id -> MQTT topic from a device-list ``devices`` array.
+
+        Shared by the legacy ``/device/rest/devices/v1/list`` and the BFF
+        ``/bff-app/v1/device/list`` responses: both carry the topic at
+        ``deviceExt.deviceSettings.topic``, and both may deliver ``deviceExt``
+        and/or ``deviceSettings`` as JSON strings that need parsing.
+        """
+        topics: dict[str, str] = {}
+        for device in devices:
+            device_id = device.get("device")
+            if not device_id:
+                continue
+
+            device_ext = device.get("deviceExt", {})
+            if isinstance(device_ext, str):
+                try:
+                    device_ext = json.loads(device_ext)
+                except (json.JSONDecodeError, TypeError):
+                    device_ext = {}
+
+            device_settings = device_ext.get("deviceSettings", {})
+            if isinstance(device_settings, str):
+                try:
+                    device_settings = json.loads(device_settings)
+                except (json.JSONDecodeError, TypeError):
+                    device_settings = {}
+            if not isinstance(device_settings, dict):
+                continue
+
+            topic = device_settings.get("topic")
+            if topic:
+                topics[device_id] = topic
+        return topics
+
+    async def _fetch_bff_device_topics(self, token: str) -> dict[str, str]:
+        """Fetch device MQTT topics from the BFF device list.
+
+        The BFF ``/bff-app/v1/device/list`` response carries
+        ``deviceExt.deviceSettings.topic`` for gateway-attached (BLE-over-H5044)
+        devices — e.g. the H5901 Smart Water Timer — that the legacy device-list
+        endpoint omits, leaving them uncontrollable (issue #135).
+        """
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "appVersion": GOVEE_APP_VERSION,
+            "clientType": GOVEE_CLIENT_TYPE,
+            "iotVersion": GOVEE_IOT_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        async with self._require_session().get(
+            GOVEE_BFF_DEVICE_LIST_URL,
+            headers=headers,
+        ) as response:
+            data = await response.json()
+            if response.status != 200:
+                message = data.get("message", f"HTTP {response.status}")
+                raise GoveeApiError(
+                    f"BFF device list failed: {message}", code=response.status
+                )
+            devices = data.get("data", {}).get("devices", [])
+            return self._extract_topics_from_devices(devices)
+
     async def fetch_device_topics(
         self,
         token: str,
@@ -579,54 +644,34 @@ class GoveeAuthClient:
                         f"Failed to get device list: {message}", code=response.status
                     )
 
-                # Extract device topics from response
-                # Structure: devices[].device_ext.device_settings.topic
-                device_topics: dict[str, str] = {}
+                # Extract topics from the legacy list (structure:
+                # devices[].deviceExt.deviceSettings.topic), then merge in topics
+                # from the BFF device list, which additionally carries them for
+                # gateway-attached (BLE-over-H5044) devices the legacy endpoint
+                # omits — e.g. the H5901 Smart Water Timer (issue #135).
                 devices = data.get("devices", [])
+                device_topics = self._extract_topics_from_devices(devices)
+                legacy_count = len(device_topics)
 
-                for device in devices:
-                    device_id = device.get("device")
-                    if not device_id:
-                        continue
+                added = 0
+                try:
+                    bff_topics = await self._fetch_bff_device_topics(token)
+                except Exception as err:  # noqa: BLE001
+                    # Best-effort supplement: the BFF merge must never regress the
+                    # legacy topic set, so any failure is swallowed (non-fatal).
+                    _LOGGER.debug("BFF topic fetch failed (non-fatal): %s", err)
+                else:
+                    for device_id, topic in bff_topics.items():
+                        if device_id not in device_topics:
+                            device_topics[device_id] = topic
+                            added += 1
 
-                    # device_ext may be a JSON string that needs parsing
-                    device_ext = device.get("deviceExt", {})
-                    if isinstance(device_ext, str):
-                        try:
-                            device_ext = json.loads(device_ext)
-                        except (json.JSONDecodeError, TypeError):
-                            device_ext = {}
-
-                    # device_settings may also be a JSON string
-                    device_settings = device_ext.get("deviceSettings", {})
-                    if isinstance(device_settings, str):
-                        try:
-                            device_settings = json.loads(device_settings)
-                        except (json.JSONDecodeError, TypeError):
-                            device_settings = {}
-
-                    topic = device_settings.get("topic")
-                    if topic:
-                        device_topics[device_id] = topic
-                        _LOGGER.debug(
-                            "Device %s has MQTT topic: %s...", device_id, topic[:30]
-                        )
-                    else:
-                        # Log missing topics - group devices (numeric IDs) never have topics
-                        # because they're virtual aggregation entities, not physical devices
-                        is_likely_group = device_id.isdigit() if device_id else False
-                        if is_likely_group:
-                            _LOGGER.debug(
-                                "Group device %s has no MQTT topic (expected - groups are virtual)",
-                                device_id,
-                            )
-                        else:
-                            _LOGGER.debug(
-                                "Device %s has no MQTT topic in response",
-                                device_id,
-                            )
-
-                _LOGGER.info("Fetched MQTT topics for %d devices", len(device_topics))
+                _LOGGER.info(
+                    "Fetched MQTT topics for %d device(s) (%d legacy + %d BFF-only)",
+                    len(device_topics),
+                    legacy_count,
+                    added,
+                )
                 return device_topics
 
         except aiohttp.ClientError as err:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -835,6 +835,9 @@ class TestFetchDeviceTopicsHeaders:
             return _async_cm(device_resp)
 
         session.post = _post
+        session.get = lambda *a, **kw: _async_cm(
+            make_mock_response(200, {"data": {"devices": []}})
+        )
         client = GoveeAuthClient(session=session)
 
         # Act
@@ -852,9 +855,11 @@ class TestFetchDeviceTopicsHeaders:
         """should return a dict mapping device_id strings to MQTT topic strings."""
         # Arrange
         device_resp = make_mock_response(200, create_device_list_response())
+        bff_resp = make_mock_response(200, {"data": {"devices": []}})
         session = MagicMock(spec=aiohttp.ClientSession)
         session.close = AsyncMock()
         session.post = lambda *a, **kw: _async_cm(device_resp)
+        session.get = lambda *a, **kw: _async_cm(bff_resp)
         client = GoveeAuthClient(session=session)
 
         # Act
@@ -872,9 +877,11 @@ class TestFetchDeviceTopicsHeaders:
         )
         devices = [{"device": "CC:DD:EE:FF:00:11", "deviceExt": device_ext_str}]
         device_resp = make_mock_response(200, create_device_list_response(devices))
+        bff_resp = make_mock_response(200, {"data": {"devices": []}})
         session = MagicMock(spec=aiohttp.ClientSession)
         session.close = AsyncMock()
         session.post = lambda *a, **kw: _async_cm(device_resp)
+        session.get = lambda *a, **kw: _async_cm(bff_resp)
         client = GoveeAuthClient(session=session)
 
         # Act
@@ -894,9 +901,11 @@ class TestFetchDeviceTopicsHeaders:
             },
         ]
         device_resp = make_mock_response(200, create_device_list_response(devices))
+        bff_resp = make_mock_response(200, {"data": {"devices": []}})
         session = MagicMock(spec=aiohttp.ClientSession)
         session.close = AsyncMock()
         session.post = lambda *a, **kw: _async_cm(device_resp)
+        session.get = lambda *a, **kw: _async_cm(bff_resp)
         client = GoveeAuthClient(session=session)
 
         # Act
@@ -1565,6 +1574,9 @@ class TestDeterministicClientId:
             return _async_cm(topics_resp)
 
         session.post = _post
+        session.get = lambda *a, **kw: _async_cm(
+            make_mock_response(200, {"data": {"devices": []}})
+        )
         client = GoveeAuthClient(session=session)
         client._client_id = "login-cid-xyz"
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -935,6 +935,151 @@ class TestFetchDeviceTopicsHeaders:
         with pytest.raises(GoveeApiError):
             await client.fetch_device_topics(token="tok")
 
+    async def test_fetch_device_topics_merges_bff_only_topics(self):
+        """should add topics from the BFF list for devices the legacy list omits.
+
+        Gateway-attached devices (e.g. the H5901 behind an H5044) carry a topic
+        in the BFF ``/bff-app/v1/device/list`` response but not the legacy one.
+        """
+        legacy_resp = make_mock_response(
+            200,
+            create_device_list_response(
+                [
+                    {
+                        "device": "WIFI:AA",
+                        "deviceExt": {"deviceSettings": {"topic": "GD/wifi-aa"}},
+                    }
+                ]
+            ),
+        )
+        # BFF shape is {"data": {"devices": [...]}} and includes a gateway-attached
+        # device that is absent from the legacy list.
+        bff_resp = make_mock_response(
+            200,
+            {
+                "data": {
+                    "devices": [
+                        {
+                            "device": "WIFI:AA",
+                            "deviceExt": {"deviceSettings": {"topic": "GD/wifi-aa"}},
+                        },
+                        {
+                            "sku": "H5901",
+                            "device": "HUB:H5901",
+                            "deviceExt": {
+                                "deviceSettings": json.dumps({"topic": "GD/hub-h5901"})
+                            },
+                        },
+                    ]
+                }
+            },
+        )
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.close = AsyncMock()
+        session.post = lambda *a, **kw: _async_cm(legacy_resp)
+        session.get = lambda *a, **kw: _async_cm(bff_resp)
+        client = GoveeAuthClient(session=session)
+
+        # Act
+        topics = await client.fetch_device_topics(token="tok")
+
+        # Assert
+        assert topics["WIFI:AA"] == "GD/wifi-aa"
+        assert topics["HUB:H5901"] == "GD/hub-h5901"
+
+    async def test_fetch_device_topics_legacy_topic_wins_over_bff(self):
+        """should not let a BFF topic override one already known from the legacy list."""
+        legacy_resp = make_mock_response(
+            200,
+            create_device_list_response(
+                [
+                    {
+                        "device": "DEV:1",
+                        "deviceExt": {"deviceSettings": {"topic": "GD/legacy"}},
+                    }
+                ]
+            ),
+        )
+        bff_resp = make_mock_response(
+            200,
+            {
+                "data": {
+                    "devices": [
+                        {
+                            "device": "DEV:1",
+                            "deviceExt": {"deviceSettings": {"topic": "GD/bff"}},
+                        }
+                    ]
+                }
+            },
+        )
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.close = AsyncMock()
+        session.post = lambda *a, **kw: _async_cm(legacy_resp)
+        session.get = lambda *a, **kw: _async_cm(bff_resp)
+        client = GoveeAuthClient(session=session)
+
+        # Act
+        topics = await client.fetch_device_topics(token="tok")
+
+        # Assert
+        assert topics["DEV:1"] == "GD/legacy"
+
+    async def test_fetch_device_topics_bff_failure_is_non_fatal(self):
+        """should return legacy topics even if the BFF supplement call fails."""
+        legacy_resp = make_mock_response(
+            200,
+            create_device_list_response(
+                [
+                    {
+                        "device": "DEV:1",
+                        "deviceExt": {"deviceSettings": {"topic": "GD/legacy"}},
+                    }
+                ]
+            ),
+        )
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.close = AsyncMock()
+        session.post = lambda *a, **kw: _async_cm(legacy_resp)
+
+        def _get_raises(*_a: Any, **_kw: Any):
+            raise aiohttp.ClientConnectionError("BFF down")
+
+        session.get = _get_raises
+        client = GoveeAuthClient(session=session)
+
+        # Act
+        topics = await client.fetch_device_topics(token="tok")
+
+        # Assert
+        assert topics["DEV:1"] == "GD/legacy"
+
+
+class TestExtractTopicsFromDevices:
+    """Test the shared device-list topic-extraction helper."""
+
+    def test_parses_dict_and_json_string_forms(self):
+        """should parse deviceExt/deviceSettings whether dicts or JSON strings."""
+        devices = [
+            {"device": "A", "deviceExt": {"deviceSettings": {"topic": "GD/a"}}},
+            {
+                "device": "B",
+                "deviceExt": json.dumps(
+                    {"deviceSettings": json.dumps({"topic": "GD/b"})}
+                ),
+            },
+        ]
+        topics = GoveeAuthClient._extract_topics_from_devices(devices)
+        assert topics == {"A": "GD/a", "B": "GD/b"}
+
+    def test_skips_devices_without_topic_or_id(self):
+        """should skip devices missing a topic or a device id."""
+        devices = [
+            {"device": "A", "deviceExt": {"deviceSettings": {}}},
+            {"deviceExt": {"deviceSettings": {"topic": "GD/x"}}},
+        ]
+        assert GoveeAuthClient._extract_topics_from_devices(devices) == {}
+
 
 # ==============================================================================
 # Tests: GoveeIotCredentials.is_valid
@@ -2137,16 +2282,12 @@ class TestBffThermoReadings:
             {
                 "sku": "H5058",  # leak sensor — excluded
                 "device": "L1",
-                "deviceExt": json.dumps(
-                    {"lastDeviceData": json.dumps({"tem": 2000})}
-                ),
+                "deviceExt": json.dumps({"lastDeviceData": json.dumps({"tem": 2000})}),
             },
             {
                 "sku": "H5310",  # BFF-only thermo — owned by dedicated path
                 "device": "T1",
-                "deviceExt": json.dumps(
-                    {"lastDeviceData": json.dumps({"tem": 2640})}
-                ),
+                "deviceExt": json.dumps({"lastDeviceData": json.dumps({"tem": 2640})}),
             },
         ]
         session = make_session_get(make_mock_response(200, _bff_response(devices)))


### PR DESCRIPTION
## What

`fetch_device_topics()` sourced MQTT topics only from the legacy `/device/rest/devices/v1/list` endpoint, which returns no `deviceExt.deviceSettings.topic` for **gateway-attached (BLE-over-gateway) devices** — e.g. the H5901 Smart Water Timer behind an H5044. Those devices end up with no topic, so no MQTT commands can be published to them.

This PR merges topics from the BFF `/bff-app/v1/device/list` endpoint (already used elsewhere in this integration) into the legacy set. That endpoint *does* carry the topic for gateway-attached devices.

## How

- Extract the topic parsing into a shared `_extract_topics_from_devices()` helper — both endpoints use the same `deviceExt.deviceSettings.topic` shape (dict or JSON string).
- After the legacy fetch, call the BFF endpoint and merge in topics for devices not already present. **Best-effort**: any BFF failure is swallowed so the legacy set is never regressed, and legacy topics win on conflict.

## Why

Unblocks MQTT command publishing for gateway-attached devices — groundwork for controlling the H5901 Smart Water Timer (#135), and applies to any H5044-bridged device.

## Verification

Tested against a live H5901 + H5044: `device_topic_count` rose from 7 to 12 and the timer now receives a `GD/` topic. Added unit tests for the helper and the merge (BFF-only add, legacy-wins-on-conflict, non-fatal BFF failure).

Refs #135