### PR TITLE
[WIP] H5901 Smart Water Timer on/off control (needs gateway BLE command)

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -539,6 +539,71 @@ class GoveeAuthClient:
             )
             raise GoveeApiError(f"Connection error getting IoT key: {err}") from err
 
+    @staticmethod
+    def _extract_topics_from_devices(devices: list[Any]) -> dict[str, str]:
+        """Map device_id -> MQTT topic from a device-list ``devices`` array.
+
+        Shared by the legacy ``/device/rest/devices/v1/list`` and the BFF
+        ``/bff-app/v1/device/list`` responses: both carry the topic at
+        ``deviceExt.deviceSettings.topic``, and both may deliver ``deviceExt``
+        and/or ``deviceSettings`` as JSON strings that need parsing.
+        """
+        topics: dict[str, str] = {}
+        for device in devices:
+            device_id = device.get("device")
+            if not device_id:
+                continue
+
+            device_ext = device.get("deviceExt", {})
+            if isinstance(device_ext, str):
+                try:
+                    device_ext = json.loads(device_ext)
+                except (json.JSONDecodeError, TypeError):
+                    device_ext = {}
+
+            device_settings = device_ext.get("deviceSettings", {})
+            if isinstance(device_settings, str):
+                try:
+                    device_settings = json.loads(device_settings)
+                except (json.JSONDecodeError, TypeError):
+                    device_settings = {}
+            if not isinstance(device_settings, dict):
+                continue
+
+            topic = device_settings.get("topic")
+            if topic:
+                topics[device_id] = topic
+        return topics
+
+    async def _fetch_bff_device_topics(self, token: str) -> dict[str, str]:
+        """Fetch device MQTT topics from the BFF device list.
+
+        The BFF ``/bff-app/v1/device/list`` response carries
+        ``deviceExt.deviceSettings.topic`` for gateway-attached (BLE-over-H5044)
+        devices — e.g. the H5901 Smart Water Timer — that the legacy device-list
+        endpoint omits, leaving them uncontrollable (issue #135).
+        """
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "appVersion": GOVEE_APP_VERSION,
+            "clientType": GOVEE_CLIENT_TYPE,
+            "iotVersion": GOVEE_IOT_VERSION,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        async with self._require_session().get(
+            GOVEE_BFF_DEVICE_LIST_URL,
+            headers=headers,
+        ) as response:
+            data = await response.json()
+            if response.status != 200:
+                message = data.get("message", f"HTTP {response.status}")
+                raise GoveeApiError(
+                    f"BFF device list failed: {message}", code=response.status
+                )
+            devices = data.get("data", {}).get("devices", [])
+            return self._extract_topics_from_devices(devices)
+
     async def fetch_device_topics(
         self,
         token: str,
@@ -579,54 +644,34 @@ class GoveeAuthClient:
                         f"Failed to get device list: {message}", code=response.status
                     )
 
-                # Extract device topics from response
-                # Structure: devices[].device_ext.device_settings.topic
-                device_topics: dict[str, str] = {}
+                # Extract topics from the legacy list (structure:
+                # devices[].deviceExt.deviceSettings.topic), then merge in topics
+                # from the BFF device list, which additionally carries them for
+                # gateway-attached (BLE-over-H5044) devices the legacy endpoint
+                # omits — e.g. the H5901 Smart Water Timer (issue #135).
                 devices = data.get("devices", [])
+                device_topics = self._extract_topics_from_devices(devices)
+                legacy_count = len(device_topics)
 
-                for device in devices:
-                    device_id = device.get("device")
-                    if not device_id:
-                        continue
+                added = 0
+                try:
+                    bff_topics = await self._fetch_bff_device_topics(token)
+                except Exception as err:  # noqa: BLE001
+                    # Best-effort supplement: the BFF merge must never regress the
+                    # legacy topic set, so any failure is swallowed (non-fatal).
+                    _LOGGER.debug("BFF topic fetch failed (non-fatal): %s", err)
+                else:
+                    for device_id, topic in bff_topics.items():
+                        if device_id not in device_topics:
+                            device_topics[device_id] = topic
+                            added += 1
 
