### PR TITLE
feat(fan): Normalize preset modes to lowercase keys + add icons

### DIFF
--- a/custom_components/govee/fan.py
+++ b/custom_components/govee/fan.py
@@ -50,9 +50,11 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
-# Stable user-facing preset labels.
-PRESET_MODE_NORMAL = "Normal"
-PRESET_MODE_AUTO = "Auto"
+# Stable internal preset identifiers (lowercase canonical keys).
+# These are used for icon lookup (icons.json) and internal state.
+# User-facing labels remain Title Case via Home Assistant translations.
+PRESET_MODE_NORMAL = "normal"
+PRESET_MODE_AUTO = "auto"
 
 # Capability fallback defaults when workMode metadata is unavailable.
 DEFAULT_WORK_MODE_MANUAL = 1
@@ -61,6 +63,19 @@ DEFAULT_WORK_MODE_AUTO = 3
 WORK_MODE_GEAR = DEFAULT_WORK_MODE_MANUAL
 WORK_MODE_AUTO = DEFAULT_WORK_MODE_AUTO
 MANUAL_MODE_NAMES = {"manual", "gearmode", "fanspeed"}
+# Canonical preset keys are lowercase so preset_mode always matches
+# Home Assistant translation keys and icon state keys (strings.json/icons.json).
+PRESET_MODE_ALIASES = {
+    "normal": PRESET_MODE_NORMAL,
+    "auto": PRESET_MODE_AUTO,
+    "manual": PRESET_MODE_NORMAL,
+    "gearmode": PRESET_MODE_NORMAL,
+    "fanspeed": PRESET_MODE_NORMAL,
+    "nature": "nature",
+    "sleep": "sleep",
+    "custom": "custom",
+    "turbo": "turbo",
+}
 
 
 async def async_setup_entry(
@@ -174,11 +189,11 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
                     mode_value_options = field.get("options", [])
             break
 
-        mode_values_by_name = {
-            str(opt.get("name", "")).strip().lower(): opt
-            for opt in mode_value_options
-            if opt.get("name")
-        }
+        mode_values_by_name: dict[str, dict[str, Any]] = {}
+        for opt in mode_value_options:
+            normalized_name = self._normalize_mode_name(opt.get("name"))
+            if normalized_name is not None:
+                mode_values_by_name[normalized_name] = opt
         mode_value_speeds_by_name: dict[str, list[int]] = {}
         for mode_name, mode_opt in mode_values_by_name.items():
             speeds: list[int] = []
@@ -198,33 +213,28 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
         # Discover manual mode and its display name from workMode options.
         manual_name = ""
         for opt in work_mode_options:
-            opt_name = str(opt.get("name", "")).strip()
+            opt_name = self._normalize_mode_name(opt.get("name"))
             opt_value = opt.get("value")
-            if opt_value is None:
-                continue
-            if opt_name.lower() in MANUAL_MODE_NAMES:
+            if opt_value is not None and opt_name is not None and opt_name in MANUAL_MODE_NAMES:
                 self._manual_work_mode = int(opt_value)
                 manual_name = opt_name
                 break
 
-        # The manual preset is always surfaced as "Normal" regardless of the
+        # The manual preset is always surfaced as "normal" regardless of the
         # device's workMode option name (gearMode/FanSpeed/manual/...), so
-        # automations and scenes referencing "Normal" stay stable across SKUs.
+        # automations and scenes referencing "normal" stay stable across SKUs.
         self._speed_work_modes = {self._manual_work_mode}
         self._speedless_work_modes = set()
 
         # Discover auto mode ID from workMode options.
         for opt in work_mode_options:
-            if (
-                str(opt.get("name", "")).strip().lower() == PRESET_MODE_AUTO.lower()
-                and opt.get("value") is not None
-            ):
+            if self._normalize_mode_name(opt.get("name")) == PRESET_MODE_AUTO and opt.get("value") is not None:
                 self._auto_work_mode = int(opt["value"])
                 break
 
         # Build authoritative manual speeds from modeValue nested options.
         manual_sub_options = (
-            mode_values_by_name.get(manual_name.lower(), {}).get("options", [])
+            mode_values_by_name.get(manual_name, {}).get("options", [])
             if manual_name
             else []
         )
@@ -269,43 +279,53 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
         )
         seen.add(self._manual_preset_name.lower())
 
