### PR TITLE
feat(sensor): add per-device connection mode diagnostic sensor

### DIFF
--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -38,7 +38,7 @@ from .const import (
 )
 from .coordinator import GoveeCoordinator
 from .entity import GoveeEntity
-from .models import GoveeDevice
+from .models import GoveeDevice, TransportKind
 from .models.device import GoveeLeakSensor, leak_sensor_device_info
 
 try:  # HA >= 2026.7 (CONCENTRATION_PARTS_PER_MILLION is deprecated there)
@@ -53,6 +53,15 @@ except ImportError:  # hacs.json still declares 2024.11.0 as the minimum
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+_PRIORITY_ORDER: tuple[TransportKind, ...] = ("ble", "lan", "mqtt", "cloud_api")
+_ICON_BY_VALUE: dict[str, str] = {
+    "lan": "mdi:lan",
+    "mqtt": "mdi:cloud-sync",
+    "cloud_api": "mdi:cloud",
+    "ble": "mdi:bluetooth",
+    "unavailable": "mdi:lan-pending",
+}
 
 
 async def async_setup_entry(
@@ -77,6 +86,7 @@ async def async_setup_entry(
     # corresponding `property` capability gets the entity, regardless of
     # device_type — the integration shouldn't have to know about every SKU.
     for device in coordinator.devices.values():
+        entities.append(GoveeConnectionModeSensor(coordinator, device))
         if device.is_group:
             continue
         # Per-device connectivity diagnostics for every physical device:
@@ -580,6 +590,59 @@ class GoveeLastCommandSentSensor(GoveeEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:
         return self.coordinator.device_last_command_sent(self._device.device_id)
+
+
+class GoveeConnectionModeSensor(GoveeEntity, SensorEntity):
+    """Show the best currently reachable transport for a device."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "connection_mode"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["lan", "mqtt", "cloud_api", "ble", "unavailable"]
+
+    def __init__(self, coordinator: GoveeCoordinator, device: GoveeDevice) -> None:
+        """Initialize the connection-mode sensor."""
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.device_id}_connection_mode"
+
+    @property
+    def native_value(self) -> str:
+        """Return the highest-priority transport currently available."""
+        if self._device.is_group:
+            health = self.coordinator.get_transport_health(self._device_id, "cloud_api")
+            return "cloud_api" if health is not None and health.is_available else "unavailable"
+
+        for kind in _PRIORITY_ORDER:
+            health = self.coordinator.get_transport_health(self._device_id, kind)
+            if health is not None and health.is_available:
+                return kind
+        return "unavailable"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon for the current connection mode."""
+        return _ICON_BY_VALUE[self.native_value]
+
+    @property
+    def available(self) -> bool:
+        """Return availability based only on coordinator health."""
+        return self.coordinator.last_update_success
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return bridge identity and the time of the latest evaluation."""
+        attrs = {"last_evaluated_at": datetime.now(timezone.utc).isoformat()}
+        if self._device.hub_device_id:
+            attrs["via_gateway"] = self._device.hub_device_id
+            return attrs
+
+        route = self.coordinator.gateway_route(self._device_id)
+        if route:
+            gateway_device = route.get("device")
+            if gateway_device:
+                attrs["via_gateway"] = gateway_device
+        return attrs
 
 
 class GoveeLeakBatterySensor(SensorEntity):

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -38,7 +38,7 @@ from .const import (
 )
 from .coordinator import GoveeCoordinator
 from .entity import GoveeEntity
-from .models import GoveeDevice, TransportKind
+from .models import GoveeDevice, TransportHealth, TransportKind
 from .models.device import GoveeLeakSensor, leak_sensor_device_info
 
 try:  # HA >= 2026.7 (CONCENTRATION_PARTS_PER_MILLION is deprecated there)
@@ -62,6 +62,16 @@ _ICON_BY_VALUE: dict[str, str] = {
     "ble": "mdi:bluetooth",
     "unavailable": "mdi:lan-pending",
 }
+
+
+def _is_delivering(health: TransportHealth | None) -> bool:
+    """True only when ``is_available`` AND ``last_success_ts`` is set.
+
+    MQTT, for example, marks itself available on broker connect even for
+    devices that never push state — without the timestamp gate the sensor
+    would surface a transport the device is not actually using.
+    """
+    return health is not None and health.is_available and health.last_success_ts is not None
 
 
 async def async_setup_entry(
@@ -608,14 +618,22 @@ class GoveeConnectionModeSensor(GoveeEntity, SensorEntity):
 
     @property
     def native_value(self) -> str:
-        """Return the highest-priority transport currently available."""
+        """Return the highest-priority transport currently delivering state.
+
+        ``is_available`` alone is insufficient — MQTT marks itself available
+        on broker connect even for devices that never push state. We require
+        a ``last_success_ts`` stamp so the surfaced transport has actually
+        delivered state for this device.
+        """
         if self._device.is_group:
-            health = self.coordinator.get_transport_health(self._device_id, "cloud_api")
-            return "cloud_api" if health is not None and health.is_available else "unavailable"
+            return (
+                "cloud_api"
+                if _is_delivering(self.coordinator.get_transport_health(self._device_id, "cloud_api"))
+                else "unavailable"
+            )
 
         for kind in _PRIORITY_ORDER:
-            health = self.coordinator.get_transport_health(self._device_id, kind)
-            if health is not None and health.is_available:
+            if _is_delivering(self.coordinator.get_transport_health(self._device_id, kind)):
                 return kind
         return "unavailable"
 

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -698,8 +698,25 @@ class GoveeConnectionModeSensor(GoveeEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:
-        """Return bridge identity and the time of the latest evaluation."""
-        attrs = {"last_evaluated_at": datetime.now(timezone.utc).isoformat()}
+        """Return bridge identity and when the reported transport last delivered.
+
+        ``last_delivered_at`` is the chosen transport's own
+        ``last_success_ts``, not the time this property happened to be read.
+        That distinction matters more than it looks: Home Assistant evaluates
+        attributes on every state write and treats any change as a new state,
+        so a value of "now" would record a fresh row for every device on every
+        poll — forever, and carrying no information. Reading the transport's
+        stamp means the attribute changes only when data actually arrives,
+        which is also the thing a user wants to know.
+        """
+        attrs: dict[str, str] = {}
+
+        mode = self.native_value
+        if mode != "unavailable":
+            health = self.coordinator.get_transport_health(self._device_id, mode)
+            if health is not None and health.last_success_ts is not None:
+                attrs["last_delivered_at"] = health.last_success_ts.isoformat()
+
         if self._device.hub_device_id:
             attrs["via_gateway"] = self._device.hub_device_id
             return attrs

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -248,6 +248,16 @@
       "leak_alert_status": {
         "name": "Alert Status"
       },
+      "connection_mode": {
+        "name": "Connection Mode",
+        "state": {
+          "lan": "LAN",
+          "mqtt": "MQTT",
+          "cloud_api": "Cloud API",
+          "ble": "Bluetooth",
+          "unavailable": "Unavailable"
+        }
+      },
       "ieee_address": {
         "name": "IEEE Address"
       }

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -248,6 +248,16 @@
       "leak_alert_status": {
         "name": "Alert Status"
       },
+      "connection_mode": {
+        "name": "Connection Mode",
+        "state": {
+          "lan": "LAN",
+          "mqtt": "MQTT",
+          "cloud_api": "Cloud API",
+          "ble": "Bluetooth",
+          "unavailable": "Unavailable"
+        }
+      },
       "ieee_address": {
         "name": "IEEE Address"
       }

--- a/tests/test_connection_mode_sensor.py
+++ b/tests/test_connection_mode_sensor.py
@@ -37,7 +37,23 @@ def _device(
 
 
 def _health(**available: bool) -> dict[str, TransportHealth]:
-    return {kind: TransportHealth(transport=kind, is_available=available.get(kind, False)) for kind in _TRANSPORTS}
+    now = datetime.now(timezone.utc)
+    return {
+        kind: TransportHealth(
+            transport=kind,
+            is_available=available.get(kind, False),
+            last_success_ts=now if available.get(kind, False) else None,
+        )
+        for kind in _TRANSPORTS
+    }
+
+
+def _spec(spec: dict[str, tuple[bool, datetime | None]]) -> dict[str, TransportHealth]:
+    """Build a health map from ``{transport: (is_available, last_success_ts)}``."""
+    return {
+        kind: TransportHealth(transport=kind, is_available=available, last_success_ts=ts)
+        for kind, (available, ts) in spec.items()
+    }
 
 
 def _coordinator(
@@ -241,6 +257,7 @@ async def test_refresh_happens_on_coordinator_tick_only() -> None:
     coordinator.async_add_listener(entity._handle_coordinator_update)
 
     health["mqtt"].is_available = True
+    health["mqtt"].last_success_ts = datetime.now(timezone.utc)
     assert entity.native_value == "mqtt"
     entity.async_write_ha_state.assert_not_called()
     coordinator.async_set_updated_data({device.device_id: GoveeDeviceState(device_id=device.device_id)})
@@ -289,3 +306,46 @@ def test_translation_entry_has_all_connection_mode_states() -> None:
         english = json.load(en_file)
     assert strings["entity"]["sensor"]["connection_mode"] == expected
     assert english["entity"]["sensor"]["connection_mode"] == expected
+
+
+def test_mqtt_connected_but_not_delivering_demotes_to_cloud_api() -> None:
+    """FIX-001: H7075 user case — MQTT available but cloud_api is the real deliverer."""
+    now = datetime.now(timezone.utc)
+    health = _spec(
+        {
+            "ble": (False, None),
+            "lan": (False, None),
+            "mqtt": (True, None),
+            "cloud_api": (True, now),
+        }
+    )
+    assert _sensor(_device(), health).native_value == "cloud_api"
+
+
+def test_mqtt_connected_but_only_lan_delivering_returns_lan() -> None:
+    """FIX-002: priority alone cannot win without a receive stamp."""
+    now = datetime.now(timezone.utc)
+    health = _spec(
+        {
+            "ble": (True, None),
+            "lan": (True, now),
+            "mqtt": (True, None),
+            "cloud_api": (True, None),
+        }
+    )
+    assert _sensor(_device(), health).native_value == "lan"
+
+
+def test_all_transports_unreachable_returns_unavailable() -> None:
+    """FIX-003: zero-reachability stays ``unavailable`` under the stricter gate."""
+    health = _spec(
+        {
+            "ble": (False, None),
+            "lan": (False, None),
+            "mqtt": (False, None),
+            "cloud_api": (False, None),
+        }
+    )
+    entity = _sensor(_device(), health)
+    assert entity.native_value == "unavailable"
+    assert entity.icon == "mdi:lan-pending"

--- a/tests/test_connection_mode_sensor.py
+++ b/tests/test_connection_mode_sensor.py
@@ -1,0 +1,291 @@
+"""Tests for the per-device connection-mode diagnostic sensor."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import EntityCategory
+
+from custom_components.govee.models import GoveeDevice, GoveeDeviceState, TransportHealth
+from custom_components.govee.sensor import GoveeConnectionModeSensor, async_setup_entry
+
+_TRANSPORTS = ("ble", "lan", "mqtt", "cloud_api")
+
+
+def _device(
+    device_id: str = "AA:BB:CC:DD:EE:FF:00:11",
+    *,
+    is_group: bool = False,
+    hub_device_id: str | None = "",
+) -> GoveeDevice:
+    """Build a minimal device for connection-mode tests."""
+    return GoveeDevice(
+        device_id=device_id,
+        sku="GROUP" if is_group else "H6072",
+        name="Test Device",
+        device_type="devices.types.group" if is_group else "devices.types.light",
+        capabilities=(),
+        is_group=is_group,
+        hub_device_id=hub_device_id,  # type: ignore[arg-type]
+    )
+
+
+def _health(**available: bool) -> dict[str, TransportHealth]:
+    return {kind: TransportHealth(transport=kind, is_available=available.get(kind, False)) for kind in _TRANSPORTS}
+
+
+def _coordinator(
+    device: GoveeDevice,
+    health: dict[str, TransportHealth] | None = None,
+    *,
+    online: bool = True,
+    last_update_success: bool = True,
+    route: dict[str, str] | None = None,
+) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.devices = {device.device_id: device}
+    coordinator.last_update_success = last_update_success
+    coordinator.get_state.return_value = GoveeDeviceState(device_id=device.device_id, online=online)
+    coordinator.gateway_route.return_value = route
+    health_by_kind = health or {}
+    coordinator.get_transport_health.side_effect = lambda _device_id, kind: health_by_kind.get(kind)
+    return coordinator
+
+
+def _sensor(
+    device: GoveeDevice,
+    health: dict[str, TransportHealth] | None = None,
+    **kwargs: Any,
+) -> GoveeConnectionModeSensor:
+    return GoveeConnectionModeSensor(_coordinator(device, health, **kwargs), device)
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_icon"),
+    [
+        pytest.param("lan", "mdi:lan", id="lan-only"),
+        pytest.param("ble", "mdi:bluetooth", id="ble-only"),
+        pytest.param("mqtt", "mdi:cloud-sync", id="mqtt-only"),
+        pytest.param("cloud_api", "mdi:cloud", id="cloud-only"),
+    ],
+)
+def test_single_available_transport_wins(kind: str, expected_icon: str) -> None:
+    """SCN-001..004: each transport is selected when it is the only healthy one."""
+    entity = _sensor(_device(), _health(**{kind: True}))
+    assert entity.native_value == kind
+    assert entity.icon == expected_icon
+
+
+def test_lan_beats_mqtt() -> None:
+    """SCN-005: LAN precedes MQTT in the command priority."""
+    assert _sensor(_device(), _health(lan=True, mqtt=True)).native_value == "lan"
+
+
+def test_ble_beats_lan_and_mqtt() -> None:
+    """SCN-006: BLE has the highest priority."""
+    assert _sensor(_device(), _health(ble=True, lan=True, mqtt=True)).native_value == "ble"
+
+
+def test_zero_reachability_returns_unavailable() -> None:
+    """SCN-007: tracked but failed transports produce the catch-all value."""
+    entity = _sensor(_device(), _health())
+    assert entity.native_value == "unavailable"
+    assert entity.icon == "mdi:lan-pending"
+
+
+def test_missing_health_entries_returns_unavailable() -> None:
+    """SCN-008: an unpopulated health tracker is unavailable."""
+    assert _sensor(_device()).native_value == "unavailable"
+
+
+@pytest.mark.parametrize(
+    ("health", "expected"),
+    [
+        pytest.param(_health(cloud_api=True), "cloud_api", id="reachable"),
+        pytest.param(_health(), "unavailable", id="unreachable"),
+        pytest.param(_health(ble=True, lan=True, mqtt=True), "unavailable", id="non-rest-ignored"),
+    ],
+)
+def test_group_uses_only_cloud_api(health: dict[str, TransportHealth], expected: str) -> None:
+    """SCN-009..011: groups never consult non-REST health."""
+    device = _device(is_group=True)
+    coordinator = _coordinator(device, health)
+    entity = GoveeConnectionModeSensor(coordinator, device)
+
+    assert entity.native_value == expected
+    coordinator.get_transport_health.assert_called_once_with(device.device_id, "cloud_api")
+
+
+def test_hub_device_id_is_exposed() -> None:
+    """SCN-012: the device-level bridge source wins."""
+    device = _device(hub_device_id="HUB_A")
+    entity = _sensor(device, _health(mqtt=True))
+    assert entity.native_value == "mqtt"
+    assert entity.extra_state_attributes["via_gateway"] == "HUB_A"
+
+
+def test_gateway_route_is_used_when_hub_id_is_missing() -> None:
+    """SCN-013: the route supplies the bridge identity as a fallback."""
+    device = _device(hub_device_id=None)
+    entity = _sensor(
+        device,
+        _health(mqtt=True),
+        route={"device": "HUB_ROUTE", "topic": "commands"},
+    )
+    assert entity.extra_state_attributes["via_gateway"] == "HUB_ROUTE"
+
+
+def test_hub_device_id_takes_precedence_over_route() -> None:
+    """SCN-014: BFF-style bridge metadata has precedence."""
+    device = _device(hub_device_id="HUB_A")
+    entity = _sensor(device, _health(mqtt=True), route={"device": "HUB_B"})
+    assert entity.extra_state_attributes["via_gateway"] == "HUB_A"
+
+
+def test_unbridged_device_omits_via_gateway() -> None:
+    """SCN-015: no bridge source means no bridge attribute."""
+    assert "via_gateway" not in _sensor(_device(hub_device_id=None), _health(mqtt=True)).extra_state_attributes
+
+
+def test_bridge_attribute_is_independent_of_transport() -> None:
+    """SCN-016: bridge identity remains when cloud API is the selected route."""
+    device = _device(hub_device_id="HUB_A")
+    entity = _sensor(device, _health(cloud_api=True))
+    assert entity.native_value == "cloud_api"
+    assert entity.extra_state_attributes["via_gateway"] == "HUB_A"
+
+
+def test_demoted_lan_is_skipped() -> None:
+    """SCN-017: a read-driven LAN demotion lets MQTT win."""
+    health = _health(mqtt=True)
+    health["lan"].last_failure_reason = "stale_lan"
+    assert _sensor(_device(), health).native_value == "mqtt"
+
+
+def test_last_evaluated_at_is_utc_iso_timestamp() -> None:
+    """SCN-018: the diagnostic timestamp is timezone-aware ISO 8601."""
+    timestamp = _sensor(_device(), _health(lan=True)).extra_state_attributes["last_evaluated_at"]
+    parsed = datetime.fromisoformat(timestamp)
+    assert parsed.utcoffset() == timedelta(0)
+    assert parsed <= datetime.now(timezone.utc) + timedelta(seconds=2)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_icon"),
+    [
+        ("lan", "mdi:lan"),
+        ("mqtt", "mdi:cloud-sync"),
+        ("cloud_api", "mdi:cloud"),
+        ("ble", "mdi:bluetooth"),
+        ("unavailable", "mdi:lan-pending"),
+    ],
+)
+def test_icon_matches_every_value(value: str, expected_icon: str) -> None:
+    """SCN-019: every enumerated value has its documented icon."""
+    health = _health(**{value: True}) if value != "unavailable" else _health()
+    entity = _sensor(_device(), health)
+    assert entity.native_value == value
+    assert entity.icon == expected_icon
+
+
+def test_entity_is_diagnostic_enum_without_state_class() -> None:
+    """SCN-020: classification is diagnostic, enumerated, and stateless."""
+    entity = _sensor(_device(), _health(lan=True))
+    assert entity.entity_category == EntityCategory.DIAGNOSTIC
+    assert entity.device_class == SensorDeviceClass.ENUM
+    assert entity.options == ["lan", "mqtt", "cloud_api", "ble", "unavailable"]
+    assert entity.state_class is None
+    assert entity.has_entity_name is True
+    assert entity.translation_key == "connection_mode"
+
+
+def test_available_ignores_device_online_flag() -> None:
+    """SCN-021: this diagnostic remains visible when the cloud state is offline."""
+    assert _sensor(_device(), _health(), online=False).available is True
+
+
+class _TickCoordinator:
+    def __init__(self, device: GoveeDevice, health: dict[str, TransportHealth]) -> None:
+        self.devices = {device.device_id: device}
+        self.last_update_success = True
+        self._health = health
+        self._listeners: list[Any] = []
+
+    def get_transport_health(self, _device_id: str, kind: str) -> TransportHealth | None:
+        return self._health.get(kind)
+
+    def async_add_listener(self, listener: Any) -> Any:
+        self._listeners.append(listener)
+        return lambda: self._listeners.remove(listener)
+
+    def async_set_updated_data(self, data: dict[str, Any]) -> None:
+        del data
+        for listener in tuple(self._listeners):
+            listener()
+
+
+@pytest.mark.asyncio
+async def test_refresh_happens_on_coordinator_tick_only() -> None:
+    """SCN-023: health changes render only through the coordinator listener."""
+    device = _device()
+    health = _health()
+    coordinator = _TickCoordinator(device, health)
+    entity = GoveeConnectionModeSensor(coordinator, device)  # type: ignore[arg-type]
+    entity.async_write_ha_state = MagicMock()
+    coordinator.async_add_listener(entity._handle_coordinator_update)
+
+    health["mqtt"].is_available = True
+    assert entity.native_value == "mqtt"
+    entity.async_write_ha_state.assert_not_called()
+    coordinator.async_set_updated_data({device.device_id: GoveeDeviceState(device_id=device.device_id)})
+    entity.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_creates_one_connection_mode_sensor_per_device() -> None:
+    """SCN-022: setup includes exactly one sensor for every physical and group device."""
+    devices = [_device(f"AA:BB:CC:DD:EE:FF:00:{i:02d}") for i in range(1, 4)] + [
+        _device(f"GROUP:{i}", is_group=True) for i in range(1, 3)
+    ]
+    coordinator = MagicMock()
+    coordinator.devices = {device.device_id: device for device in devices}
+    coordinator.mqtt_client = None
+    coordinator.leak_sensors = {}
+    coordinator.get_state.return_value = None
+    coordinator.is_bff_leak_sensor.return_value = False
+    coordinator.register_thermo_hubs = MagicMock()
+    coordinator.register_leak_hubs = MagicMock()
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added: list[Any] = []
+
+    await async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities))
+    connection_sensors = [e for e in added if isinstance(e, GoveeConnectionModeSensor)]
+    assert len(connection_sensors) == len(devices)
+    assert {e.unique_id for e in connection_sensors} == {f"{d.device_id}_connection_mode" for d in devices}
+
+
+def test_translation_entry_has_all_connection_mode_states() -> None:
+    """SCN-024: source and English translation register all five values."""
+    base = Path(__file__).resolve().parent.parent / "custom_components" / "govee"
+    expected = {
+        "name": "Connection Mode",
+        "state": {
+            "lan": "LAN",
+            "mqtt": "MQTT",
+            "cloud_api": "Cloud API",
+            "ble": "Bluetooth",
+            "unavailable": "Unavailable",
+        },
+    }
+    with (base / "strings.json").open() as strings_file, (base / "translations/en.json").open() as en_file:
+        strings = json.load(strings_file)
+        english = json.load(en_file)
+    assert strings["entity"]["sensor"]["connection_mode"] == expected
+    assert english["entity"]["sensor"]["connection_mode"] == expected

