### PR TITLE
fix(#146,#145): bound startup discovery; H5054 dry-default + battery

### DIFF
--- a/custom_components/govee/binary_sensor.py
+++ b/custom_components/govee/binary_sensor.py
@@ -221,10 +221,17 @@ class GoveeWaterLeakBinarySensor(GoveeEntity, BinarySensorEntity):
         return self.coordinator.last_update_success
 
     @property
-    def is_on(self) -> bool | None:
-        """Return True when water is detected."""
+    def is_on(self) -> bool:
+        """Return True when water is detected, else dry.
+
+        ``state.water_leak`` is ``None`` until the account ``warnMessage`` poll
+        first resolves the sensor's status. A moisture sensor with no known trip
+        is dry, so report ``False`` in that window rather than surfacing an
+        "Unknown" state (issue #145) — a real leak flips it to ``True`` on the
+        next poll or MQTT push.
+        """
         state = self.device_state
-        return state.water_leak if state else None
+        return bool(state.water_leak) if state else False
 
 
 class GoveeOccupancyBinarySensor(GoveeEntity, BinarySensorEntity):

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -10,7 +10,7 @@ import asyncio
 import dataclasses
 import logging
 import time
-from collections.abc import Mapping
+from collections.abc import Awaitable, Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -128,6 +128,11 @@ _LOGGER = logging.getLogger(__name__)
 
 # State fetch timeout per device
 STATE_FETCH_TIMEOUT = 30
+
+# Per-step timeout for fallible account/BFF discovery calls during setup. Bounds
+# each so a hung endpoint degrades that feature to polling instead of letting HA
+# cancel the whole config-entry setup (issue #146).
+STARTUP_STEP_TIMEOUT = 30
 
 # Segment command pacing — Govee silently rate-limits bursts of segment
 # updates on RGBIC strips (H80A1 has 14 segments). Serialize per-device
@@ -717,6 +722,15 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         """
         return device_id in self._bff_thermometer_ids
 
+    def is_water_detector(self, device_id: str) -> bool:
+        """Return True if this device is a standalone water detector (H5054).
+
+        Like the BFF thermometers, these are sleepy gateway-bridged sensors that
+        report ``online: false`` at poll time, so entity availability must not
+        gate on ``online`` (issues #62, #145).
+        """
+        return any(d.device_id == device_id for d in self._water_detectors)
+
     def is_power_off_pending(self, device_id: str) -> bool:
         """Return True if a power-off command is in flight for this device.
 
@@ -741,6 +755,39 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         """Compatibility delegate — tests still call this directly."""
         self._ble_handler.handle_advertisement(service_info)
 
+    async def _run_startup_step(self, coro: Awaitable[None], name: str) -> None:
+        """Run a fallible startup discovery step, bounded and failure-isolated.
+
+        The account/BFF endpoints these steps call can hang (a stuck socket read
+        with no server response). Left unbounded, a single hang lets Home
+        Assistant cancel the *entire* config-entry setup — the traceback in
+        issue #146 is exactly this: a ``CancelledError`` raised inside
+        ``_discover_leak_sensors``' BFF GET, which the method's ``except
+        Exception`` can't catch (``CancelledError`` is a ``BaseException``), so
+        setup dies and every entity goes offline.
+
+        Bound each step with its own timeout and swallow timeouts/errors so the
+        integration still loads; the feature degrades to the next poll cycle. A
+        genuine outer cancel (HA shutting the entry down) still propagates,
+        because ``asyncio.timeout`` only converts *its own* deadline into a
+        ``TimeoutError`` — an externally-injected cancel re-raises as
+        ``CancelledError`` past the ``except`` clauses below.
+        """
+        try:
+            async with asyncio.timeout(STARTUP_STEP_TIMEOUT):
+                await coro
+        except TimeoutError:
+            _LOGGER.warning(
+                "Startup step %r did not complete within %ss; continuing without "
+                "it (it will retry on the next poll)",
+                name,
+                STARTUP_STEP_TIMEOUT,
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "Startup step %r failed (%s); continuing without it", name, err
+            )
+
     async def _async_setup(self) -> None:
         """Set up the coordinator - discover devices and start MQTT.
 
@@ -752,25 +799,35 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # Start MQTT client if credentials available
         if self._iot_credentials:
             await self._start_mqtt()
-            # Fetch device-specific MQTT topics for publishing commands
-            await self._fetch_device_topics()
+            # Fetch device-specific MQTT topics for publishing commands. Bounded:
+            # it hits the legacy + BFF device lists and must not hang setup (#146).
+            await self._run_startup_step(
+                self._fetch_device_topics(), "fetch device topics"
+            )
 
         # OpenAPI event subscription — needs only the API key (no account
         # login), so it runs regardless of IoT credentials. Failure-isolated:
         # a broker hiccup must never fail setup (the client retries forever).
         await self._start_openapi_events()
 
-        # Discover leak sensors via BFF API (requires email/password)
-        await self._discover_leak_sensors()
+        # Discover leak sensors via BFF API (requires email/password). Bounded so
+        # a hung BFF call degrades to polling instead of cancelling setup (#146).
+        await self._run_startup_step(
+            self._discover_leak_sensors(), "discover leak sensors"
+        )
 
         # Discover BFF-only thermo-hygrometers (H5301) that the Developer API
         # omits (issue #86). Also requires email/password.
-        await self._discover_bff_thermometers()
+        await self._run_startup_step(
+            self._discover_bff_thermometers(), "discover BFF thermometers"
+        )
 
         # Standalone water detectors (H5054) deliver their trip only via the
         # account warnMessage history — start the dedicated leak poll (issue #62).
         if self._water_detectors and self._iot_credentials:
-            await self._poll_water_detectors()
+            await self._run_startup_step(
+                self._poll_water_detectors(), "poll water detectors"
+            )
             self._schedule_water_detector_poll()
 
         # LAN (UDP) transport is opened LAST, after every fallible discovery /
@@ -2077,12 +2134,20 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                     if state.online != online:
                         state.online = online
                         changed = True
+                    # Battery (%) rides along in the same BFF device/list poll —
+                    # surface it so the H5054 gets a battery sensor (issue #145).
+                    battery = info.get("battery")
+                    if battery is not None and state.battery != battery:
+                        state.battery = battery
+                        changed = True
                     state.source = "api"
                     _LOGGER.debug(
-                        "Water-detector %s: online=%s water_leak=%s last_time=%s",
+                        "Water-detector %s: online=%s water_leak=%s battery=%s "
+                        "last_time=%s",
                         device_id,
                         online,
                         state.water_leak,
+                        state.battery,
                         last_time,
                     )
         except Exception as err:  # noqa: BLE001

--- a/custom_components/govee/scene_cache.py
+++ b/custom_components/govee/scene_cache.py
@@ -155,9 +155,15 @@ class SceneCacheManager:
                 device.name,
             )
             return scenes
-        except GoveeApiError as err:
+        except (GoveeApiError, TimeoutError) as err:
+            # TimeoutError (a raw aiohttp read timeout, not wrapped in
+            # GoveeApiError) must be caught here too: scenes are fetched from
+            # light/select ``async_added_to_hass``, so an uncaught timeout there
+            # aborts adding the entity entirely (issue #146). Scenes are optional
+            # effect support — degrade to cached/empty and let the entity load.
             _LOGGER.error(
-                "API error fetching scenes for %s: %s",
+                "%s fetching scenes for %s: %s",
+                type(err).__name__,
                 device.name,
                 err,
             )
@@ -248,9 +254,12 @@ class SceneCacheManager:
                 device.name,
             )
             return scenes
-        except GoveeApiError as err:
+        except (GoveeApiError, TimeoutError) as err:
+            # See _fetch_and_cache_scenes: a raw read TimeoutError here would
+            # otherwise abort adding the entity (issue #146).
             _LOGGER.error(
-                "API error fetching DIY scenes for %s: %s",
+                "%s fetching DIY scenes for %s: %s",
+                type(err).__name__,
                 device.name,
                 err,
             )

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -263,7 +263,13 @@ class _BffThermometerAvailabilityMixin(GoveeEntity):
 
     @property
     def available(self) -> bool:
-        if self.coordinator.is_bff_thermometer(self._device_id):
+        # Water detectors (H5054) are sleepy gateway-bridged devices that report
+        # online: false at poll time, same as the BFF thermometers — gate their
+        # battery sensor on coordinator success, not online, or it would show
+        # permanently unavailable (issues #97, #145).
+        if self.coordinator.is_bff_thermometer(
+            self._device_id
+        ) or self.coordinator.is_water_detector(self._device_id):
             return self.coordinator.last_update_success and (
                 self.device_state is not None
             )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1997,7 +1997,25 @@ class TestWaterDetectorPoll:
         state = coord._states[did]
         assert state.water_leak is True
         assert state.online is True
+        assert state.battery == 80  # surfaced for the battery sensor (#145)
         coord.async_update_listeners.assert_called()
+
+    def test_is_water_detector_predicate(self):
+        coord, did = self._coord_with_detector()
+        assert coord.is_water_detector(did) is True
+        assert coord.is_water_detector("not-a-detector") is False
+
+    def test_battery_sensor_available_despite_offline(self):
+        """H5054 battery sensor stays available though the device is offline (#145)."""
+        from custom_components.govee.sensor import GoveeThermoBatterySensor
+
+        coord, did = self._coord_with_detector()
+        state = coord._states[did]
+        state.online = False
+        state.battery = 80
+        entity = GoveeThermoBatterySensor(coord, coord._devices[did])
+        assert entity.available is True
+        assert entity.native_value == 80
 
     @pytest.mark.asyncio
     async def test_warnmessage_skipped_when_no_new_report(self, monkeypatch):
@@ -2082,6 +2100,56 @@ def _make_async(return_value):
         return return_value
 
     return _inner
+
+
+class TestStartupStepResilience:
+    """A hung/failing account-BFF discovery step must not cancel setup (#146)."""
+
+    def _bare_coord(self):
+        import custom_components.govee.coordinator as coord_mod
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        return coord_mod.GoveeCoordinator(
+            hass=MagicMock(),
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=MagicMock(token="tok"),
+            poll_interval=60,
+        )
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_swallowed(self, monkeypatch):
+        import custom_components.govee.coordinator as coord_mod
+
+        monkeypatch.setattr(coord_mod, "STARTUP_STEP_TIMEOUT", 0.01)
+        coord = self._bare_coord()
+
+        async def _hangs():
+            await asyncio.sleep(1)
+
+        # Returns normally (does not raise) even though the step never finishes.
+        await coord._run_startup_step(_hangs(), "hanging step")
+
+    @pytest.mark.asyncio
+    async def test_error_is_swallowed(self):
+        coord = self._bare_coord()
+
+        async def _boom():
+            raise RuntimeError("BFF exploded")
+
+        await coord._run_startup_step(_boom(), "failing step")
+
+    @pytest.mark.asyncio
+    async def test_success_runs_to_completion(self):
+        coord = self._bare_coord()
+        ran = {"ok": False}
+
+        async def _ok():
+            ran["ok"] = True
+
+        await coord._run_startup_step(_ok(), "good step")
+        assert ran["ok"] is True
 
 
 class TestBffThermometerDiscovery:

--- a/tests/test_scene_cache.py
+++ b/tests/test_scene_cache.py
@@ -249,6 +249,21 @@ class TestErrorHandling:
         assert mock_api.get_dynamic_scenes.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_timeout_returns_fallback_not_raises(
+        self, mock_api: AsyncMock, device: GoveeDevice
+    ) -> None:
+        """A raw read TimeoutError degrades to empty, not an exception (#146).
+
+        Scenes are fetched from light/select ``async_added_to_hass``; a
+        propagating timeout there would abort adding the entity entirely.
+        """
+        mock_api.get_dynamic_scenes = AsyncMock(side_effect=TimeoutError())
+        manager = SceneCacheManager(mock_api)
+
+        result = await manager.async_get_scenes(device.device_id, device)
+        assert result == []
+
+    @pytest.mark.asyncio
     async def test_api_error_falls_back_to_cached_data(
         self, mock_api: AsyncMock, device: GoveeDevice
     ) -> None:

--- a/tests/test_water_leak.py
+++ b/tests/test_water_leak.py
@@ -163,8 +163,9 @@ class TestBinarySensor:
     def test_is_on_dry(self, h5054_device):
         assert self._entity(h5054_device, False).is_on is False
 
-    def test_is_on_unknown(self, h5054_device):
-        assert self._entity(h5054_device, None).is_on is None
+    def test_is_on_defaults_dry_before_first_poll(self, h5054_device):
+        """water_leak=None (pre-poll) reads as dry, not Unknown (issue #145)."""
+        assert self._entity(h5054_device, None).is_on is False
 
     def test_available_despite_offline_device(self, h5054_device):
         """Entity stays available even though the detector reports online=False."""


### PR DESCRIPTION
Fixes #146 and #145.

## #146 — config-entry setup could be cancelled outright
A hung account/BFF discovery call during setup let Home Assistant cancel the **entire** config entry, taking every entity offline. The traceback: a `CancelledError` raised inside the BFF `GET` in `_discover_leak_sensors` — a `BaseException`, so the method's `except Exception` never caught it, and setup died.

- **coordinator**: new `_run_startup_step()` bounds each fallible discovery step (`fetch_device_topics`, `discover_leak_sensors`, `discover_bff_thermometers`, `poll_water_detectors`) with `asyncio.timeout` and swallows timeouts/errors so setup completes and the feature degrades to the next poll cycle. A genuine outer cancel (HA shutdown) still propagates.
- **scene_cache**: dynamic + DIY scene fetch now catch raw `TimeoutError` (not just `GoveeApiError`), since scenes load from light/select `async_added_to_hass` where a propagating timeout aborted adding the entity.

## #145 — H5054 showed "Unknown" state and no battery
- **binary_sensor**: `GoveeWaterLeakBinarySensor.is_on` defaults to `False` (dry) when `water_leak` is `None` (before the first `warnMessage` poll) instead of surfacing Unknown; a real trip still flips it `True`.
- **coordinator**: `_poll_water_detectors` now applies the battery % already returned by the BFF `device/list`; adds an `is_water_detector()` predicate.
- **sensor**: the shared battery-availability mixin treats water detectors like BFF thermometers (gate on coordinator success, not the sleepy device's `online: false`), so the H5054 battery sensor is visible.

## Tests
Added: startup-step timeout/error/success resilience, scene-fetch timeout fallback, H5054 dry-default, battery plumbing + `is_water_detector` predicate + battery-sensor availability. **Full suite: 1602 passing** locally (py3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)