### PR TITLE
fix(binary_sensor): don't create a second moisture entity for hub-attached sensors

### DIFF
--- a/custom_components/govee/binary_sensor.py
+++ b/custom_components/govee/binary_sensor.py
@@ -76,7 +76,18 @@ async def async_setup_entry(
         # device list with a bodyAppearedEvent capability — issue #62. Presence
         # sensors (H5127) share that instance but are excluded here (they get an
         # occupancy sensor below instead of a moisture one) — issue #124.
-        if device.supports_water_leak_event:
+        # Hub-attached sensors (H5058 via H5043) expose the same capability but
+        # already get a moisture entity from the BFF/multiSync path, which
+        # arrived first on the trips measured so far — skip them rather than
+        # duplicate. Fails open by design: an empty roster (API-key-only setup,
+        # or a BFF outage at boot) creates the entity rather than leaving the
+        # sensor blind — see test_outage_leaves_a_working_moisture_entity.
+        # The cost is accepted knowingly: a row seeded during an outage is
+        # suppressed on the next healthy boot, and the repairs notice reports
+        # it. A stale row the user is told about beats a blind leak sensor.
+        if device.supports_water_leak_event and not coordinator.is_bff_leak_sensor(
+            device.device_id
+        ):
             entities.append(GoveeWaterLeakBinarySensor(coordinator, device))
         # mmWave presence/occupancy sensors (H5127) — issue #124. They expose
         # the generic bodyAppearedEvent capability with Presence/Absence

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -156,6 +156,12 @@ BFF_POLL_INTERVAL = 300  # 5 minutes
 # the account API's rate limit is unverified (homebridge issue #543).
 WATER_DETECTOR_POLL_INTERVAL = 120  # 2 minutes
 
+
+def normalize_device_id(device_id: str) -> str:
+    """Canonical form for comparing device IDs across Govee's APIs."""
+    return device_id.replace(":", "").upper()
+
+
 # Delay before re-polling device state after a humidifier work_mode/humidity
 # write, to attach a timestamped "what Govee reports N seconds later" snapshot
 # to that same recent_commands entry (issue #118: these writes return HTTP 200
@@ -730,6 +736,22 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         gate on ``online`` (issues #62, #145).
         """
         return any(d.device_id == device_id for d in self._water_detectors)
+
+    def is_bff_leak_sensor(self, device_id: str) -> bool:
+        """Return True if BFF/hub discovery owns this device's moisture entity.
+
+        Compared on the colon-stripped form because Govee is not consistent
+        about device-ID formatting between the Developer API and the BFF list
+        (see ``fetch_water_detector_states``).
+
+        Reflects the live roster only. Persisting the answer would make it
+        monotone-true, and a device that leaves the hub would then end up with
+        no moisture entity at all.
+        """
+        target = normalize_device_id(device_id)
+        return any(
+            normalize_device_id(sensor_id) == target for sensor_id in self._leak_sensors
+        )
 
     def is_power_off_pending(self, device_id: str) -> bool:
         """Return True if a power-off command is in flight for this device.

--- a/tests/test_water_leak.py
+++ b/tests/test_water_leak.py
@@ -12,7 +12,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.govee.binary_sensor import GoveeWaterLeakBinarySensor
+from custom_components.govee.binary_sensor import (
+    GoveeLeakBinarySensor,
+    GoveeWaterLeakBinarySensor,
+    async_setup_entry,
+)
+from custom_components.govee.coordinator import GoveeCoordinator
 from custom_components.govee.models import (
     GoveeCapability,
     GoveeDevice,
@@ -21,6 +26,7 @@ from custom_components.govee.models import (
 from custom_components.govee.models.device import (
     CAPABILITY_EVENT,
     INSTANCE_BODY_APPEARED_EVENT,
+    GoveeLeakSensor,
 )
 
 # --------------------------------------------------------------------------- #
@@ -174,3 +180,142 @@ class TestBinarySensor:
     def test_unavailable_when_coordinator_failed(self, h5054_device):
         entity = self._entity(h5054_device, None, last_update_success=False)
         assert entity.available is False
+
+
+# --------------------------------------------------------------------------- #
+# Hub-attached sensors must not get a second moisture entity
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def h5058_device() -> GoveeDevice:
+    """H5058 as the developer API returns it — same capability as the H5054."""
+    return GoveeDevice(
+        device_id="01:32:7A:C4:06:02:1C:42",
+        sku="H5058",
+        name="Master sink",
+        device_type="devices.types.sensor",
+        capabilities=(
+            GoveeCapability(
+                type=CAPABILITY_EVENT,
+                instance=INSTANCE_BODY_APPEARED_EVENT,
+                parameters={},
+            ),
+        ),
+        is_group=False,
+    )
+
+
+class TestHubAttachedSensorNotDuplicated:
+    """H5058 matches the H5054 capability rule but is owned by the BFF path.
+
+    Both SKUs expose ``bodyAppearedEvent``, so a purely capability-based check
+    gave hub-attached sensors two moisture entities: this one plus the
+    BFF/multiSync ``GoveeLeakBinarySensor``. The BFF entity wins (it is the
+    faster of the two pushes), so this platform skips devices already
+    discovered as leak sensors.
+    """
+
+    @staticmethod
+    def _entry(device: GoveeDevice, *, discovered_via_bff: bool) -> MagicMock:
+        leak_sensors = {}
+        if discovered_via_bff:
+            leak_sensors[device.device_id] = GoveeLeakSensor(
+                device_id=device.device_id,
+                name=device.name,
+                sku=device.sku,
+                hub_device_id="09:C2:60:74:F4:64:AB:FA",
+                sno=14,
+            )
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        coordinator.leak_sensors = leak_sensors
+        coordinator._leak_sensors = leak_sensors
+        coordinator._config_entry.data = {}
+        coordinator.register_leak_hubs = MagicMock()
+        coordinator.is_bff_leak_sensor = (
+            lambda did: GoveeCoordinator.is_bff_leak_sensor(coordinator, did)
+        )
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.options = {}
+        return entry
+
+    @staticmethod
+    async def _water_leak_entities(entry: MagicMock) -> list:
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+        return [e for e in added if isinstance(e, GoveeWaterLeakBinarySensor)]
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_already_discovered_via_bff(self, h5058_device):
+        entry = self._entry(h5058_device, discovered_via_bff=True)
+        assert await self._water_leak_entities(entry) == []
+
+    @pytest.mark.asyncio
+    async def test_still_created_for_standalone_detector(self, h5054_device):
+        """H5054 has no BFF/hub entity, so it must keep this one."""
+        entry = self._entry(h5054_device, discovered_via_bff=False)
+        assert len(await self._water_leak_entities(entry)) == 1
+
+    @pytest.mark.asyncio
+    async def test_created_when_bff_discovery_unavailable(self, h5058_device):
+        """API-key-only setups have no BFF discovery — don't leave them blind."""
+        entry = self._entry(h5058_device, discovered_via_bff=False)
+        assert len(await self._water_leak_entities(entry)) == 1
+
+    @pytest.mark.asyncio
+    async def test_bff_entity_survives_the_suppression(self, h5058_device):
+        """The kept entity must be the BFF one — not zero moisture entities."""
+        entry = self._entry(h5058_device, discovered_via_bff=True)
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+
+        moisture = [
+            e
+            for e in added
+            if isinstance(e, (GoveeLeakBinarySensor, GoveeWaterLeakBinarySensor))
+        ]
+        assert len(moisture) == 1
+        assert isinstance(moisture[0], GoveeLeakBinarySensor)
+
+    @pytest.mark.asyncio
+    async def test_outage_leaves_a_working_moisture_entity(self, h5058_device):
+        """A BFF outage must never leave the device with nothing.
+
+        The standalone entity still receives OpenAPI leak events, so keeping it
+        is a working fallback; suppressing it here would mean zero moisture
+        entities for a leak sensor.
+        """
+        entry = self._entry(h5058_device, discovered_via_bff=False)
+        assert entry.runtime_data.leak_sensors == {}  # discovery came back empty
+
+        assert len(await self._water_leak_entities(entry)) == 1
+
+    @pytest.mark.asyncio
+    async def test_both_discovery_outcomes_add_a_moisture_entity(self, h5058_device):
+        """Setup adds a moisture entity whether or not BFF discovery found it."""
+        for discovered in (True, False):
+            entry = self._entry(h5058_device, discovered_via_bff=discovered)
+            added: list = []
+            await async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+            moisture = [
+                e
+                for e in added
+                if isinstance(e, (GoveeLeakBinarySensor, GoveeWaterLeakBinarySensor))
+            ]
+            assert len(moisture) >= 1, f"no moisture entity when {discovered=}"
+
+    @pytest.mark.asyncio
+    async def test_dedupe_survives_id_format_mismatch(self, h5058_device):
+        """Govee is inconsistent about colons between its APIs; match anyway."""
+        entry = self._entry(h5058_device, discovered_via_bff=True)
+        coordinator = entry.runtime_data
+        colonless = {
+            device_id.replace(":", ""): sensor
+            for device_id, sensor in coordinator.leak_sensors.items()
+        }
+        coordinator.leak_sensors = colonless
+        coordinator._leak_sensors = colonless
+
+        assert await self._water_leak_entities(entry) == []


### PR DESCRIPTION
An H5058 attached to an H5043 hub gets two moisture entities. One comes from the BFF/multiSync discovery path, the other from the developer-API path, because `supports_water_leak_event` is capability-based rather than SKU-locked and the H5058 does expose `bodyAppearedEvent` — the same capability the standalone H5054 is detected by.

Both entities work; this is redundancy, not a dead entity. A real trip on 2026-07-31T23:09:31Z fired both, the BFF-backed one at `.801` and the OpenAPI-backed one at `23:09:32.316`. That is a single observation, but the BFF push arrived first, so that is the one kept and the developer-API path skips devices already on the hub roster.

IDs are compared colon-stripped, because Govee is not consistent about device-ID formatting between the two APIs.

The check reads the live roster and is deliberately not persisted. An answer cached at discovery would be monotone-true, and a device that later leaves the hub would then have no moisture entity at all. It also fails open: an empty roster — API-key-only setup, or a BFF outage at boot — creates the entity rather than leaving a leak sensor blind.

### Note for upgraders, and a decision for you

Anyone who already has the second entity keeps the registry row. It stops being created, so it goes permanently `unavailable`, and an automation bound to it with `to: "on"` stops firing without saying so. The device is never blind — suppression and creation read the same `_leak_sensors` dict, so the surviving BFF entity is guaranteed present and fed — but an automation pointed at the old `entity_id` needs repointing.

The exposure looks small: the duplicate arrived in d0e0d8d (2026-06-05, first shipped in v2026.6.10), so it affects only hub-attached H5058 owners who installed in the last ~7 weeks, and their sensors kept working throughout. On that basis this ships as a release note rather than code.

I did build the alternative — a repairs notice listing the affected `entity_id`s, raised only when discovery had actually answered and only when the surviving entity was enabled. It worked, but it came to ~160 lines around a 35-line fix, so it is not in this PR. Happy to send it separately if you would rather upgraders were told in-app.

### Tests

Cover the no-duplicate property, the ID-format mismatch across both colon and case, the survivor being the BFF entity, and the fail-open outage path.

34 production lines across `binary_sensor.py` and `coordinator.py`.