### PR TITLE
fix: Use `UnitOfRatio.PARTS_PER_MILLION` over deprecated constant `CONCENTRATION_PARTS_PER_MILLION`

### DIFF
--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -20,9 +20,9 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
-    EntityCategory,
     PERCENTAGE,
+    EntityCategory,
+    UnitOfRatio,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -380,7 +380,7 @@ class GoveeCO2Sensor(GoveeEntity, SensorEntity):
     _attr_translation_key = "sensor_co2"
     _attr_device_class = SensorDeviceClass.CO2
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
+    _attr_native_unit_of_measurement = UnitOfRatio.PARTS_PER_MILLION
 
     def __init__(
         self,

--- a/tests/test_co2_sensor.py
+++ b/tests/test_co2_sensor.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION
+from homeassistant.const import UnitOfRatio
 
-from custom_components.govee.sensor import GoveeCO2Sensor
 from custom_components.govee.models import GoveeDevice, GoveeDeviceState
 from custom_components.govee.models.device import CAPABILITY_PROPERTY, INSTANCE_CO2
+from custom_components.govee.sensor import GoveeCO2Sensor
 
 
 def _h5140() -> GoveeDevice:
@@ -63,5 +63,5 @@ def test_co2_entity():
     entity = GoveeCO2Sensor(coordinator, dev)
     assert entity.native_value == 609
     assert entity.device_class == SensorDeviceClass.CO2
-    assert entity.native_unit_of_measurement == CONCENTRATION_PARTS_PER_MILLION
+    assert entity.native_unit_of_measurement == UnitOfRatio.PARTS_PER_MILLION
     assert entity.unique_id == f"{dev.device_id}_co2"


### PR DESCRIPTION
```
[homeassistant.const] The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from govee. It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_MILLION instead, please report it to the author of the 'govee' custom integration
```