### PR TITLE
fix(#138): apply H5054 OpenAPI leak events in real time

### DIFF
--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -1390,8 +1390,7 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # bodyAppearedEvent fires for BOTH transitions on presence sensors:
         # value 1 = Presence, 2 = Absence (Govee Subscribe Device Event docs,
         # issue #124). SKU-locked to presence sensors — the H5054 water
-        # detector shares this instance but means "leak", and its state is
-        # owned by the warnMessage poll.
+        # detector shares this instance but means "leak" (see below).
         if instance == "bodyAppearedEvent" and device.supports_presence_event:
             state = self._get_or_create_state(device_id)
             state.presence = value == 1
@@ -1400,6 +1399,23 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 device_id,
                 sku,
                 "present" if value == 1 else "absent",
+            )
+            self.async_set_updated_data(self._states)
+            return
+
+        # H5054 water detectors reuse the same bodyAppearedEvent instance to
+        # report a leak trip: value 1 = LEAKED (wet), 2 = UN_LEAKED (dry),
+        # mirroring the presence 1/2 encoding (issue #138). This is the
+        # real-time path; the warnMessage BFF poll remains the fallback that
+        # backstops missed pushes and covers the initial state.
+        if instance == "bodyAppearedEvent" and device.supports_water_leak_event:
+            state = self._get_or_create_state(device_id)
+            state.water_leak = value == 1
+            _LOGGER.info(
+                "Water-leak event for %s (%s): %s",
+                device_id,
+                sku,
+                "wet" if value == 1 else "dry",
             )
             self.async_set_updated_data(self._states)
 

--- a/tests/test_openapi_events.py
+++ b/tests/test_openapi_events.py
@@ -228,10 +228,9 @@ class TestCoordinatorBodyAppearedEvent:
         )
         assert coord._states[device.device_id].presence is False
 
-    def test_non_presence_sku_ignored(self):
-        # The H5054 water detector shares the bodyAppearedEvent instance but
-        # means "leak" — its state is owned by the warnMessage poll.
-        device = GoveeDevice(
+    @staticmethod
+    def _h5054() -> GoveeDevice:
+        return GoveeDevice(
             device_id="AA:BB:CC:DD:EE:FF:50:54",
             sku="H5054",
             name="Water Detector",
@@ -240,12 +239,48 @@ class TestCoordinatorBodyAppearedEvent:
                 GoveeCapability(type=CAPABILITY_EVENT, instance="bodyAppearedEvent"),
             ),
         )
+
+    def test_h5054_leaked_value_1_sets_wet(self):
+        # The H5054 water detector shares the bodyAppearedEvent instance but
+        # means "leak": value 1 = LEAKED (issue #138). Real-time path; the
+        # warnMessage poll remains the fallback.
+        device = self._h5054()
         coord = self._coordinator(device)
         coord._on_openapi_event(
-            device.device_id, "H5054", "bodyAppearedEvent", [{"value": 1}]
+            device.device_id,
+            "H5054",
+            "bodyAppearedEvent",
+            [{"name": "LEAKED", "value": 1, "message": "Leaked"}],
         )
+        assert coord._states[device.device_id].water_leak is True
         assert coord._states[device.device_id].presence is None
-        coord.async_set_updated_data.assert_not_called()
+        coord.async_set_updated_data.assert_called_once()
+
+    def test_h5054_un_leaked_value_2_sets_dry(self):
+        # value 2 = UN_LEAKED, mirroring the diagnostics in issue #138.
+        device = self._h5054()
+        coord = self._coordinator(device)
+        coord._states[device.device_id].water_leak = True
+        coord._on_openapi_event(
+            device.device_id,
+            "H5054",
+            "bodyAppearedEvent",
+            [{"name": "UN_LEAKED", "value": 2, "message": "Un_Leaked"}],
+        )
+        assert coord._states[device.device_id].water_leak is False
+        assert coord._states[device.device_id].presence is None
+        coord.async_set_updated_data.assert_called_once()
+
+    def test_h5127_presence_not_treated_as_leak(self):
+        # Guard the inverse: a presence sensor's event must never touch
+        # water_leak (issue #124 / #138 must not cross-contaminate).
+        device = self._h5127()
+        coord = self._coordinator(device)
+        coord._on_openapi_event(
+            device.device_id, "H5127", "bodyAppearedEvent", [{"value": 1}]
+        )
+        assert coord._states[device.device_id].water_leak is None
+        assert coord._states[device.device_id].presence is True
 
 
 class TestBffWaterFullNoLongerApplied:


### PR DESCRIPTION
## #138 — H5054 OpenAPI leak event received but water-leak entity not updated

### Root cause
H5054 water detectors report leak trips over the OpenAPI event channel as `bodyAppearedEvent` (`value 1 = LEAKED`, `2 = UN_LEAKED`), but `_on_openapi_event` only acted on that instance when `device.supports_presence_event` was true. The H5054 is SKU-locked out of presence, so its events fell through and the entity relied solely on the conservative `warnMessage` BFF poll — which never transitioned during a physical test.

### Fix
- Add a `supports_water_leak_event` branch mapping the event to `state.water_leak` and notifying observers immediately.
- Presence branch now `return`s so the shared `bodyAppearedEvent` instance can't cross-contaminate the two SKUs.
- `warnMessage` BFF poll left intact as fallback / initial-state source.

### Tests
- `test_h5054_leaked_value_1_sets_wet`
- `test_h5054_un_leaked_value_2_sets_dry`
- `test_h5127_presence_not_treated_as_leak` (inverse guard)

Reproduced by two reporters (mrbosi, joetuesday) on v2026.7.6 / HA 2026.7.2, direct and via H5040 hub.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)