-        auto_name = ""
+        auto_preset_name = ""
         auto_mode_value_opt: dict[str, Any] = {}
         for opt in work_mode_options:
-            if str(opt.get("name", "")).strip().lower() != PRESET_MODE_AUTO.lower():
+            normalized_auto_name = self._normalize_mode_name(opt.get("name"))
+            if normalized_auto_name != PRESET_MODE_AUTO:
                 continue
-            auto_name = str(opt.get("name", "")).strip() or PRESET_MODE_AUTO
-            auto_mode_value_opt = mode_values_by_name.get(auto_name.lower(), {})
+            auto_preset_name = PRESET_MODE_AUTO
+            auto_mode_value_opt = mode_values_by_name.get(normalized_auto_name, {})
             break
-        if auto_name and auto_name.lower() not in seen:
+        if auto_preset_name and auto_preset_name.lower() not in seen:
             auto_mode_value = self._extract_mode_value(auto_mode_value_opt)
             auto_mode_value = max(auto_mode_value, 0)
-            self._preset_work_modes[auto_name] = self._auto_work_mode
-            self._preset_commands[auto_name] = (self._auto_work_mode, int(auto_mode_value))
-            if mode_value_speeds_by_name.get(auto_name.lower()):
+            self._preset_work_modes[auto_preset_name] = self._auto_work_mode
+            self._preset_commands[auto_preset_name] = (
+                self._auto_work_mode,
+                int(auto_mode_value),
+            )
+            if mode_value_speeds_by_name.get(PRESET_MODE_AUTO):
                 self._speed_work_modes.add(self._auto_work_mode)
-                self._work_mode_speed_values[self._auto_work_mode] = mode_value_speeds_by_name[auto_name.lower()]
-                self._work_mode_speed_sets[self._auto_work_mode] = set(mode_value_speeds_by_name[auto_name.lower()])
+                self._work_mode_speed_values[self._auto_work_mode] = (
+                    mode_value_speeds_by_name[PRESET_MODE_AUTO]
+                )
+                self._work_mode_speed_sets[self._auto_work_mode] = set(
+                    mode_value_speeds_by_name[PRESET_MODE_AUTO]
+                )
             else:
                 self._speedless_work_modes.add(self._auto_work_mode)
-            seen.add(auto_name.lower())
+            seen.add(auto_preset_name.lower())
 
         for opt in work_mode_options:
-            preset_name = str(opt.get("name", "")).strip()
+            preset_name = self._normalize_mode_name(opt.get("name"))
             work_mode = opt.get("value")
             if not preset_name or work_mode is None:
                 continue
-            if preset_name.lower() in MANUAL_MODE_NAMES:
+            if preset_name in MANUAL_MODE_NAMES:
                 continue
-            if preset_name.lower() == PRESET_MODE_AUTO.lower():
+            if preset_name == PRESET_MODE_AUTO:
                 continue
-            if preset_name.lower() in seen:
+            canonical_preset_name = self._normalize_preset_mode(preset_name)
+            if canonical_preset_name is None:
+                continue
+            if canonical_preset_name.lower() in seen:
                 continue
 
-            preset_name_lower = preset_name.lower()
-            mode_value_opt = mode_values_by_name.get(preset_name_lower, {})
+            mode_value_opt = mode_values_by_name.get(preset_name, {})
             mode_value = self._extract_mode_value(mode_value_opt)
-            mode_speeds = mode_value_speeds_by_name.get(preset_name_lower, [])
+            mode_speeds = mode_value_speeds_by_name.get(preset_name, [])
             work_mode = int(work_mode)
             if mode_speeds:
                 mode_value = max(mode_value, min(mode_speeds))
@@ -316,9 +336,9 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
                 mode_value = max(mode_value, 0)
                 self._speedless_work_modes.add(work_mode)
 
-            self._preset_work_modes[preset_name] = work_mode
-            self._preset_commands[preset_name] = (work_mode, int(mode_value))
-            seen.add(preset_name.lower())
+            self._preset_work_modes[canonical_preset_name] = work_mode
+            self._preset_commands[canonical_preset_name] = (work_mode, int(mode_value))
+            seen.add(canonical_preset_name.lower())
 
         if PRESET_MODE_AUTO.lower() not in seen:
             self._preset_work_modes[PRESET_MODE_AUTO] = self._auto_work_mode
@@ -345,6 +365,26 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
             return int(mode_value)
         except (TypeError, ValueError):
             return 0