-                    # device_ext may be a JSON string that needs parsing
-                    device_ext = device.get("deviceExt", {})
-                    if isinstance(device_ext, str):
-                        try:
-                            device_ext = json.loads(device_ext)
-                        except (json.JSONDecodeError, TypeError):
-                            device_ext = {}
-
-                    # device_settings may also be a JSON string
-                    device_settings = device_ext.get("deviceSettings", {})
-                    if isinstance(device_settings, str):
-                        try:
-                            device_settings = json.loads(device_settings)
-                        except (json.JSONDecodeError, TypeError):
-                            device_settings = {}
-
-                    topic = device_settings.get("topic")
-                    if topic:
-                        device_topics[device_id] = topic
-                        _LOGGER.debug(
-                            "Device %s has MQTT topic: %s...", device_id, topic[:30]
-                        )
-                    else:
-                        # Log missing topics - group devices (numeric IDs) never have topics
-                        # because they're virtual aggregation entities, not physical devices
-                        is_likely_group = device_id.isdigit() if device_id else False
-                        if is_likely_group:
-                            _LOGGER.debug(
-                                "Group device %s has no MQTT topic (expected - groups are virtual)",
-                                device_id,
-                            )
-                        else:
-                            _LOGGER.debug(
-                                "Device %s has no MQTT topic in response",
-                                device_id,
-                            )
-
-                _LOGGER.info("Fetched MQTT topics for %d devices", len(device_topics))
+                _LOGGER.info(
+                    "Fetched MQTT topics for %d device(s) (%d legacy + %d BFF-only)",
+                    len(device_topics),
+                    legacy_count,
+                    added,
+                )
                 return device_topics
 
         except aiohttp.ClientError as err:

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -2569,8 +2569,13 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             # power/brightness/color over the AWS IoT channel (~50ms) instead
             # of the REST cloud API (~500ms). Group devices and non-capable
             # commands (color temp, scenes, segments) fall through to REST.
+            #
+            # Water timers (e.g. H5901) are forced onto MQTT regardless of the
+            # opt-in: they are gateway-attached BLE devices that the developer
+            # REST API always rejects with "device offline", so MQTT is their
+            # only viable control path.
             if (
-                self._enable_mqtt_control
+                (self._enable_mqtt_control or device.is_water_timer)
                 and self.mqtt_connected
                 and not device.is_group
             ):

--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -170,6 +170,10 @@ INSTANCE_BACKGROUND_LIGHT_TOGGLE = "backgroundLightToggle"
 # Device type for stand-alone temperature/humidity sensors.
 DEVICE_TYPE_THERMOMETER = "devices.types.thermometer"
 
+# Water timer / irrigation valve (e.g. H5901 Smart Water Timer). Exposes a
+# single on_off/powerSwitch capability; gateway-attached (BLE-over-H5044).
+DEVICE_TYPE_TIMER = "devices.types.timer"
+
 
 @dataclass(frozen=True)
 class ColorTempRange:
@@ -479,7 +483,10 @@ class GoveeDevice:
         /device/snapshots endpoint 404s).
         """
         for cap in self.capabilities:
-            if cap.type == CAPABILITY_DYNAMIC_SCENE and cap.instance == INSTANCE_SNAPSHOT:
+            if (
+                cap.type == CAPABILITY_DYNAMIC_SCENE
+                and cap.instance == INSTANCE_SNAPSHOT
+            ):
                 options: list[dict[str, Any]] = cap.parameters.get("options", [])
                 return options
         return []
@@ -506,6 +513,11 @@ class GoveeDevice:
     def is_plug(self) -> bool:
         """Check if device is a smart plug."""
         return self.device_type == DEVICE_TYPE_PLUG
+
+    @property
+    def is_water_timer(self) -> bool:
+        """Check if device is a water timer / irrigation valve (e.g. H5901)."""
+        return self.device_type == DEVICE_TYPE_TIMER
 
     @property
     def is_fan(self) -> bool:
@@ -1095,7 +1107,10 @@ class GoveeDevice:
     def get_nightlight_scene_options(self) -> list[dict[str, Any]]:
         """Extract nightlightScene options as {"name", "value"} dicts (#114)."""
         for cap in self.capabilities:
-            if cap.type == CAPABILITY_MODE and cap.instance == INSTANCE_NIGHTLIGHT_SCENE:
+            if (
+                cap.type == CAPABILITY_MODE
+                and cap.instance == INSTANCE_NIGHTLIGHT_SCENE
+            ):
                 options: list[dict[str, Any]] = cap.parameters.get("options", [])
                 return options
         return []

--- a/custom_components/govee/switch.py
+++ b/custom_components/govee/switch.py
@@ -98,6 +98,12 @@ async def async_setup_entry(
         if device.is_plug and device.supports_power:
             entities.append(GoveePlugSwitchEntity(coordinator, device))
 
+        # Create switch for water timers / irrigation valves (e.g. H5901). These
+        # are gateway-attached BLE devices; on/off is published to the device's
+        # MQTT topic (requires the topic from fetch_device_topics).
+        if device.is_water_timer and device.supports_power:
+            entities.append(GoveeWaterTimerSwitchEntity(coordinator, device))
+
         # Create switch for night light toggle (lights with night light mode).
         # Appliances whose nightlight has brightness/colour get a richer
         # nightlight *light* entity instead, so skip the plain switch for them
@@ -184,9 +190,7 @@ async def async_setup_entry(
             # the optimistic light zones (issue #114).
             for socket_index, instance in enumerate(device.socket_toggle_instances):
                 entities.append(
-                    GoveeSocketSwitchEntity(
-                        coordinator, device, instance, socket_index
-                    )
+                    GoveeSocketSwitchEntity(coordinator, device, instance, socket_index)
                 )
                 _LOGGER.debug(
                     "Created outlet switch %d (%s) for %s",
@@ -258,6 +262,62 @@ class GoveePlugSwitchEntity(GoveeEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the plug off."""
+        await self.coordinator.async_control_device(
+            self._device_id,
+            PowerCommand(power_on=False),
+        )
+
+
+class GoveeWaterTimerSwitchEntity(GoveeEntity, SwitchEntity):
+    """Govee water timer / irrigation valve switch (e.g. H5901 Smart Water Timer).
+
+    Publishes on/off to the device's MQTT topic via a PowerCommand. These are
+    gateway-attached (BLE-over-H5044) devices that do not reliably report power
+    state back, so ``is_on`` reflects the last known state and may be ``None``
+    until a command is sent.
+    """
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_icon = "mdi:sprinkler-variant"
+
+    def __init__(
+        self,
+        coordinator: GoveeCoordinator,
+        device: GoveeDevice,
+    ) -> None:
+        """Initialize the water timer switch entity."""
+        super().__init__(coordinator, device)
+
+        # Use the device name as the entity name.
+        self._attr_name = None
+
+    @property
+    def available(self) -> bool:
+        """Return True while the coordinator is healthy.
+
+        Gateway-attached water timers report ``online=False`` even when they
+        are controllable, so the base entity's online gate would leave this
+        switch permanently unavailable. Mirror the group-device rationale:
+        we can't reliably query state, but control is fire-and-forget over
+        MQTT, so stay available whenever coordinator updates are succeeding.
+        """
+        return self.coordinator.last_update_success
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the valve is open, or None if unknown."""
+        state = self.device_state
+        return state.power_state if state else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Open the valve (start watering)."""
+        await self.coordinator.async_control_device(
+            self._device_id,
+            PowerCommand(power_on=True),
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Close the valve (stop watering)."""
         await self.coordinator.async_control_device(
             self._device_id,
             PowerCommand(power_on=False),

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -935,6 +935,151 @@ class TestFetchDeviceTopicsHeaders:
         with pytest.raises(GoveeApiError):
             await client.fetch_device_topics(token="tok")
 
+    async def test_fetch_device_topics_merges_bff_only_topics(self):
+        """should add topics from the BFF list for devices the legacy list omits.
+
+        Gateway-attached devices (e.g. the H5901 behind an H5044) carry a topic
+        in the BFF ``/bff-app/v1/device/list`` response but not the legacy one.
+        """
+        legacy_resp = make_mock_response(
+            200,
+            create_device_list_response(
+                [
+                    {
+                        "device": "WIFI:AA",
+                        "deviceExt": {"deviceSettings": {"topic": "GD/wifi-aa"}},
+                    }
+                ]
+            ),
+        )
+        # BFF shape is {"data": {"devices": [...]}} and includes a gateway-attached
+        # device that is absent from the legacy list.
+        bff_resp = make_mock_response(
+            200,
+            {
+                "data": {
+                    "devices": [
+                        {
+                            "device": "WIFI:AA",
+                            "deviceExt": {"deviceSettings": {"topic": "GD/wifi-aa"}},
+                        },
+                        {
+                            "sku": "H5901",
+                            "device": "HUB:H5901",
+                            "deviceExt": {
+                                "deviceSettings": json.dumps({"topic": "GD/hub-h5901"})
+                            },
+                        },
+                    ]
+                }
+            },
+        )
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.close = AsyncMock()
+        session.post = lambda *a, **kw: _async_cm(legacy_resp)
+        session.get = lambda *a, **kw: _async_cm(bff_resp)
+        client = GoveeAuthClient(session=session)
+
+        # Act
+        topics = await client.fetch_device_topics(token="tok")
+
+        # Assert
+        assert topics["WIFI:AA"] == "GD/wifi-aa"
+        assert topics["HUB:H5901"] == "GD/hub-h5901"
+
+    async def test_fetch_device_topics_legacy_topic_wins_over_bff(self):
+        """should not let a BFF topic override one already known from the legacy list."""
+        legacy_resp = make_mock_response(
+            200,
+            create_device_list_response(
+                [
+                    {
+                        "device": "DEV:1",
+                        "deviceExt": {"deviceSettings": {"topic": "GD/legacy"}},
+                    }
+                ]
+            ),
+        )
+        bff_resp = make_mock_response(
+            200,
+            {
+                "data": {
+                    "devices": [
+                        {
+                            "device": "DEV:1",
+                            "deviceExt": {"deviceSettings": {"topic": "GD/bff"}},
+                        }
+                    ]
+                }
+            },
+        )
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.close = AsyncMock()
+        session.post = lambda *a, **kw: _async_cm(legacy_resp)
+        session.get = lambda *a, **kw: _async_cm(bff_resp)
+        client = GoveeAuthClient(session=session)
+
+        # Act
+        topics = await client.fetch_device_topics(token="tok")
+
+        # Assert
+        assert topics["DEV:1"] == "GD/legacy"
+
+    async def test_fetch_device_topics_bff_failure_is_non_fatal(self):
+        """should return legacy topics even if the BFF supplement call fails."""
+        legacy_resp = make_mock_response(
+            200,
+            create_device_list_response(
+                [
+                    {
+                        "device": "DEV:1",
+                        "deviceExt": {"deviceSettings": {"topic": "GD/legacy"}},
+                    }
+                ]
+            ),
+        )
+        session = MagicMock(spec=aiohttp.ClientSession)
+        session.close = AsyncMock()
+        session.post = lambda *a, **kw: _async_cm(legacy_resp)
+
+        def _get_raises(*_a: Any, **_kw: Any):
+            raise aiohttp.ClientConnectionError("BFF down")
+
+        session.get = _get_raises
+        client = GoveeAuthClient(session=session)
+
+        # Act
+        topics = await client.fetch_device_topics(token="tok")
+
+        # Assert
+        assert topics["DEV:1"] == "GD/legacy"
+
+
+class TestExtractTopicsFromDevices:
+    """Test the shared device-list topic-extraction helper."""
+
+    def test_parses_dict_and_json_string_forms(self):
+        """should parse deviceExt/deviceSettings whether dicts or JSON strings."""
+        devices = [
+            {"device": "A", "deviceExt": {"deviceSettings": {"topic": "GD/a"}}},
+            {
+                "device": "B",
+                "deviceExt": json.dumps(
+                    {"deviceSettings": json.dumps({"topic": "GD/b"})}
+                ),
+            },
+        ]
+        topics = GoveeAuthClient._extract_topics_from_devices(devices)
+        assert topics == {"A": "GD/a", "B": "GD/b"}
+
+    def test_skips_devices_without_topic_or_id(self):
+        """should skip devices missing a topic or a device id."""
+        devices = [
+            {"device": "A", "deviceExt": {"deviceSettings": {}}},
+            {"deviceExt": {"deviceSettings": {"topic": "GD/x"}}},
+        ]
+        assert GoveeAuthClient._extract_topics_from_devices(devices) == {}
+
 
 # ==============================================================================
 # Tests: GoveeIotCredentials.is_valid
@@ -2137,16 +2282,12 @@ class TestBffThermoReadings:
             {
                 "sku": "H5058",  # leak sensor — excluded
                 "device": "L1",
-                "deviceExt": json.dumps(
-                    {"lastDeviceData": json.dumps({"tem": 2000})}
-                ),
+                "deviceExt": json.dumps({"lastDeviceData": json.dumps({"tem": 2000})}),
             },
             {
                 "sku": "H5310",  # BFF-only thermo — owned by dedicated path
                 "device": "T1",
-                "deviceExt": json.dumps(
-                    {"lastDeviceData": json.dumps({"tem": 2640})}
-                ),
+                "deviceExt": json.dumps({"lastDeviceData": json.dumps({"tem": 2640})}),
             },
         ]
         session = make_session_get(make_mock_response(200, _bff_response(devices)))


### PR DESCRIPTION
> **Draft / WIP.** Control scaffolding for the H5901 Smart Water Timer. The switch, topic, and MQTT routing are verified end-to-end on live hardware, but a native `turn` does **not** actuate the valve — the H5044 gateway needs a `ptReal` BLE-passthrough packet whose opcode isn't known yet (see #135). Not for merge until that command is captured. Stacks on #136.

## What this adds
- **`models/device.py`** — `DEVICE_TYPE_TIMER` + `is_water_timer`.
- **`switch.py`** — `GoveeWaterTimerSwitchEntity`: an on/off switch for water timers. Optimistic and stays available while the coordinator is healthy (these gateway-attached BLE devices report `online=False` even when controllable, so the base online gate would leave the switch permanently unavailable).
- **`coordinator.py`** — force water-timer `PowerCommand`s onto MQTT. The developer REST API always rejects them with `"device offline"`, so MQTT (publish to the device's `GD/` topic) is the only viable path.

Depends on #136 (BFF device topics) so the H5901 has a `GD/` topic to publish to.

## Verified
On a live H5901 + H5044: the switch appears, and toggling it publishes `turn {"val":1|0}` to the H5901's `GD/` topic (`Published turn to GD/…` in the logs).

## The one missing piece
A native `turn` doesn't open the valve. The H5044 relays base64 BLE packets (`op.command`), so the H5901 needs a `ptReal` packet with its valve opcode. That command couldn't be captured (app HTTPS is anti-tamper/cert-pinned; the account AWS IoT cert is policy-denied from subscribing to the gateway `GD/` command topic; `GA/` status packets encode a duration/flow protocol that doesn't reverse cleanly). Tracking in #135 — happy to test candidate packets against the live device.

Refs #135