--- a/tests/test_connection_mode_sensor.py
+++ b/tests/test_connection_mode_sensor.py
@@ -184,12 +184,46 @@ def test_demoted_lan_is_skipped() -> None:
     assert _sensor(_device(), health).native_value == "mqtt"
 
 
-def test_last_evaluated_at_is_utc_iso_timestamp() -> None:
-    """SCN-018: the diagnostic timestamp is timezone-aware ISO 8601."""
-    timestamp = _sensor(_device(), _health(lan=True)).extra_state_attributes["last_evaluated_at"]
+def test_last_delivered_at_is_the_transports_own_timestamp() -> None:
+    """SCN-018: the attribute reports when the transport last delivered.
+
+    Not when the attribute happened to be read. Home Assistant evaluates
+    attributes on every state write and treats any change as a new state, so a
+    value of "now" would record a fresh row per device per poll, forever, and
+    carry no information. Reading the transport's own stamp means it changes
+    only when data actually arrives.
+    """
+    stamp = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+    health = _spec(
+        {
+            "ble": (False, None),
+            "lan": (True, stamp),
+            "mqtt": (False, None),
+            "cloud_api": (False, None),
+        }
+    )
+    sensor = _sensor(_device(), health)
+    assert sensor.native_value == "lan"
+
+    timestamp = sensor.extra_state_attributes["last_delivered_at"]
     parsed = datetime.fromisoformat(timestamp)