+
+    @staticmethod
+    def _normalize_mode_name(name: Any) -> str | None:
+        """Normalize arbitrary mode names to lowercase keys with collapsed whitespace."""
+        if name is None:
+            return None
+        if not isinstance(name, str):
+            return None
+        normalized = " ".join(name.split()).lower()
+        if not normalized:
+            return None
+        return normalized
+
+    @staticmethod
+    def _normalize_preset_mode(name: Any) -> str | None:
+        """Normalize preset names into canonical lowercase internal keys."""
+        normalized = GoveeFanEntity._normalize_mode_name(name)
+        if normalized is None:
+            return None
+        return PRESET_MODE_ALIASES.get(normalized, normalized)
 
     def _manual_mode_value_from_state(self) -> int | None:
         """Return modeValue when state is in manual mode and value is a valid speed."""
@@ -484,6 +524,14 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
+        normalized_preset_mode = self._normalize_preset_mode(preset_mode)
+        if normalized_preset_mode is None:
+            _LOGGER.warning(
+                "Invalid or empty preset mode received %r; falling back to %r",
+                preset_mode,
+                PRESET_MODE_NORMAL,
+            )
+            normalized_preset_mode = PRESET_MODE_NORMAL
         manual_mode_value = self._manual_mode_value_from_state()
         if manual_mode_value is not None:
             self._last_manual_mode_value = manual_mode_value
@@ -510,9 +558,11 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
             else:
                 self._last_mode_values[state_work_mode] = state_mode_value
 
-        if preset_mode in self._preset_commands:
-            work_mode, mode_value = self._preset_commands[preset_mode]
-            if preset_mode == self._manual_preset_name:
+        preset_key = normalized_preset_mode
+
+        if preset_key in self._preset_commands:
+            work_mode, mode_value = self._preset_commands[preset_key]
+            if preset_key == self._manual_preset_name:
                 mode_value = self._last_manual_mode_value
                 if manual_mode_value is not None:
                     mode_value = manual_mode_value
@@ -529,6 +579,12 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
             else:
                 mode_value = self._last_mode_values.get(work_mode, mode_value)
         else:
+            _LOGGER.warning(
+                "Unknown preset mode %r; falling back to %r",
+                preset_mode,
+                self._manual_preset_name,
+            )
+            preset_key = self._manual_preset_name
             # Manual mode fallback - use current speed or typical available speed
             work_mode = self._manual_work_mode
             mode_value = self._last_manual_mode_value
@@ -538,7 +594,7 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
 
         _LOGGER.debug(
             "Setting preset mode: preset=%s, work_mode=%d, mode_value=%d",
-            preset_mode,
+            preset_key,
             work_mode,
             mode_value,
         )

--- a/custom_components/govee/icons.json
+++ b/custom_components/govee/icons.json
@@ -1,0 +1,21 @@
+{
+  "entity": {
+    "fan": {
+      "govee_fan": {
+        "default": "mdi:fan",
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:fan",
+            "state": {
+              "nature": "mdi:leaf",
+              "sleep": "mdi:sleep",
+              "auto": "mdi:fan-auto",
+              "custom": "mdi:format-list-bulleted-type",
+              "turbo": "mdi:car-turbocharger"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -282,6 +282,23 @@
         "name": "Internet"
       }
     },
+    "fan": {
+      "govee_fan": {
+        "name": "{device_name}",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "normal": "Normal",
+              "nature": "Nature",
+              "sleep": "Sleep",
+              "auto": "Auto",
+              "custom": "Custom",
+              "turbo": "Turbo"
+            }
+          }
+        }
+      }
+    },
     "humidifier": {
       "govee_humidifier": {
         "name": "{device_name}",

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -282,6 +282,23 @@
         "name": "Internet"
       }
     },
