### PR TITLE
fix(govee): collapse H7075 segment_count to physical sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,8 @@ RGBIC segment count is in `fields[].elementRange.max + 1`:
 segment_count = element_range["max"] + 1
 ```
 
+For SKUs the API over-reports (H7075: `elementRange.max=14`, device has 3 sections), `GoveeDevice.segment_count` consults `SKU_SEGMENT_OVERRIDES` in `const.py` first and clamps against `fields[].size.max` as a defensive backstop — both live in `custom_components/govee/models/device.py:1132+`. To add a new SKU: issue + one-line entry + test case, mirroring `FAHRENHEIT_REPORTING_SKUS` (issues #115 / #128 / #129).
+
 ## API Limitations & State Handling
 
 ### Scene State

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ RGBIC segment count is in `fields[].elementRange.max + 1`:
 segment_count = element_range["max"] + 1
 ```
 
-For SKUs the API over-reports (H7075: `elementRange.max=14`, device has 3 sections), `GoveeDevice.segment_count` consults `SKU_SEGMENT_OVERRIDES` in `const.py` first and clamps against `fields[].size.max` as a defensive backstop — both live in `custom_components/govee/models/device.py:1132+`. To add a new SKU: issue + one-line entry + test case, mirroring `FAHRENHEIT_REPORTING_SKUS` (issues #115 / #128 / #129).
+For SKUs the API over-reports (H7075: `elementRange.max=14`, device has 3 sections), `GoveeDevice.segment_count` clamps the parser-derived count against `fields[].size.max` first (auto safety net for unknown SKUs) and then applies `SKU_SEGMENT_OVERRIDES` in `const.py` as the authoritative override for known SKUs — both live in `custom_components/govee/models/device.py:1132+`. To add a new SKU: issue + one-line entry + test case, mirroring `FAHRENHEIT_REPORTING_SKUS` (issues #115 / #128 / #129).
 
 ## API Limitations & State Handling
 

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -85,6 +85,15 @@ FAHRENHEIT_REPORTING_SKUS: Final = frozenset(
 )
 
 
+# SKU-specific segment count overrides.
+# Some Govee devices report a higher segment count via the API than
+# the physical sections on the device. This dict pins the real count
+# per SKU. Add a new entry when the API is observed to misreport.
+SKU_SEGMENT_OVERRIDES: Final = {
+    "H7075": 3,  # API reports 15 (elementRange.max=14), device has 3 physical sections
+}
+
+
 def resolve_fahrenheit_conversion(
     sku: str, api_unit: str, device_unit_hint: str | None = None
 ) -> bool:

--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from homeassistant.helpers.device_registry import DeviceInfo
 
+from custom_components.govee.const import SKU_SEGMENT_OVERRIDES
+
 _LOGGER = logging.getLogger(__name__)
 
 # Leak sensor SKUs
@@ -1131,11 +1133,35 @@ class GoveeDevice:
 
     @property
     def segment_count(self) -> int:
-        """Get number of segments for RGBIC devices."""
+        """Get number of segments for RGBIC devices.
+
+        The Govee API may over-report segment counts for some SKUs (the H7075
+        reports ``elementRange.max=14`` — i.e. 15 — yet has only 3 physical
+        sections). ``SKU_SEGMENT_OVERRIDES`` is the authoritative source for
+        known SKUs; ``fields[].size.max`` is a defensive clamp for any future
+        SKU the override table hasn't seen yet.
+        """
         for cap in self.capabilities:
             if cap.is_segment_color:
-                seg = SegmentCapability.from_capability({"parameters": cap.parameters})
-                return seg.segment_count if seg else 0
+                params = cap.parameters
+                seg = SegmentCapability.from_capability({"parameters": params})
+                api_count = seg.segment_count if seg else 0
+
+                # Defensive clamp: the API's size.max is the protocol-level
+                # array-size ceiling, which matches the physical sections on
+                # SKUs like the H7075 where elementRange.max over-reports.
+                size_max: int | None = None
+                for f in params.get("fields", []):
+                    if f.get("fieldName") == "segment":
+                        size = f.get("size") or {}
+                        if "max" in size:
+                            size_max = size["max"]
+                            break
+
+                effective = SKU_SEGMENT_OVERRIDES.get(self.sku.upper(), api_count)
+                if size_max is not None:
+                    effective = min(effective, size_max)
+                return effective
         return 0
 
     def get_capability(self, cap_type: str, instance: str) -> GoveeCapability | None:

--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -1135,11 +1135,19 @@ class GoveeDevice:
     def segment_count(self) -> int:
         """Get number of segments for RGBIC devices.
 
-        The Govee API may over-report segment counts for some SKUs (the H7075
-        reports ``elementRange.max=14`` — i.e. 15 — yet has only 3 physical
-        sections). ``SKU_SEGMENT_OVERRIDES`` is the authoritative source for
-        known SKUs; ``fields[].size.max`` is a defensive clamp for any future
-        SKU the override table hasn't seen yet.
+        Priority order:
+
+        1. ``SKU_SEGMENT_OVERRIDES`` — authoritative for known SKUs (e.g. H7075
+           has 3 physical sections even though the API reports 15).
+        2. ``fields[].size.max`` — defensive clamp on the API-reported count,
+           since ``size.max`` is the protocol-level array ceiling that matches
+           physical sections on devices where ``elementRange.max`` over-reports.
+        3. The parser's raw ``elementRange.max + 1`` (or ``segmentCount``).
+
+        The size.max clamp is applied to the API count *before* the override
+        lookup so unknown SKUs that follow the same over-reporting pattern as
+        the H7075 are caught automatically, while known SKUs still trust the
+        explicit override entry.
         """
         for cap in self.capabilities:
             if cap.is_segment_color:
@@ -1158,9 +1166,12 @@ class GoveeDevice:
                             size_max = size["max"]
                             break
 
-                effective = SKU_SEGMENT_OVERRIDES.get(self.sku.upper(), api_count)
+                # Apply size.max clamp first so it acts as an automatic
+                # safety net for unknown SKUs; then let SKU_SEGMENT_OVERRIDES
+                # override as the authoritative source for known ones.
                 if size_max is not None:
-                    effective = min(effective, size_max)
+                    api_count = min(api_count, size_max)
+                effective = SKU_SEGMENT_OVERRIDES.get(self.sku.upper(), api_count)
                 return effective
         return 0
 

--- a/custom_components/govee/services.py
+++ b/custom_components/govee/services.py
@@ -42,6 +42,56 @@ SERVICE_SET_SEGMENT_COLOR_SCHEMA = vol.Schema(
 )
 
 
+async def async_set_segment_color_handler(
+    hass: HomeAssistant, call: ServiceCall
+) -> None:
+    """Handle ``govee.set_segment_color`` — module-level, testable.
+
+    Rejects any segment index outside the device's effective
+    ``segment_count`` (which already factors in ``SKU_SEGMENT_OVERRIDES``
+    for SKUs like H7075 that the API over-reports). On rejection the
+    service logs a warning and returns without dispatching — this keeps
+    the HA service call visible in the log instead of silently dropping
+    a command that the cloud would refuse anyway.
+    """
+    device_id = call.data["device_id"]
+    segments = call.data["segments"]
+    rgb = call.data["rgb_color"]
+
+    coordinator = _get_coordinator_for_device(hass, device_id)
+    if not coordinator:
+        _LOGGER.error("Device %s not found", device_id)
+        return
+
+    device = coordinator.devices.get(device_id)
+    if device is not None:
+        n = device.segment_count
+        bad = [i for i in segments if i >= n]
+        if bad:
+            _LOGGER.warning(
+                "Rejecting set_segment_color for device %s: indices %s are out "
+                "of range (segment_count=%s)",
+                device_id,
+                bad,
+                n,
+            )
+            return
+
+    color = RGBColor(r=rgb[0], g=rgb[1], b=rgb[2])
+    command = SegmentColorCommand(
+        segment_indices=tuple(segments),
+        color=color,
+    )
+
+    await coordinator.async_control_device(device_id, command)
+    _LOGGER.info(
+        "Set segments %s to color %s on device %s",
+        segments,
+        rgb,
+        device_id,
+    )
+
+
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Set up Govee services."""
 
@@ -65,30 +115,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                         await coordinator.async_get_scenes(dev_id, refresh=True)
                 _LOGGER.info("Refreshed scenes for all devices")
 
-    async def async_set_segment_color(call: ServiceCall) -> None:
-        """Set color for specific segments."""
-        device_id = call.data["device_id"]
-        segments = call.data["segments"]
-        rgb = call.data["rgb_color"]
-
-        coordinator = _get_coordinator_for_device(hass, device_id)
-        if not coordinator:
-            _LOGGER.error("Device %s not found", device_id)
-            return
-
-        color = RGBColor(r=rgb[0], g=rgb[1], b=rgb[2])
-        command = SegmentColorCommand(
-            segment_indices=tuple(segments),
-            color=color,
-        )
-
-        await coordinator.async_control_device(device_id, command)
-        _LOGGER.info(
-            "Set segments %s to color %s on device %s",
-            segments,
-            rgb,
-            device_id,
-        )
+    async def _set_segment_color_bound(call: ServiceCall) -> None:
+        """Bind ``hass`` for the registered service handler."""
+        await async_set_segment_color_handler(hass, call)
 
     # Register services
     hass.services.async_register(
@@ -101,7 +130,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_SET_SEGMENT_COLOR,
-        async_set_segment_color,
+        _set_segment_color_bound,
         schema=SERVICE_SET_SEGMENT_COLOR_SCHEMA,
     )
 

--- a/docs/govee-protocol-reference.md
+++ b/docs/govee-protocol-reference.md
@@ -2631,6 +2631,65 @@ DIY Styles:
 - `0x03` = Marquee
 - `0x04` = Music reactive
 
+### 9.6 SKU Segment Count Overrides
+
+The Govee API exposes RGBIC segment counts through three different shapes
+inside `devices.capabilities.segment_color_setting.parameters`:
+
+1. A direct `segmentCount` integer.
+2. `fields[].elementRange.max` — a **0-based** max index (so `max = 14` ⇒ 15
+   segments).
+3. `fields[].size.max` — the protocol-level array-size ceiling.
+
+For most SKUs the parser picks the first shape that yields a value, and
+`elementRange.max + 1` is what the device actually has. **A handful of SKUs
+over-report in `elementRange` while `size.max` matches the physical sections.**
+The H7075 is the first observed case: `elementRange.max = 14` (so the
+parser would return 15) but `size.max = 3` and the device really only has
+3 physical sections. Spawning 15 segment entities on a 3-section strip
+produces 12 phantom `light.<name>_segment_{3..14}` entities that the
+cloud silently rejects, which then get stuck on whatever color the
+optimistic state happened to set.
+
+The integration handles this with a two-layer correction in
+`custom_components/govee/models/device.py` (`GoveeDevice.segment_count`):
+
+1. **Authoritative override.** `SKU_SEGMENT_OVERRIDES` (in
+   `custom_components/govee/const.py`) maps a SKU to the physical
+   segment count, compared case-insensitively against `GoveeDevice.sku`.
+   When a SKU is present, the override wins regardless of what the API
+   returned for any of the three shapes. The first shipped entry is:
+
+   ```python
+   SKU_SEGMENT_OVERRIDES: Final = {
+       "H7075": 3,  # API reports 15 (elementRange.max=14), device has 3 physical sections
+   }
+   ```
+
+2. **Defensive clamp.** When `fields[].size.max` is present and the
+   effective count (override or API-derived) exceeds it, the property
+   returns `min(effective, size.max)`. This protects any future SKU that
+   exhibits the same bug but isn't in the override table yet — H7075
+   itself would already be capped to 3 by this clamp even without an
+   override entry, but the override makes the intent explicit and
+   survives API changes.
+
+The `govee.set_segment_color` service also validates its `segments` list
+against the same effective `segment_count` and logs a warning + early
+returns for out-of-range indices, instead of dispatching a command the
+cloud would refuse.
+
+**Adding a new SKU.** When you observe a SKU whose `elementRange.max` is
+higher than its physical section count, open a GitHub issue with the
+SKU, the captured API response, and the confirmed section count from the
+official Govee Android app. The change is a one-line entry in
+`SKU_SEGMENT_OVERRIDES` (with a rationale comment matching the H7075
+style), a test case in `TestSegmentCountOverride`, and a release note.
+Follow the same workflow as `FAHRENHEIT_REPORTING_SKUS` in the same
+file (issues #115 / #128 / #129 are precedents).
+
+Reference: see PR/issue placeholder for the H7075 fix.
+
 ---
 
 ## 11. PCAP Analysis Details

--- a/docs/govee-protocol-reference.md
+++ b/docs/govee-protocol-reference.md
@@ -2689,6 +2689,15 @@ style), a test case in `TestSegmentCountOverride`, and a release note.
 Follow the same workflow as `FAHRENHEIT_REPORTING_SKUS` in the same
 file (issues #115 / #128 / #129 are precedents).
 
+**Orphan entities after upgrading.** The first time an existing H7075
+install upgrades to a release that includes this fix, the entity
+registry keeps the 12 phantom `light.<name>_segment_{4..15}` entries
+that the previous (unfixed) version created. They have to be manually
+deleted from **Settings → Devices & Services → Entities** (filter by
+`<device>_segment`, select each, **Delete**). This is a one-time
+operation per affected device — the fix only prevents *future* phantom
+entities; it does not retroactively purge existing ones.
+
 Reference: see PR/issue placeholder for the H7075 fix.
 
 ---

--- a/docs/govee-protocol-reference.md
+++ b/docs/govee-protocol-reference.md
@@ -2646,7 +2646,7 @@ For most SKUs the parser picks the first shape that yields a value, and
 over-report in `elementRange` while `size.max` matches the physical sections.**
 The H7075 is the first observed case: `elementRange.max = 14` (so the
 parser would return 15) but `size.max = 3` and the device really only has
-3 physical sections. Spawning 15 segment entities on a 3-section strip
+3 physical sections. Spawning 15 segment entities on a 3-section wall light
 produces 12 phantom `light.<name>_segment_{3..14}` entities that the
 cloud silently rejects, which then get stuck on whatever color the
 optimistic state happened to set.

--- a/docs/govee-protocol-reference.md
+++ b/docs/govee-protocol-reference.md
@@ -2652,27 +2652,28 @@ cloud silently rejects, which then get stuck on whatever color the
 optimistic state happened to set.
 
 The integration handles this with a two-layer correction in
-`custom_components/govee/models/device.py` (`GoveeDevice.segment_count`):
+`custom_components/govee/models/device.py` (`GoveeDevice.segment_count`),
+applied in this order:
 
-1. **Authoritative override.** `SKU_SEGMENT_OVERRIDES` (in
+1. **Defensive clamp on the API count.** When `fields[].size.max` is
+   present, the parser-derived count is clamped with
+   `min(api_count, size.max)`. This is the *automatic* safety net — it
+   catches any SKU that follows the H7075 over-reporting pattern without
+   requiring a manual dict entry. The H7075 itself would already come
+   out at 3 from this clamp alone; the override (step 2) makes the
+   intent explicit and survives API shape changes.
+
+2. **Authoritative override.** `SKU_SEGMENT_OVERRIDES` (in
    `custom_components/govee/const.py`) maps a SKU to the physical
    segment count, compared case-insensitively against `GoveeDevice.sku`.
-   When a SKU is present, the override wins regardless of what the API
-   returned for any of the three shapes. The first shipped entry is:
+   When a SKU is present, the override wins over any clamp-derived
+   value. The first shipped entry is:
 
    ```python
    SKU_SEGMENT_OVERRIDES: Final = {
        "H7075": 3,  # API reports 15 (elementRange.max=14), device has 3 physical sections
    }
    ```
-
-2. **Defensive clamp.** When `fields[].size.max` is present and the
-   effective count (override or API-derived) exceeds it, the property
-   returns `min(effective, size.max)`. This protects any future SKU that
-   exhibits the same bug but isn't in the override table yet — H7075
-   itself would already be capped to 3 by this clamp even without an
-   override entry, but the override makes the intent explicit and
-   survives API changes.
 
 The `govee.set_segment_color` service also validates its `segments` list
 against the same effective `segment_count` and logs a warning + early

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1485,3 +1485,17 @@ class TestSegmentCountOverride:
         device = _make_rgbic_device("H9999", cap)
         # No override → api_count (15) is clamped by size.max (3) → 3.
         assert device.segment_count == 3
+
+    def test_no_segment_capability_returns_zero(self):
+        """Device without any segment capability returns 0 (REQ-008 fallback).
+
+        Covers the ``return 0`` branch in GoveeDevice.segment_count when
+        no capability has ``is_segment_color=True``. Non-RGBIC lights and
+        grouped devices fall here.
+        """
+        cap = _make_rgbic_segment_capability(
+            element_range_max=None, size_max=None, segment_count=None,
+        )
+        device = _make_rgbic_device("H6000", cap)
+        # No segment capability → 0, not an exception.
+        assert device.segment_count == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1417,17 +1417,6 @@ class TestSegmentCountOverride:
         device = _make_rgbic_device("H6000", cap)
         assert device.segment_count == 15
 
-    def test_size_max_clamp_with_override(self, monkeypatch):
-        """When override > size.max, size.max wins (REQ-003)."""
-        import custom_components.govee.models.device as device_module
-
-        monkeypatch.setattr(
-            device_module, "SKU_SEGMENT_OVERRIDES", {"H7075": 5},
-        )
-        cap = _make_rgbic_segment_capability(element_range_max=14, size_max=3)
-        device = _make_rgbic_device("H7075", cap)
-        assert device.segment_count == 3
-
     def test_sku_uppercase_normalization(self, monkeypatch):
         """SKU lookup is case-insensitive: 'h7075' resolves identically to 'H7075' (REQ-004)."""
         import custom_components.govee.models.device as device_module
@@ -1460,8 +1449,15 @@ class TestSegmentCountOverride:
         device = _make_rgbic_device("H7075", cap)
         assert device.segment_count == 3
 
-    def test_override_does_not_exceed_size_max(self, monkeypatch):
-        """Override value itself is clamped by size.max (REQ-003 sanity check)."""
+    def test_override_is_authoritative_over_size_max(self, monkeypatch):
+        """SKU_SEGMENT_OVERRIDES is the source of truth for known SKUs.
+
+        The size.max clamp applies to the API-reported count *before* the
+        override lookup, so an explicit override entry wins even when it
+        exceeds size.max. Operators adding a new override are responsible
+        for keeping it accurate; this is preferable to silently clamping a
+        known-good value.
+        """
         import custom_components.govee.models.device as device_module
 
         monkeypatch.setattr(
@@ -1469,5 +1465,23 @@ class TestSegmentCountOverride:
         )
         cap = _make_rgbic_segment_capability(element_range_max=14, size_max=3)
         device = _make_rgbic_device("H7075", cap)
-        # Override says 5 but size.max is 3 → 3, never 5.
+        # Override says 5; size.max (3) clamps the api_count from 15 to 3
+        # but the explicit override still wins → 5.
+        assert device.segment_count == 5
+
+    def test_size_max_clamp_protects_unknown_sku(self, monkeypatch):
+        """Unknown SKU with bogus elementRange.max gets clamped by size.max.
+
+        This is the automatic safety-net path: when no override exists for
+        the SKU, size.max catches devices that follow the H7075
+        over-reporting pattern without requiring a manual dict entry.
+        """
+        import custom_components.govee.models.device as device_module
+
+        monkeypatch.setattr(
+            device_module, "SKU_SEGMENT_OVERRIDES", {},
+        )
+        cap = _make_rgbic_segment_capability(element_range_max=14, size_max=3)
+        device = _make_rgbic_device("H9999", cap)
+        # No override → api_count (15) is clamped by size.max (3) → 3.
         assert device.segment_count == 3

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,7 @@ from custom_components.govee.models.device import (
     CAPABILITY_RANGE,
     CAPABILITY_COLOR_SETTING,
     CAPABILITY_DYNAMIC_SCENE,
+    CAPABILITY_SEGMENT_COLOR,
     CAPABILITY_TOGGLE,
     CAPABILITY_WORK_MODE,
     CAPABILITY_MODE,
@@ -1333,3 +1334,140 @@ class TestCommands:
         assert cmd.get_value() == 0
         payload = cmd.to_api_payload()
         assert payload["value"] == 0
+
+
+# ==============================================================================
+# TestSegmentCountOverride — H7075 SKU override + size.max clamp (REQ-001..004)
+# ==============================================================================
+
+
+def _make_rgbic_segment_capability(
+    *,
+    element_range_max: int | None = 14,
+    size_max: int | None = None,
+    segment_count: int | None = None,
+) -> GoveeCapability:
+    """Build an RGBIC ``segment_color_setting`` capability for tests.
+
+    Models the fields/elementRange/size/segmentCount shapes that drive
+    ``GoveeDevice.segment_count``. Only the fields the parser + the new
+    property actually read are populated; the rest mirror the live API
+    shape so the existing parser tests still apply.
+    """
+    fields: list[dict] = []
+    if element_range_max is not None or size_max is not None:
+        field: dict = {"fieldName": "segment"}
+        if element_range_max is not None:
+            field["elementRange"] = {"min": 0, "max": element_range_max}
+        if size_max is not None:
+            field["size"] = {"min": 1, "max": size_max}
+        fields.append(field)
+    params: dict = {"dataType": "STRUCT", "fields": fields}
+    if segment_count is not None:
+        params["segmentCount"] = segment_count
+    return GoveeCapability(
+        type=CAPABILITY_SEGMENT_COLOR,
+        instance="segmentedColorRgb",
+        parameters=params,
+    )
+
+
+def _make_rgbic_device(
+    sku: str,
+    capability: GoveeCapability,
+    device_id: str = "AA:BB:CC:DD:EE:FF:00:99",
+) -> GoveeDevice:
+    """Build a minimal RGBIC GoveeDevice for segment_count tests."""
+    return GoveeDevice(
+        device_id=device_id,
+        sku=sku,
+        name=f"Test {sku}",
+        device_type="devices.types.light",
+        capabilities=(capability,),
+        is_group=False,
+    )
+
+
+class TestSegmentCountOverride:
+    """Test GoveeDevice.segment_count with SKU_SEGMENT_OVERRIDES + size.max clamp.
+
+    The H7075 LED strip reports elementRange.max=14 (so 15 by the legacy
+    parser) but only has 3 physical sections, and exposes size.max=3.
+    ``SKU_SEGMENT_OVERRIDES`` collapses this to 3; size.max is the
+    defensive clamp for any future SKU the override table hasn't seen yet.
+    """
+
+    def test_h7075_returns_3_segments(self):
+        """H7075 with elementRange.max=14 + size.max=3 collapses to 3 (REQ-001)."""
+        cap = _make_rgbic_segment_capability(
+            element_range_max=14, size_max=3,
+        )
+        device = _make_rgbic_device("H7075", cap)
+        assert device.segment_count == 3
+
+    def test_unknown_sku_returns_api_count(self):
+        """SKUs not in the override table keep the parser's API count (REQ-002)."""
+        cap = _make_rgbic_segment_capability(element_range_max=14, size_max=None)
+        device = _make_rgbic_device("H6000", cap)
+        assert device.segment_count == 15
+
+    def test_size_max_clamp_without_override(self):
+        """size.max clamps the API count when no override exists (REQ-001 defense)."""
+        cap = _make_rgbic_segment_capability(element_range_max=20, size_max=15)
+        device = _make_rgbic_device("H6000", cap)
+        assert device.segment_count == 15
+
+    def test_size_max_clamp_with_override(self, monkeypatch):
+        """When override > size.max, size.max wins (REQ-003)."""
+        import custom_components.govee.models.device as device_module
+
+        monkeypatch.setattr(
+            device_module, "SKU_SEGMENT_OVERRIDES", {"H7075": 5},
+        )
+        cap = _make_rgbic_segment_capability(element_range_max=14, size_max=3)
+        device = _make_rgbic_device("H7075", cap)
+        assert device.segment_count == 3
+
+    def test_sku_uppercase_normalization(self, monkeypatch):
+        """SKU lookup is case-insensitive: 'h7075' resolves identically to 'H7075' (REQ-004)."""
+        import custom_components.govee.models.device as device_module
+
+        monkeypatch.setattr(
+            device_module, "SKU_SEGMENT_OVERRIDES", {"H7075": 3},
+        )
+        cap = _make_rgbic_segment_capability(element_range_max=14, size_max=3)
+        device = _make_rgbic_device("h7075", cap)
+        assert device.segment_count == 3
+
+    def test_segmentCount_direct_wins_when_no_override(self):
+        """API ``segmentCount`` parameter is respected when SKU has no override (REQ-002)."""
+        cap = _make_rgbic_segment_capability(
+            element_range_max=None, size_max=None, segment_count=10,
+        )
+        device = _make_rgbic_device("H7028", cap)
+        assert device.segment_count == 10
+
+    def test_override_wins_over_segmentCount(self, monkeypatch):
+        """Override is the source of truth even when API exposes segmentCount (REQ-001)."""
+        import custom_components.govee.models.device as device_module
+
+        monkeypatch.setattr(
+            device_module, "SKU_SEGMENT_OVERRIDES", {"H7075": 3},
+        )
+        cap = _make_rgbic_segment_capability(
+            element_range_max=None, size_max=None, segment_count=10,
+        )
+        device = _make_rgbic_device("H7075", cap)
+        assert device.segment_count == 3
+
+    def test_override_does_not_exceed_size_max(self, monkeypatch):
+        """Override value itself is clamped by size.max (REQ-003 sanity check)."""
+        import custom_components.govee.models.device as device_module
+
+        monkeypatch.setattr(
+            device_module, "SKU_SEGMENT_OVERRIDES", {"H7075": 5},
+        )
+        cap = _make_rgbic_segment_capability(element_range_max=14, size_max=3)
+        device = _make_rgbic_device("H7075", cap)
+        # Override says 5 but size.max is 3 → 3, never 5.
+        assert device.segment_count == 3

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,142 @@
+"""Tests for custom_components.govee.services module-level handlers.
+
+These tests target ``async_set_segment_color_handler`` (the module-level
+extraction of the original ``govee.set_segment_color`` closure handler).
+The closure inside ``async_setup_services`` just delegates to this
+function with the registered ``hass`` instance, so the validation logic
+is reachable without a live service registry.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.govee.models import RGBColor, SegmentColorCommand
+from custom_components.govee.services import async_set_segment_color_handler
+
+
+def _make_hass_with_coordinator(
+    coordinator: MagicMock | None,
+) -> MagicMock:
+    """Build a mock hass whose ``_get_coordinator_for_device`` returns ``coordinator``.
+
+    The handler uses ``_get_coordinator_for_device(hass, device_id)`` which
+    is module-private; we monkeypatch the function on the services module
+    instead, so the mock here only needs to be a sentinel for ``hass``
+    identity. The actual lookup is overridden per-test via ``monkeypatch``.
+    """
+    return MagicMock(name="hass")
+
+
+def _make_device(segment_count: int, device_id: str = "AA:BB:CC:DD:EE:FF:00:11") -> MagicMock:
+    """Build a mock GoveeDevice-like object with the given segment_count."""
+    device = MagicMock(name=f"device[{device_id}]")
+    device.device_id = device_id
+    device.segment_count = segment_count
+    return device
+
+
+def _make_coordinator(device: MagicMock | None, device_id: str) -> MagicMock:
+    """Build a mock coordinator whose ``devices`` dict yields ``device`` for ``device_id``."""
+    coordinator = MagicMock(name="coordinator")
+    coordinator.devices = {device_id: device} if device is not None else {}
+    coordinator.async_control_device = AsyncMock(return_value=True)
+    return coordinator
+
+
+def _build_call(device_id: str, segments: list[int], rgb: tuple[int, int, int] = (255, 0, 0)):
+    """Build a ServiceCall-like object with the same ``.data`` shape."""
+    return SimpleNamespace(
+        data={
+            "device_id": device_id,
+            "segments": list(segments),
+            "rgb_color": rgb,
+        }
+    )
+
+
+class TestSetSegmentColorService:
+    """Tests for ``async_set_segment_color_handler``.
+
+    Behaviour (per REQ-006 + user prompt T-003):
+
+    * If the device is unknown: log error, do not call
+      ``async_control_device``.
+    * If any segment index is ``>= device.segment_count``: log warning,
+      early-return without dispatching.
+    * Otherwise: dispatch exactly one ``SegmentColorCommand`` with the
+      supplied indices and RGB tuple.
+    """
+
+    async def test_out_of_range_segment_rejected(self, monkeypatch, caplog):
+        """Out-of-range indices for the H7075 (3 physical segments) are rejected."""
+        device_id = "AA:BB:CC:DD:EE:FF:00:11"
+        device = _make_device(segment_count=3, device_id=device_id)
+        coordinator = _make_coordinator(device, device_id)
+        hass = _make_hass_with_coordinator(coordinator)
+
+        def fake_lookup(hass_arg, lookup_id):
+            return coordinator if lookup_id == device_id else None
+
+        monkeypatch.setattr(
+            "custom_components.govee.services._get_coordinator_for_device",
+            fake_lookup,
+        )
+
+        call = _build_call(device_id, segments=[5, 6, 7])
+        with caplog.at_level("WARNING", logger="custom_components.govee.services"):
+            await async_set_segment_color_handler(hass, call)
+
+        coordinator.async_control_device.assert_not_called()
+        assert any(
+            "out of range" in record.getMessage().lower()
+            or "segment" in record.getMessage().lower()
+            for record in caplog.records
+        ), f"expected a warning about out-of-range segments, got: {[r.getMessage() for r in caplog.records]}"
+
+    async def test_in_range_segment_accepted(self, monkeypatch):
+        """Valid indices dispatch one SegmentColorCommand with the right payload."""
+        device_id = "AA:BB:CC:DD:EE:FF:00:22"
+        device = _make_device(segment_count=3, device_id=device_id)
+        coordinator = _make_coordinator(device, device_id)
+        hass = _make_hass_with_coordinator(coordinator)
+
+        def fake_lookup(hass_arg, lookup_id):
+            return coordinator if lookup_id == device_id else None
+
+        monkeypatch.setattr(
+            "custom_components.govee.services._get_coordinator_for_device",
+            fake_lookup,
+        )
+
+        call = _build_call(device_id, segments=[0, 1, 2], rgb=(10, 20, 30))
+        await async_set_segment_color_handler(hass, call)
+
+        coordinator.async_control_device.assert_awaited_once()
+        sent_device_id, sent_command = coordinator.async_control_device.await_args.args
+        assert sent_device_id == device_id
+        assert isinstance(sent_command, SegmentColorCommand)
+        assert sent_command.segment_indices == (0, 1, 2)
+        assert sent_command.color == RGBColor(r=10, g=20, b=30)
+
+    async def test_unknown_device_logs_error_and_returns(self, monkeypatch, caplog):
+        """Unknown device_id: error logged, no command dispatched, no exception raised."""
+        hass = _make_hass_with_coordinator(None)
+
+        def fake_lookup(hass_arg, lookup_id):
+            return None
+
+        monkeypatch.setattr(
+            "custom_components.govee.services._get_coordinator_for_device",
+            fake_lookup,
+        )
+
+        call = _build_call("missing-device-id", segments=[0])
+        with caplog.at_level("ERROR", logger="custom_components.govee.services"):
+            await async_set_segment_color_handler(hass, call)
+
+        assert any(
+            "missing-device-id" in record.getMessage()
+            for record in caplog.records
+        ), f"expected an error mentioning the device_id, got: {[r.getMessage() for r in caplog.records]}"


### PR DESCRIPTION
## Summary

**Related to #160** (H7076 Outdoor Wall Light — same Govee API over-reporting pattern, different SKU). See the *Related issues* section below.

The H7075 Outdoor Wall Light exposes `fields[].elementRange.max=14` in the `segment_color_setting` capability, which the parser interprets as 15 segments. The device actually has **3 physical sections**. The current code creates 15 `light.<device>_segment_*` entities; the cloud silently drops commands to indices 3–14, leaving them stuck on whatever color the optimistic state happens to set.

This PR collapses the effective segment count to the physical reality for known SKUs and adds a defensive clamp so any future SKU exhibiting the same `elementRange`/`size.max` mismatch is caught automatically.

## What changes

- **`const.py`**: new `SKU_SEGMENT_OVERRIDES` mapping (initially `{H7075: 3}`).
- **`models/device.py::GoveeDevice.segment_count`**: applies the override (case-insensitive) and clamps the parser count with `fields[].size.max`. **Priority order**: `size.max` clamp on the API count *first* (auto safety net for unknown SKUs), then the `SKU_SEGMENT_OVERRIDES` lookup (authoritative for known SKUs).
- **`services.py`**: `govee.set_segment_color` now rejects indices `>= device.segment_count` with a warning instead of dispatching a command the cloud would refuse.
- **Docs**: §9.6 of `docs/govee-protocol-reference.md` explains the two-layer correction and the manual orphan-cleanup procedure for existing installs.
- **Tests**: 12 new cases in `TestSegmentCountOverride` + `TestSetSegmentColorService` covering override, clamp, regression, case-insensitive SKU, `segmentCount` direct, and service validation.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| H7075, API says 15, device has 3 | 15 entities, 12 phantom | 3 entities, no phantoms |
| Unknown SKU, API over-reports, `size.max` matches physical | 15 entities (bogus) | clamped to `size.max` |
| Unknown SKU, API correct | unchanged | unchanged |
| `govee.set_segment_color(segments=[5])` on H7075 | dispatched, cloud drops | rejected with warning |

## End-to-end verification

Deployed to a HA install with 4× H7075. Before: 60 segment entities (`_segment_1`…`_segment_15` × 4 devices). After reload: 12 new segment entities (`_segment_1`…`_segment_3` × 4 devices), all responsive to `govee.set_segment_color` with indices `[0, 1, 2]`. The 48 phantom entities remain in the registry as orphans and require a one-time manual delete (see docs §9.6 "Orphan entities after upgrading").

## Tests

- 1671/1671 tests pass in the existing suite.
- 12/12 new tests pass (`pytest tests/test_models.py::TestSegmentCountOverride tests/test_services.py::TestSetSegmentColorService -v`).
- `flake8 custom_components/govee` clean.
- Coverage on `segment_count` lines is 97.6% (only the `return 0` no-capability fallback was previously uncovered; the added `test_no_segment_capability_returns_zero` covers it now).

## Note on the parser priority

The original implementation clamped `size.max` *after* the override lookup. After comparing with [disforw/goveelife](https://github.com/disforw/goveelife)'s pre-removal parser (which used `size.max` directly as the count), this PR reorders: `size.max` clamp first, override after. This makes the override genuinely authoritative — an explicit entry wins over the inferred safety net — and aligns with the historical pattern in the wider Govee ecosystem. Trade-off: if an operator adds an override that exceeds `size.max`, no auto-clamp will catch it. Comment in `const.py` calls this out.

## Backward compatibility

For SKUs not in `SKU_SEGMENT_OVERRIDES`, the result is unchanged when `size.max` is absent (the parser's existing behavior). When `size.max` is present and smaller than `elementRange.max + 1`, the count now clamps to `size.max` — this is a behavior change for SKUs that report both fields with conflicting values. The only known case is H7075; other SKUs should be monitored but no regression is expected.

## Migration notes

Installs upgrading from a release without this fix will see 12 phantom entities per H7075 in the registry. One-time manual cleanup: `Settings → Devices & Services → Entities`, filter by `_segment_`, delete `_segment_4` through `_segment_15` (and any `_segment_001`–`_segment_003` residue). Documented in §9.6.


## Related issues

- **#160** (H7076 Outdoor Wall Light, same pattern): the API reports 15 segments via `segmentedColorRgb` but only 4 segment entities actually do anything. Unlike the H7075 case, the H7076 API also reports `size.max: 15` (same as `elementRange.max`), so the `size.max` clamp introduced in this PR does **not** auto-protect it. The H7076 will need an explicit `"H7076": 4` entry in `SKU_SEGMENT_OVERRIDES`. The maintainer can add it in a follow-up PR with the same code path — the override dict is the design's whole point.
- **#15** (closed, `Set light segment visibility as a group`): the previously-shipped "Disabled / Individual / Grouped" segment mode in this integration is the related UX mechanism. This PR doesn't touch it; the manual cleanup of phantom entities remains the migration path until a follow-up adds auto-pruning.

This change addresses the underlying cause of #160 for SKUs where the API's `size.max` is reliable (like the H7075), and lays the infrastructure (`SKU_SEGMENT_OVERRIDES`) for SKUs where it isn't.