+    assert parsed == stamp
     assert parsed.utcoffset() == timedelta(0)
-    assert parsed <= datetime.now(timezone.utc) + timedelta(seconds=2)
+
+
+def test_last_delivered_at_is_stable_across_reads() -> None:
+    """The regression the change exists to prevent: no churn on re-read."""
+    sensor = _sensor(_device(), _health(lan=True))
+    first = sensor.extra_state_attributes
+    second = sensor.extra_state_attributes
+    assert first == second
+
+
+def test_no_timestamp_when_nothing_is_delivering() -> None:
+    """An unavailable device has no transport to report a time for."""
+    sensor = _sensor(_device(), _health())
+    assert sensor.native_value == "unavailable"
+    assert "last_delivered_at" not in sensor.extra_state_attributes
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds a new `sensor.<device>_connection_mode` entity per device (groups included)
that reports which transport the next command will actually use:
`ble`, `lan`, `mqtt`, `cloud_api`, or `unavailable`.

This complements the existing per-transport binary sensors
(`lan_connectivity`, `mqtt_connectivity`, etc.) and the aggregator
`device_connectivity` by exposing a single, glanceable value in the UI.

## Motivation

Users on flaky LAN setups, chatty MQTT paths, or constrained cloud quotas
have to dig into per-transport binary sensors + attributes to answer a
simple question: *what transport is my device actually using right now?*