+    "fan": {
+      "govee_fan": {
+        "name": "{device_name}",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "normal": "Normal",
+              "nature": "Nature",
+              "sleep": "Sleep",
+              "auto": "Auto",
+              "custom": "Custom",
+              "turbo": "Turbo"
+            }
+          }
+        }
+      }
+    },
     "humidifier": {
       "govee_humidifier": {
         "name": "{device_name}",

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -759,17 +760,17 @@ class TestFanDuplicatePreset:
         # Presets come directly from capabilities with no duplicates.
         assert modes.count(PRESET_MODE_AUTO) == 1
         assert PRESET_MODE_NORMAL in modes
-        assert "Sleep" in modes
-        assert "Nature" in modes
-        assert "Custom" in modes
+        assert "sleep" in modes
+        assert "nature" in modes
+        assert "custom" in modes
         assert len(modes) == len(set(modes))
 
     def test_preset_modes_map_to_discovered_work_modes(self, h7106_entity):
         assert h7106_entity._auto_work_mode == 2
-        assert h7106_entity._preset_work_modes.get("Auto") == 2
+        assert h7106_entity._preset_work_modes.get("auto") == 2
         assert h7106_entity._manual_work_mode == 1
         assert h7106_entity._manual_preset_name == PRESET_MODE_NORMAL
-        assert h7106_entity._preset_work_modes.get("Sleep") == 5
+        assert h7106_entity._preset_work_modes.get("sleep") == 5
 
     def test_speed_count_and_percentage_step_from_fanspeed_modevalue(self, h7106_entity):
         assert h7106_entity.speed_count == 8
@@ -961,10 +962,10 @@ class TestFanSpeedManualModeDiscovery:
         assert h7107_entity.percentage_step == pytest.approx(100 / 12)
         assert h7107_entity.preset_modes == [
             PRESET_MODE_NORMAL,
-            "Auto",
-            "Sleep",
-            "Nature",
-            "Custom",
+            "auto",
+            "sleep",
+            "nature",
+            "custom",
         ]
 
     @pytest.mark.asyncio
@@ -1162,3 +1163,47 @@ class TestFanModeNameWhitespaceHandling:
         assert entity._fan_speeds == [1, 2, 3, 5]
         assert entity._fan_speeds.count(3) == 1
         assert entity.speed_count == 4
+
+    def test_normalize_preset_mode_handles_case_whitespace_alias_and_empty(self):
+        assert GoveeFanEntity._normalize_mode_name("FanSpeed") == "fanspeed"
+        assert GoveeFanEntity._normalize_preset_mode(" Auto ") == PRESET_MODE_AUTO
+        assert GoveeFanEntity._normalize_preset_mode("FanSpeed") == PRESET_MODE_NORMAL
+        assert GoveeFanEntity._normalize_preset_mode("  Turbo  ") == "turbo"
+        assert GoveeFanEntity._normalize_preset_mode("  Breezy  ") == "breezy"
+        assert GoveeFanEntity._normalize_preset_mode("   ") is None
+        assert GoveeFanEntity._normalize_preset_mode(0) is None
+        assert GoveeFanEntity._normalize_preset_mode(False) is None
+
+    @pytest.mark.asyncio
+    async def test_set_empty_preset_mode_falls_back_to_manual(self):
+        device = _h7107_whitespace_device()
+        state = MagicMock(work_mode=2, mode_value=0)
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        coordinator.get_state = MagicMock(return_value=state)
+        coordinator.async_control_device = AsyncMock(return_value=True)
+        entity = GoveeFanEntity(coordinator, device)
+
+        await entity.async_set_preset_mode("   ")
+
+        cmd = entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == entity._manual_work_mode
+
+    @pytest.mark.asyncio
+    async def test_set_unknown_preset_mode_warns_and_falls_back_to_manual(self, caplog):
+        device = _h7107_whitespace_device()
+        state = MagicMock(work_mode=2, mode_value=0)
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        coordinator.get_state = MagicMock(return_value=state)
+        coordinator.async_control_device = AsyncMock(return_value=True)
+        entity = GoveeFanEntity(coordinator, device)
+
+        with caplog.at_level(logging.WARNING):
+            await entity.async_set_preset_mode("UnknownPreset")
+
+        cmd = entity.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == entity._manual_work_mode
+        assert "Unknown preset mode" in caplog.text

--- a/tests/test_issue_114.py
+++ b/tests/test_issue_114.py
@@ -548,7 +548,7 @@ class TestH7124FanPresets:
     def test_preset_modes_include_sleep_turbo(self, fan):
         from custom_components.govee.fan import PRESET_MODE_AUTO, PRESET_MODE_NORMAL
 
-        assert fan.preset_modes == [PRESET_MODE_NORMAL, PRESET_MODE_AUTO, "Sleep", "Turbo"]
+        assert fan.preset_modes == [PRESET_MODE_NORMAL, PRESET_MODE_AUTO, "sleep", "turbo"]
 
     def test_preset_mode_maps_sleep(self, device):
         from custom_components.govee.fan import GoveeFanEntity
@@ -556,7 +556,7 @@ class TestH7124FanPresets:
         state = GoveeDeviceState(device_id=device.device_id, online=True)
         state.work_mode = 5  # Sleep
         fan = GoveeFanEntity(_coordinator_with_state(device, state), device)
-        assert fan.preset_mode == "Sleep"
+        assert fan.preset_mode == "sleep"
 
     def test_preset_mode_maps_turbo(self, device):
         from custom_components.govee.fan import GoveeFanEntity
@@ -564,7 +564,7 @@ class TestH7124FanPresets:
         state = GoveeDeviceState(device_id=device.device_id, online=True)
         state.work_mode = 7  # Turbo
         fan = GoveeFanEntity(_coordinator_with_state(device, state), device)
-        assert fan.preset_mode == "Turbo"
+        assert fan.preset_mode == "turbo"
 
     @pytest.mark.asyncio
     async def test_set_preset_turbo_sends_work_mode(self, fan):
@@ -573,6 +573,14 @@ class TestH7124FanPresets:
         assert isinstance(cmd, WorkModeCommand)
         assert cmd.work_mode == 7
         assert cmd.mode_value == 0
+
+    @pytest.mark.asyncio
+    async def test_set_preset_normal_alias_still_works(self, fan):
+        """Regression test for #140."""
+        await fan.async_set_preset_mode("Normal")
+        cmd = fan.coordinator.async_control_device.call_args[0][1]
+        assert isinstance(cmd, WorkModeCommand)
+        assert cmd.work_mode == fan._manual_work_mode
 
     @pytest.mark.asyncio
     async def test_set_percentage_from_turbo_uses_manual_mode(self, fan):


### PR DESCRIPTION
Following #133, what started as a simple UI improvement (adding preset_mode icons) required more robust string handling to make the icons actually work reliably.

refs yyolk#5  
refs yyolk#6  
refs yyolk#7  
refs yyolk#8  

### Background
PR #133 made fan presets fully capability-driven. This was a great step forward, but it also meant that mode names coming from different Govee devices could arrive with inconsistent casing, whitespace, and aliases (`FanSpeed`, `gearMode`, `manual`, `AUTO`, etc.).

As a result, a simple `icons.json` addition was not enough — the entity needed consistent canonical keys so that Home Assistant’s icon lookup would match reliably.

### Changes

**1. Canonical lowercase keys + normalization**
- `PRESET_MODE_NORMAL = "normal"` / `PRESET_MODE_AUTO = "auto"`
- Added `PRESET_MODE_ALIASES` (maps common device variants like `manual` / `gearmode` / `fanspeed` → `normal`)
- Added `_normalize_mode_name()` and `_normalize_preset_mode()` helpers
- Applied normalization consistently when parsing capabilities and in `async_set_preset_mode`
- Graceful fallback + warning for empty/invalid preset input

**2. Icons + Translations**
Added `icons.json` + translation entries so the UI still shows nice Title Case labels while using stable lowercase keys internally.

| Preset mode | Icon |
|-------------|------|
| **Normal**  | ![](https://api.iconify.design/mdi/fan.svg) `mdi:fan` |
| **Nature**  | ![](https://api.iconify.design/mdi/leaf.svg) `mdi:leaf` |
| **Sleep**   | ![](https://api.iconify.design/mdi/sleep.svg) `mdi:sleep` |
| **Auto**    | ![](https://api.iconify.design/mdi/fan-auto.svg) `mdi:fan-auto` |
| **Custom**  | ![](https://api.iconify.design/mdi/format-list-bulleted-type.svg) `mdi:format-list-bulleted-type` |
| **Turbo**   | ![](https://api.iconify.design/mdi/car-turbocharger.svg) `mdi:car-turbocharger` |

The default (and fallback) icon is ![](https://api.iconify.design/mdi/fan.svg) `mdi:fan`.

<img width="585" height="700" alt="image" src="https://github.com/user-attachments/assets/7138cb0d-50cb-40e2-bdd4-c311311b84a5" />

**3. Tests**
Updated and expanded tests to cover the new normalization behavior (casing, whitespace, aliases, and fallbacks).

### Result
- Preset icons now display correctly and consistently
- Internal state is robust across different Govee fan models
- The change that looked trivial (icons) ended up requiring better string handling throughout the fan entity — which is a net improvement for reliability going forward