### PR TITLE
bugfix: normalize all whitespace (not just spaces) when matching the "leakage alert" warnMessage text.

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -1248,9 +1248,7 @@ class GoveeAuthClient:
                 return any(
                     isinstance(m, dict)
                     and not m.get("read", True)
-                    and str(m.get("message", ""))
-                    .lower()
-                    .replace(" ", "")
+                    and re.sub(r"\s+", "", str(m.get("message", "")).lower())
                     .startswith("leakagealert")
                     for m in messages
                 )

--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -46,6 +46,7 @@ from .const import (
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
     CONF_SEGMENT_MODE,
+    CONF_WATER_DETECTOR_POLL_INTERVAL,
     CONFIG_VERSION,
     DEFAULT_API_TEMPERATURE_UNIT,
     DEFAULT_ENABLE_DIY_SCENES,
@@ -57,9 +58,12 @@ from .const import (
     DEFAULT_LAN_TARGETS,
     DEFAULT_POLL_INTERVAL,
     DEFAULT_SEGMENT_MODE,
+    DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DOMAIN,
     KEY_IOT_CREDENTIALS,
     KEY_IOT_LOGIN_FAILED,
+    MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_WATER_DETECTOR_POLL_INTERVAL,
     SEGMENT_MODE_DISABLED,
     SEGMENT_MODE_GROUPED,
     SEGMENT_MODE_INDIVIDUAL,
@@ -418,6 +422,9 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_ENABLE_DIY_SCENES: DEFAULT_ENABLE_DIY_SCENES,
                 CONF_ENABLE_SEGMENTS: DEFAULT_ENABLE_SEGMENTS,
                 CONF_SEGMENT_MODE: DEFAULT_SEGMENT_MODE,
+                CONF_WATER_DETECTOR_POLL_INTERVAL: (
+                    DEFAULT_WATER_DETECTOR_POLL_INTERVAL
+                ),
             },
         )
 
@@ -692,6 +699,19 @@ class GoveeOptionsFlow(OptionsFlow):
                         CONF_POLL_INTERVAL,
                         default=source.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
                     ): vol.All(vol.Coerce(int), vol.Range(min=30, max=300)),