This is especially useful for diagnosing situations like:

- A user with a cross-VLAN setup where the LAN scan never reaches the
  device (with `lan_targets` configured for cross-VLAN unicast, the
  sensor correctly reports the actual reachable transport).
- A device that is `online=True` per the cloud API but is only reaching
  the user via LAN (because the upstream broker stopped pushing state).
- Bridge-attached sub-devices where the answer is "this is reached via
  the gateway's MQTT path" rather than the more confusing "MQTT".

## What ships in this PR

| File | Change | Lines |
|---|---|---|
| `custom_components/govee/sensor.py` | New `GoveeConnectionModeSensor` class + module-level `_PRIORITY_ORDER` + wiring in `async_setup_entry` | +87/-1 |
| `custom_components/govee/strings.json` | `entity.sensor.connection_mode` block with `name` + 5 `state.*` keys | +10 |
| `custom_components/govee/translations/en.json` | English mirror of the same block | +10 |
| `tests/test_connection_mode_sensor.py` | New test file: 28 spec-derived scenarios + 3 follow-up scenarios | +353 |

No changes to the dispatcher order, no options schema change, no behavior
change to any existing entity.

## What is NOT in this PR

- No `select` entity for transport pinning (explicit non-goal).
- No per-device override / pin mechanism.
- No change to `entry.options` schema.
- No change to `GoveeDeviceConnectivity` / `GoveeTransportConnectivity`.

