### PR TITLE
fix(#141): read H5179 temperature/humidity from BFF lastDeviceData

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -36,7 +36,12 @@ from .exceptions import (
     GoveeLoginRejectedError,
 )
 
-from ..models.device import LEAK_HUB_SKUS, LEAK_SENSOR_SKUS, THERMO_HYGRO_BFF_SKUS
+from ..models.device import (
+    LEAK_HUB_SKUS,
+    LEAK_SENSOR_SKUS,
+    THERMO_HYGRO_BFF_READ_SKUS,
+    THERMO_HYGRO_BFF_SKUS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -739,7 +744,13 @@ class GoveeAuthClient:
                 sensors: list[dict[str, Any]] = []
                 for device in devices:
                     sku = device.get("sku", "")
-                    if sku not in THERMO_HYGRO_BFF_SKUS:
+                    # BFF-only SKUs are synthesized; BFF-read SKUs (e.g. H5179)
+                    # already exist from Developer-API discovery but read their
+                    # live value here (#86, #141).
+                    if (
+                        sku not in THERMO_HYGRO_BFF_SKUS
+                        and sku not in THERMO_HYGRO_BFF_READ_SKUS
+                    ):
                         continue
 
                     device_id = device.get("device", "")

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -1767,6 +1767,33 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 device_id = sensor["device_id"]
                 if not device_id:
                     continue
+
+                # A device already discovered via the Developer API (e.g. the
+                # H5179 WiFi thermometer, #141) whose live reading only comes
+                # from the BFF lastDeviceData — the Developer poll returns empty
+                # strings. Route it through the BFF path (owns its state, skips
+                # the futile Developer poll via _bff_thermometer_ids) instead of
+                # synthesizing a duplicate device.
+                if device_id in self._devices:
+                    self._bff_thermometer_ids.add(device_id)
+                    state = self._states.get(
+                        device_id
+                    ) or GoveeDeviceState.create_empty(device_id)
+                    state.online = sensor.get("online", state.online)
+                    if sensor.get("temperature") is not None:
+                        state.sensor_temperature = sensor.get("temperature")
+                    if sensor.get("humidity") is not None:
+                        state.sensor_humidity = sensor.get("humidity")
+                    if sensor.get("battery") is not None:
+                        state.battery = sensor.get("battery")
+                    self._states[device_id] = state
+                    if (
+                        state.sensor_temperature is not None
+                        or state.sensor_humidity is not None
+                    ):
+                        self._sensor_reading_changed_at[device_id] = dt_util.utcnow()
+                    continue
+
                 hub_device_id = sensor.get("hub_device_id", "")
                 device = GoveeDevice.synthetic_thermometer(
                     device_id=device_id,

--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -34,6 +34,14 @@ PRESENCE_SENSOR_SKUS = frozenset({"H5127"})
 # each so the existing temperature/humidity sensor entities attach.
 THERMO_HYGRO_BFF_SKUS = frozenset({"H5301", "H5310"})
 
+# Thermo-hygrometers that ARE returned by the Developer API (so they're
+# discovered normally and get temperature/humidity entities) but whose live
+# reading only arrives via the BFF ``lastDeviceData`` — the Developer poll
+# returns empty strings for their sensorTemperature/sensorHumidity. The
+# coordinator routes these through the BFF read path instead of synthesizing a
+# duplicate device (issue #141, H5179 WiFi thermometer).
+THERMO_HYGRO_BFF_READ_SKUS = frozenset({"H5179"})
+
 # Subset of THERMO_HYGRO_BFF_SKUS that have NO hygrometer (e.g. the H5310 pool
 # thermometer). Govee reports their ``hum`` as the u16 sentinel 0xFFFF, so a
 # synthesized humidity entity would be permanently bogus/unknown (#97). We omit

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -307,6 +307,14 @@ class GoveeTemperatureSensor(_BffThermometerAvailabilityMixin, SensorEntity):
 
         value = float(state.sensor_temperature)
 
+        # BFF-sourced readings (lastDeviceData) are already canonical °C from
+        # _bff_reading's centi-scaling, so the SKU-based °F conversion below —
+        # which targets the Developer-API path — must NOT apply. The H5179 lives
+        # in both worlds: it's in FAHRENHEIT_REPORTING_SKUS for its Developer
+        # path, but its value here comes via BFF (issue #141).
+        if self.coordinator.is_bff_thermometer(self._device_id):
+            return value
+
         # Some thermometer/hygrometer SKUs (FAHRENHEIT_REPORTING_SKUS) return °F
         # via the Cloud API without unit metadata, while the native unit is
         # tagged °C — surfacing e.g. 101°F as 213.5°F (issues #72, #78, #96).

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2218,6 +2218,76 @@ class TestBffThermometerDiscovery:
         coord._schedule_bff_poll.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_dev_api_thermometer_supplemented_from_bff(self, monkeypatch):
+        """H5179 exists from Developer-API discovery but reads via BFF (#141).
+
+        It must NOT be re-synthesized; instead the existing device gets its
+        reading from the BFF and is routed through the BFF path
+        (``_bff_thermometer_ids``) so the futile Developer poll is skipped.
+        """
+        from custom_components.govee.models.device import (
+            CAPABILITY_PROPERTY,
+            INSTANCE_SENSOR_HUMIDITY,
+            INSTANCE_SENSOR_TEMPERATURE,
+        )
+
+        coord, coord_mod = self._coord()
+        did = "AA:BB:CC:DD:EE:FF:00:11"
+        # Pre-existing Developer-API H5179 with empty reading.
+        existing = GoveeDevice(
+            device_id=did,
+            sku="H5179",
+            name="Garage Fridge",
+            device_type="devices.types.thermometer",
+            capabilities=(
+                GoveeCapability(
+                    type=CAPABILITY_PROPERTY,
+                    instance=INSTANCE_SENSOR_TEMPERATURE,
+                    parameters={},
+                ),
+                GoveeCapability(
+                    type=CAPABILITY_PROPERTY,
+                    instance=INSTANCE_SENSOR_HUMIDITY,
+                    parameters={},
+                ),
+            ),
+            is_group=False,
+        )
+        coord._devices[did] = existing
+        coord._states[did] = GoveeDeviceState.create_empty(did)
+
+        inner = MagicMock()
+        inner.fetch_bff_thermo_hygrometers = _make_async(
+            [
+                {
+                    "device_id": did,
+                    "name": "Garage Fridge",
+                    "sku": "H5179",
+                    "battery": 17,
+                    "online": False,
+                    "temperature": 4.9,
+                    "humidity": 53.1,
+                    "hub_device_id": "",
+                    "hub_sku": "",
+                }
+            ]
+        )
+        inner.bff_device_census = MagicMock(return_value=[])
+        inner.bff_response_skeleton = MagicMock(return_value=None)
+        inner.bff_device_values = MagicMock(return_value=[])
+        monkeypatch.setattr(coord_mod, "GoveeAuthClient", lambda **kw: _AsyncCM(inner))
+
+        await coord._discover_bff_thermometers()
+
+        # Same device object — not synthesized/replaced.
+        assert coord._devices[did] is existing
+        assert did in coord._bff_thermometer_ids
+        state = coord._states[did]
+        assert state.sensor_temperature == 4.9
+        assert state.sensor_humidity == 53.1
+        assert state.battery == 17
+
+    @pytest.mark.asyncio
     async def test_fetch_device_state_skips_developer_poll(self, monkeypatch):
         coord, coord_mod = self._coord()
         did = "AA:BB:CC:DD:EE:FF:00:11"

--- a/tests/test_thermometer.py
+++ b/tests/test_thermometer.py
@@ -184,12 +184,15 @@ class TestTemperatureSensorFahrenheitConversion:
 
         state = SimpleNamespace(sensor_temperature=raw_value)
         coordinator = SimpleNamespace(
-            config_entry=SimpleNamespace(options={"api_temperature_unit": api_unit})
+            config_entry=SimpleNamespace(options={"api_temperature_unit": api_unit}),
+            # Developer-API thermometer, not a BFF-sourced one (#141).
+            is_bff_thermometer=lambda _device_id: False,
         )
         stub = SimpleNamespace(
             device_state=state,
             coordinator=coordinator,
             _device=SimpleNamespace(sku=sku),
+            _device_id="AA:BB:CC:DD:EE:FF:00:11",
         )
         return GoveeTemperatureSensor.native_value.fget(stub)
 
@@ -232,15 +235,40 @@ class TestTemperatureSensorFahrenheitConversion:
         from custom_components.govee.sensor import GoveeTemperatureSensor
 
         state = SimpleNamespace(sensor_temperature=100.83)
-        coordinator = SimpleNamespace(config_entry=SimpleNamespace(options={}))
+        coordinator = SimpleNamespace(
+            config_entry=SimpleNamespace(options={}),
+            is_bff_thermometer=lambda _device_id: False,
+        )
         stub = SimpleNamespace(
             device_state=state,
             coordinator=coordinator,
             _device=SimpleNamespace(sku="H5109"),
+            _device_id="AA:BB:CC:DD:EE:FF:00:11",
         )
         # Default is auto -> known °F SKU converts.
         result = GoveeTemperatureSensor.native_value.fget(stub)
         assert abs(result - 38.238889) < 1e-4
+
+    def test_bff_sourced_h5179_skips_fahrenheit_conversion(self):
+        # H5179 is in FAHRENHEIT_REPORTING_SKUS for its Developer-API path, but
+        # when its reading comes via BFF (already canonical °C from _bff_reading)
+        # the conversion must NOT apply — else 4.9°C would be mangled (#141).
+        from types import SimpleNamespace
+
+        from custom_components.govee.sensor import GoveeTemperatureSensor
+
+        state = SimpleNamespace(sensor_temperature=4.9)
+        coordinator = SimpleNamespace(
+            config_entry=SimpleNamespace(options={"api_temperature_unit": "auto"}),
+            is_bff_thermometer=lambda _device_id: True,
+        )
+        stub = SimpleNamespace(
+            device_state=state,
+            coordinator=coordinator,
+            _device=SimpleNamespace(sku="H5179"),
+            _device_id="AA:BB:CC:DD:EE:FF:00:11",
+        )
+        assert GoveeTemperatureSensor.native_value.fget(stub) == 4.9
 
     def test_h717a_kettle_auto_converts_fahrenheit(self):
         # Issue #115: H717A kettle reports 187°F under the °C-tagged unit


### PR DESCRIPTION
Fixes #141.

## Root cause (confirmed from the issue diagnostics)
The H5179 WiFi thermometer is discovered via the **Developer API** — so it gets temperature/humidity entities — but the Developer `/device/state` poll returns **empty strings** for `sensorTemperature`/`sensorHumidity` (with `online: false`). The live reading only exists in the **BFF `lastDeviceData`**:

```
lastDeviceData: { tem: 490, hum: 5310, online: false }   # → 4.9°C, 53.1%
deviceSettings: { battery: 17, fahOpen: true }
```

But the BFF `lastDeviceData` read path only covered **BFF-only** SKUs (`{H5301, H5310}`), so the H5179 fell in the gap: discovered via Developer API (excluded from the BFF path), Developer API never provides a value.

## Fix
Route the H5179 through the existing BFF thermometer read path instead of the empty Developer poll:

- **models/device**: add `THERMO_HYGRO_BFF_READ_SKUS = {H5179}` — Developer-API thermometers whose live value comes via BFF.
- **api/auth**: `fetch_bff_thermo_hygrometers` also returns these SKUs.
- **coordinator**: `_discover_bff_thermometers` applies the BFF reading + battery to the already-discovered device (no duplicate synthesized) and adds it to `_bff_thermometer_ids`, so `_fetch_device_state` skips the futile Developer poll and `_refresh_bff_thermometers` keeps it fresh.
- **sensor**: `GoveeTemperatureSensor` skips the SKU-based °F conversion for BFF-sourced readings — `_bff_reading` already yields canonical °C, and the H5179 is in `FAHRENHEIT_REPORTING_SKUS` only for its Developer path (would otherwise double-convert 4.9°C into nonsense).

## Tests
- BFF supplement applies the reading + battery to the existing device without re-synthesizing a duplicate.
- A BFF-sourced H5179 skips the Fahrenheit conversion.
- **Full suite: 1604 passing** locally (py3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)