+                    vol.Optional(
+                        CONF_WATER_DETECTOR_POLL_INTERVAL,
+                        default=source.get(
+                            CONF_WATER_DETECTOR_POLL_INTERVAL,
+                            DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
+                        ),
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(
+                            min=MIN_WATER_DETECTOR_POLL_INTERVAL,
+                            max=MAX_WATER_DETECTOR_POLL_INTERVAL,
+                        ),
+                    ),
                     vol.Optional(
                         CONF_ENABLE_GROUPS,
                         default=source.get(CONF_ENABLE_GROUPS, DEFAULT_ENABLE_GROUPS),

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -19,6 +19,13 @@ CONF_SEGMENT_MODE: Final = "segment_mode"
 CONF_EXPOSE_TRANSPORT_ENTITIES: Final = "expose_transport_entities"
 CONF_ENABLE_MQTT_CONTROL: Final = "enable_mqtt_control"
 
+# Standalone water-detector (H5054) leak-poll interval (seconds). These RF-only
+# sensors deliver their trip only via the account warnMessage history (issue
+# #62); a leak surfaces with up to this much latency. Configurable because the
+# account API's rate limit is unverified (homebridge issue #543) — users with
+# many detectors may want to back off, while a single detector can poll faster.
+CONF_WATER_DETECTOR_POLL_INTERVAL: Final = "water_detector_poll_interval"
+
 # Extra LAN discovery targets for devices the local multicast scan can't reach —
 # e.g. Govee devices on a different VLAN/subnet than Home Assistant (issue #57).
 # Free-text list (comma / newline / space separated) of device IPs, broadcast
@@ -110,6 +117,13 @@ DEFAULT_EXPOSE_TRANSPORT_ENTITIES: Final = False
 DEFAULT_ENABLE_MQTT_CONTROL: Final = False
 DEFAULT_API_TEMPERATURE_UNIT: Final = "auto"
 DEFAULT_LAN_TARGETS: Final = ""
+DEFAULT_WATER_DETECTOR_POLL_INTERVAL: Final = 120  # seconds (2 minutes)
+
+# Bounds for the configurable water-detector poll interval (seconds). The lower
+# bound keeps the unverified account-API rate limit at arm's length; the upper
+# bound (1 hour) is the slowest that still makes a leak alert useful.
+MIN_WATER_DETECTOR_POLL_INTERVAL: Final = 60
+MAX_WATER_DETECTOR_POLL_INTERVAL: Final = 3600
 
 # Optimistic state handling
 # Grace window (seconds) during which API polls do NOT overwrite optimistic

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -67,7 +67,9 @@ from .api.lan_control import command_to_lan, lan_brightness_to_device
 from .const import (
     CONF_ENABLE_MQTT_CONTROL,
     CONF_LAN_TARGETS,
+    CONF_WATER_DETECTOR_POLL_INTERVAL,
     DEFAULT_ENABLE_MQTT_CONTROL,
+    DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DEVICE_REDISCOVERY_INTERVAL,
     DOMAIN,
     LAN_CORRELATION_TTL_SECONDS,
@@ -76,6 +78,8 @@ from .const import (
     LAN_WRITE_CONFIRM_TIMEOUT,
     LAN_WRITE_SUPPRESS_SECONDS,
     LAN_WRITE_SUPPRESS_THRESHOLD,
+    MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_WATER_DETECTOR_POLL_INTERVAL,
     OPTIMISTIC_GRACE_CAP_SECONDS,
 )
 from .models import (
@@ -149,12 +153,6 @@ LAN_BRIGHTNESS_CONFIRM_TOLERANCE = 2
 
 # BFF polling interval for leak sensor state (seconds)
 BFF_POLL_INTERVAL = 300  # 5 minutes
-
-# Standalone water-detector (H5054) leak-poll interval (seconds). These RF-only
-# sensors deliver their trip only via the account warnMessage history (issue
-# #62); a leak surfaces with up to this much latency. Kept conservative because
-# the account API's rate limit is unverified (homebridge issue #543).
-WATER_DETECTOR_POLL_INTERVAL = 120  # 2 minutes
 
 # Delay before re-polling device state after a humidifier work_mode/humidity
 # write, to attach a timestamped "what Govee reports N seconds later" snapshot
@@ -2090,13 +2088,36 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             if not d.is_group and d.supports_water_leak_event
         ]
 
+    @property
+    def _water_detector_poll_interval(self) -> int:
+        """Configured leak-poll interval (seconds) for standalone detectors.
+
+        Read per tick so the value is picked up on the reload that follows an
+        options change. Out-of-range or non-numeric values (e.g. hand-edited
+        options) fall back to the default rather than arming a bad timer.
+        """
+        raw = self._config_entry.options.get(
+            CONF_WATER_DETECTOR_POLL_INTERVAL, DEFAULT_WATER_DETECTOR_POLL_INTERVAL
+        )
+        try:
+            interval = int(raw)
+        except (TypeError, ValueError):
+            return DEFAULT_WATER_DETECTOR_POLL_INTERVAL
+        if not (
+            MIN_WATER_DETECTOR_POLL_INTERVAL
+            <= interval
+            <= MAX_WATER_DETECTOR_POLL_INTERVAL
+        ):
+            return DEFAULT_WATER_DETECTOR_POLL_INTERVAL
+        return interval
+
     def _schedule_water_detector_poll(self) -> None:
         """Schedule the next standalone water-detector leak poll."""
         if self._wd_poll_unsub:
             self._wd_poll_unsub()
         self._wd_poll_unsub = async_call_later(
             self.hass,
-            WATER_DETECTOR_POLL_INTERVAL,
+            self._water_detector_poll_interval,
             self._water_detector_poll_callback,
         )
 

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -79,6 +79,7 @@
         "description": "If you have RGBIC devices, per-device segment settings will appear after submitting.",
         "data": {
           "poll_interval": "Polling interval (seconds)",
+          "water_detector_poll_interval": "Leak sensor polling interval (seconds)",
           "api_temperature_unit": "Temperature unit from Govee API (thermometers)",
           "enable_groups": "Enable group devices",
           "enable_scenes": "Enable scene selector",
@@ -89,6 +90,7 @@
         },
         "data_description": {
           "api_temperature_unit": "Auto (default) converts known Fahrenheit-reporting thermometers (e.g. H5179, H5109, H5110, H5111, H5075, H5100) automatically. Choose Fahrenheit if another thermometer reads about 1.8× too high (e.g. 74 instead of 23), or Celsius to force no conversion. Govee's API omits unit metadata, so the value can't always be auto-detected.",
+          "water_detector_poll_interval": "How often standalone Govee water/leak detectors (e.g. H5054) are checked for a leak. These RF-only sensors have no push channel, so a leak surfaces with up to this much delay. Lower reacts faster but makes more account API calls; raise it if you have many detectors. Range 60\u20133600 seconds, default 120. Requires email/password login; ignored if you have no such detectors.",
           "enable_groups": "Surfaces the device groups you created in the Govee app as single light entities. A command to a group is sent once and synced to all members by Govee's cloud, so it syncs better than grouping the lights with Home Assistant helpers. State is best-effort (groups can't be polled), and group lights only support power/brightness/color.",
           "enable_mqtt_control": "Routes power/brightness/color commands through Govee's MQTT channel instead of the REST cloud API, reducing latency and bypassing REST rate limits. Requires email/password login (MQTT credentials). Falls back to REST automatically when MQTT is unavailable. Experimental — uses an undocumented channel; leave off if commands behave unexpectedly.",
           "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network."

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -79,6 +79,7 @@
         "description": "If you have RGBIC devices, per-device segment settings will appear after submitting.",
         "data": {
           "poll_interval": "Polling interval (seconds)",
+          "water_detector_poll_interval": "Leak sensor polling interval (seconds)",
           "api_temperature_unit": "Temperature unit from Govee API (thermometers)",
           "enable_groups": "Enable group devices",
           "enable_scenes": "Enable scene selector",
@@ -89,6 +90,7 @@
         },
         "data_description": {
           "api_temperature_unit": "Auto (default) converts known Fahrenheit-reporting thermometers (e.g. H5179, H5109, H5110, H5111, H5075, H5100) automatically. Choose Fahrenheit if another thermometer reads about 1.8× too high (e.g. 74 instead of 23), or Celsius to force no conversion. Govee's API omits unit metadata, so the value can't always be auto-detected.",
+          "water_detector_poll_interval": "How often standalone Govee water/leak detectors (e.g. H5054) are checked for a leak. These RF-only sensors have no push channel, so a leak surfaces with up to this much delay. Lower reacts faster but makes more account API calls; raise it if you have many detectors. Range 60\u20133600 seconds, default 120. Requires email/password login; ignored if you have no such detectors.",
           "enable_groups": "Surfaces the device groups you created in the Govee app as single light entities. A command to a group is sent once and synced to all members by Govee's cloud, so it syncs better than grouping the lights with Home Assistant helpers. State is best-effort (groups can't be polled), and group lights only support power/brightness/color.",
           "enable_mqtt_control": "Routes power/brightness/color commands through Govee's MQTT channel instead of the REST cloud API, reducing latency and bypassing REST rate limits. Requires email/password login (MQTT credentials). Falls back to REST automatically when MQTT is unavailable. Experimental — uses an undocumented channel; leave off if commands behave unexpectedly.",
           "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network."

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
+import voluptuous as vol
 
 from custom_components.govee.api.exceptions import (
     Govee2FACodeInvalidError,
@@ -21,11 +22,15 @@ from custom_components.govee.const import (
     CONF_LAN_TARGETS,
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
+    CONF_WATER_DETECTOR_POLL_INTERVAL,
     DEFAULT_ENABLE_GROUPS,
     DEFAULT_ENABLE_SCENES,
     DEFAULT_ENABLE_SEGMENTS,
     DEFAULT_POLL_INTERVAL,
+    DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DOMAIN,
+    MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_WATER_DETECTOR_POLL_INTERVAL,
 )
 
 # ==============================================================================
@@ -288,6 +293,57 @@ class TestLanTargetsOption:
         )
         assert result["type"] == "form"
         assert result["errors"] == {CONF_LAN_TARGETS: "invalid_lan_targets"}
+
+
+class TestWaterDetectorPollIntervalOption:
+    """The leak-poll interval is exposed and bounded in the options flow."""
+
+    @pytest.mark.asyncio
+    async def test_field_defaults_to_constant(self):
+        flow, entry = _options_flow()
+        result = await _run_init(flow, entry, None)
+        key = next(
+            k
+            for k in result["data_schema"].schema
+            if k == CONF_WATER_DETECTOR_POLL_INTERVAL
+        )
+        assert key.default() == DEFAULT_WATER_DETECTOR_POLL_INTERVAL
+
+    @pytest.mark.asyncio
+    async def test_field_seeded_from_saved_option(self):
+        flow, entry = _options_flow()
+        entry.options = {CONF_WATER_DETECTOR_POLL_INTERVAL: 900}
+        result = await _run_init(flow, entry, None)
+        key = next(
+            k
+            for k in result["data_schema"].schema
+            if k == CONF_WATER_DETECTOR_POLL_INTERVAL
+        )
+        assert key.default() == 900
+
+    @pytest.mark.asyncio
+    async def test_value_is_saved(self):
+        flow, entry = _options_flow()
+        result = await _run_init(
+            flow,
+            entry,
+            {CONF_POLL_INTERVAL: 60, CONF_WATER_DETECTOR_POLL_INTERVAL: 600},
+        )
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_WATER_DETECTOR_POLL_INTERVAL] == 600
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "value",
+        [MIN_WATER_DETECTOR_POLL_INTERVAL - 1, MAX_WATER_DETECTOR_POLL_INTERVAL + 1],
+    )
+    async def test_out_of_range_rejected_by_schema(self, value):
+        flow, entry = _options_flow()
+        result = await _run_init(flow, entry, None)
+        with pytest.raises(vol.Invalid):
+            result["data_schema"](
+                {CONF_POLL_INTERVAL: 60, CONF_WATER_DETECTOR_POLL_INTERVAL: value}
+            )
 
 
 class TestConfigFlowSteps:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -35,6 +35,7 @@ from custom_components.govee.models.device import (
     INSTANCE_BRIGHTNESS,
     INSTANCE_HUMIDITY,
 )
+from custom_components.govee import const
 from custom_components.govee.transport_health import TransportHealthTracker
 
 # ==============================================================================
@@ -2080,6 +2081,67 @@ class TestWaterDetectorPoll:
         coord._iot_credentials = None
         await coord._poll_water_detectors()
         assert coord._states[did].water_leak is None
+
+
+class TestWaterDetectorPollInterval:
+    """The leak-poll interval is a user-configurable option."""
+
+    def _coord_with_options(self, options):
+        import custom_components.govee.coordinator as coord_mod
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        config_entry.options = options
+        return coord_mod.GoveeCoordinator(
+            hass=MagicMock(),
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=MagicMock(token="tok"),
+            poll_interval=60,
+        )
+
+    def test_default_when_option_unset(self):
+        coord = self._coord_with_options({})
+        assert coord._water_detector_poll_interval == (
+            const.DEFAULT_WATER_DETECTOR_POLL_INTERVAL
+        )
+
+    def test_configured_value_is_used(self):
+        coord = self._coord_with_options({const.CONF_WATER_DETECTOR_POLL_INTERVAL: 600})
+        assert coord._water_detector_poll_interval == 600
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            const.MIN_WATER_DETECTOR_POLL_INTERVAL - 1,
+            const.MAX_WATER_DETECTOR_POLL_INTERVAL + 1,
+            "not-a-number",
+            None,
+        ],
+    )
+    def test_out_of_range_or_bad_value_falls_back(self, value):
+        """Hand-edited options must not arm a bad timer."""
+        coord = self._coord_with_options(
+            {const.CONF_WATER_DETECTOR_POLL_INTERVAL: value}
+        )
+        assert coord._water_detector_poll_interval == (
+            const.DEFAULT_WATER_DETECTOR_POLL_INTERVAL
+        )
+
+    def test_schedule_uses_configured_interval(self, monkeypatch):
+        import custom_components.govee.coordinator as coord_mod
+
+        coord = self._coord_with_options({const.CONF_WATER_DETECTOR_POLL_INTERVAL: 300})
+        seen = {}
+
+        def _capture(hass, delay, callback):
+            seen["delay"] = delay
+            return lambda: None
+
+        monkeypatch.setattr(coord_mod, "async_call_later", _capture)
+        coord._schedule_water_detector_poll()
+
+        assert seen["delay"] == 300
 
 
 class _AsyncCM:


### PR DESCRIPTION
bugfix #145 : normalize all whitespace (not just spaces) when matching the "leakage alert" warnMessage text.

feat: Make water-detector leak-poll interval configurable

The standalone water-detector (H5054) leak poll was hardcoded at 120s in coordinator.py. These RF-only sensors only surface a trip via the account warnMessage history, so the interval is the leak-detection latency — but the account API's rate limit is unverified, so the right value depends on how many detectors an account has.

Expose it as a Govee option (Settings -> Integrations -> Configure):

- const.py: CONF_WATER_DETECTOR_POLL_INTERVAL, default 120s, bounded 60-3600s; the old coordinator module constant is removed.
- coordinator.py: _water_detector_poll_interval reads the option per tick and falls back to the default for out-of-range / non-numeric values, so hand-edited options can't arm a bad timer.
- config_flow.py: new bounded field in the options schema, plus the default seeded into options on entry creation.
- strings.json / translations/en.json: label and help text.
- Tests for the option plumbing, bounds, fallbacks, and that the timer is armed with the configured value.