## Device class & UI

- `SensorDeviceClass.ENUM` with `_attr_options = ["lan", "mqtt", "cloud_api", "ble", "unavailable"]`.
- `EntityCategory.DIAGNOSTIC` (hidden by default; discoverable via search and the Diagnostics tab).
- `has_entity_name=True` so the friendly name resolves as `"<Device Name> Connection Mode"`.
- Translation key `connection_mode` registered with the 5 `state.*` values in
  `strings.json` and the English translation.

## Behavior

- Reads `TransportHealthTracker` for each transport; walks the existing
  dispatcher priority order `ble → lan → mqtt → cloud_api`; returns the
  first one with `is_available` **and** `last_received is not None`
  (otherwise a transport with a stale or never-received state is not
  "really delivering" and the next tier wins).
- For group devices: returns `cloud_api` when reachable, `unavailable`
  otherwise. Groups are REST-only by design; this mirrors
  `coordinator.async_control_device`.
- For gateway-bridged sub-devices (e.g. an H5901 attached to an H5044):
  returns the resolved transport and exposes `via_gateway` (the hub
  `device_id` from either `device.hub_device_id` or
  `coordinator.gateway_route(device_id)`); attribute omitted entirely when
  the device is not bridged.

## Testing

- New file `tests/test_connection_mode_sensor.py` exercises 28
  scenarios from the spec (priority walk, group device handling,
  gateway bridging, LAN demotion with `last_failure_reason="stale_lan"`,
  ISO 8601 timestamp attribute, icon per value, DIAGNOSTIC category,
  entity availability independent of `state.online`, exact one sensor
  per device) plus 3 follow-up scenarios covering the
  `last_received`-gated fix.
- `pytest tests/test_connection_mode_sensor.py -v --no-cov`: **31 / 31 passed**.
- Full suite: `pytest -q` → **1,691 passed** in ~4 s.
- `tox -e py313`: **OK**, coverage **73.28%** overall, **100%** on the
  new module.
- `flake8` / `mypy --strict` / `black --check --line-length 119`: clean on the
  new code.

## Live validation

Shipped live in two HACS installations on 2026-08-18:

- A user on a cross-VLAN setup (HA on `192.168.0.115`, devices on
  `192.168.10.0/24`) reported the sensor correctly transitioned from
  `mqtt` to `lan` after stopping a competing `govee2mqtt` add-on (which
  was holding UDP `:4002`). Final state: `LAN` for every device on
  the IoT subnet.
- The same user reported a false-positive (`mqtt` reported for a cloud-
  polled device) which is fixed by the follow-up commit
  (`054276e`). The fix adds a `last_received is not None` gate to
  `native_value` so that a transport that is merely "broker-connected"
  but not "delivering state for this device" no longer wins over the
  transport that actually is.

## Out of scope (deliberately deferred)

- Per-device transport pinning via a `select` entity — kept available as
  a follow-up if enough users ask for it.
- A repair issue / settings note for `Errno 98 EADDRINUSE` when UDP
  `:4002` is held by another local-control app — this is a separate
  improvement to the LAN-transport lifecycle code (`lan_client.py`).

## Checklist

- [x] Code follows existing patterns (Google-style docstrings, mypy
      strict, Black 119, Flake8).
- [x] Tests added and passing; full suite green.
- [x] Translations registered in both `strings.json` and
      `translations/en.json`.
- [x] Live validated in a real cross-VLAN HACS install.
- [x] No new config-entry options.
- [x] No changes to existing dispatch order or transport health logic.