### PR TITLE
feat(lan): manual device_id=ip[!] override for write-only LAN devices

### DIFF
--- a/custom_components/govee/api/lan.py
+++ b/custom_components/govee/api/lan.py
@@ -137,6 +137,8 @@ def expand_lan_targets(raw: str | None) -> list[str]:
     - a CIDR subnet (``10.20.0.0/24``)    -> every host address plus the subnet
       broadcast, so cross-VLAN devices are reached by unicast sweep (inter-VLAN
       firewalls usually drop a single directed broadcast)
+    - a ``device_id=ip`` override (see :func:`parse_lan_device_overrides`) —
+      skipped here, not a scan target
 
     Returns a de-duplicated, order-preserving list of IPv4 address strings.
     Raises ``LanTargetError`` on an unparseable token or a subnet wider than
@@ -154,6 +156,8 @@ def expand_lan_targets(raw: str | None) -> list[str]:
             targets.append(address)
 
     for token in raw.replace(",", " ").split():
+        if "=" in token:
+            continue  # a device_id=ip override — handled by the caller
         try:
             if "/" in token:
                 network = IPv4Network(token, strict=False)
@@ -174,6 +178,53 @@ def expand_lan_targets(raw: str | None) -> list[str]:
             raise LanTargetError(f"'{token}' is not a valid IP or subnet") from err
 
     return targets
+
+
+def parse_lan_device_overrides(raw: str | None) -> dict[str, tuple[str, bool]]:
+    """Parse ``device_id=ip[!]`` overrides out of the LAN-targets free text.
+
+    A cross-VLAN target (:func:`expand_lan_targets`) only fixes *reaching* a
+    device with the unicast ``scan`` request — correlation still needs that
+    device's *reply*, which is multicast and so never crosses the VLAN
+    boundary back to us regardless of firmware. A bare ``device_id=ip`` token
+    routes around that structural limit: it binds the coordinator's known
+    ``device_id`` straight to an IP, skipping discovery entirely.
+
+    A trailing ``!`` (``device_id=ip!``) is for a further, firmware-specific
+    case (issue #164): some devices never answer ``devStatus`` either, even
+    from their own subnet — a genuine silence, not a VLAN artifact. The ``!``
+    marks the device *write-only*, telling the caller to skip the read-health
+    gate and write-confirm readback, since a device that never answers a read
+    can never satisfy either.
+
+    Malformed or duplicate tokens never raise: a later duplicate device_id
+    wins, and a bad token (no ``=``, empty device_id/ip, invalid ip) is
+    skipped silently, same contract as :func:`expand_lan_targets`'s errors.
+
+    Returns ``{device_id: (ip, write_only)}``. The caller must still validate
+    each ``device_id`` against its known devices — this function can't.
+    """
+    overrides: dict[str, tuple[str, bool]] = {}
+    if not raw:
+        return overrides
+
+    for token in raw.replace(",", " ").split():
+        if "=" not in token:
+            continue
+        device_id, _, value = token.partition("=")
+        device_id = device_id.strip()
+        write_only = value.endswith("!")
+        ip = value[:-1] if write_only else value
+        ip = ip.strip()
+        if not device_id or not ip:
+            continue
+        try:
+            IPv4Address(ip)
+        except (AddressValueError, ValueError):
+            continue
+        overrides[device_id] = (ip, write_only)
+
+    return overrides
 
 
 async def async_get_lan_interface_ips(hass: HomeAssistant) -> list[str]:

--- a/custom_components/govee/api/lan.py
+++ b/custom_components/govee/api/lan.py
@@ -227,6 +227,46 @@ def parse_lan_device_overrides(raw: str | None) -> dict[str, tuple[str, bool]]:
     return overrides
 
 
+def validate_lan_device_overrides(raw: str | None) -> dict[str, tuple[str, bool]]:
+    """Strict counterpart to :func:`parse_lan_device_overrides`, for the form.
+
+    Runtime parsing is deliberately lenient — one bad token must never stop the
+    other overrides from binding, the same contract the scan-target path uses.
+    That leniency is wrong at the options form, though: a mistyped IP would
+    save cleanly and then do nothing, leaving the user with an accepted form,
+    a stored option, and a device that never works. The existing targets
+    validation exists for exactly this reason ("rejected in the form, not
+    silently dropped at scan time", #57), so overrides get the same treatment.
+
+    Raises ``LanTargetError`` on an override token with an empty device_id, an
+    empty IP, or an unparseable IP. Returns the parsed overrides so the caller
+    can run checks this module can't — notably whether each device_id is a
+    device on the account.
+    """
+    overrides: dict[str, tuple[str, bool]] = {}
+    if not raw:
+        return overrides
+
+    for token in raw.replace(",", " ").split():
+        if "=" not in token:
+            continue
+        device_id, _, value = token.partition("=")
+        device_id = device_id.strip()
+        write_only = value.endswith("!")
+        ip = (value[:-1] if write_only else value).strip()
+        if not device_id:
+            raise LanTargetError(f"'{token}' is missing a device ID before the '='")
+        if not ip:
+            raise LanTargetError(f"'{token}' is missing an IP address after the '='")
+        try:
+            IPv4Address(ip)
+        except (AddressValueError, ValueError) as err:
+            raise LanTargetError(f"'{ip}' in '{token}' is not a valid IP address") from err
+        overrides[device_id] = (ip, write_only)
+
+    return overrides
+
+
 async def async_get_lan_interface_ips(hass: HomeAssistant) -> list[str]:
     """Return the host's enabled, non-loopback IPv4 source IPs as strings.
 

--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -65,7 +65,11 @@ from .const import (
     SEGMENT_MODE_GROUPED,
     SEGMENT_MODE_INDIVIDUAL,
 )
-from .api.lan import LanTargetError, expand_lan_targets
+from .api.lan import (
+    LanTargetError,
+    expand_lan_targets,
+    validate_lan_device_overrides,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -647,6 +651,26 @@ class GoveeOptionsFlow(OptionsFlow):
         self._device_modes: dict[str, str] = {}
         self._device_index: int = 0
 
+    def _unknown_override_device_ids(
+        self, overrides: dict[str, tuple[str, bool]]
+    ) -> set[str]:
+        """Return override device_ids that aren't devices on this account (#164).
+
+        A LAN override binds a coordinator ``device_id`` straight to an IP, so
+        a mistyped id silently binds nothing. The coordinator is the only place
+        that knows the real ids, which is why this check can't live in
+        ``api.lan``. If the entry has no coordinator yet (options opened before
+        setup finished), skip the check rather than reject a correct id we
+        simply can't confirm.
+        """
+        if not overrides:
+            return set()
+        coordinator = getattr(self.config_entry, "runtime_data", None)
+        known = getattr(coordinator, "devices", None)
+        if not known:
+            return set()
+        return {device_id for device_id in overrides if device_id not in known}
+
     async def async_step_init(
         self,
         user_input: dict[str, Any] | None = None,
@@ -657,10 +681,26 @@ class GoveeOptionsFlow(OptionsFlow):
             # Validate the free-text LAN targets before saving so a bad subnet
             # is rejected in the form, not silently dropped at scan time (#57).
             try:
-                expand_lan_targets(user_input.get(CONF_LAN_TARGETS, ""))
+                raw_lan_targets = user_input.get(CONF_LAN_TARGETS, "")
+                expand_lan_targets(raw_lan_targets)
+                # device_id=ip[!] overrides get the same treatment (#164). The
+                # runtime parser skips a bad one silently so the rest still
+                # bind; here a typo must surface, or the user saves an option
+                # that quietly does nothing.
+                overrides = validate_lan_device_overrides(raw_lan_targets)
             except LanTargetError as err:
                 _LOGGER.debug("Invalid LAN targets entered: %s", err)
                 errors[CONF_LAN_TARGETS] = "invalid_lan_targets"
+            else:
+                # A device_id typo is the likeliest mistake and the only check
+                # the parser can't make for itself — it has no device list.
+                unknown = self._unknown_override_device_ids(overrides)
+                if unknown:
+                    _LOGGER.debug(
+                        "LAN override names unknown device_id(s): %s",
+                        ", ".join(sorted(unknown)),
+                    )
+                    errors[CONF_LAN_TARGETS] = "unknown_lan_device"
 
             if not errors:
                 # Save global options and proceed to device selection if needed.

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -29,6 +29,12 @@ CONF_WATER_DETECTOR_POLL_INTERVAL: Final = "water_detector_poll_interval"
 # Free-text list (comma / newline / space separated) of device IPs, broadcast
 # addresses, and CIDR subnets (≤ /24, unicast-swept since inter-VLAN firewalls
 # usually drop directed broadcast). Empty = local multicast scan only.
+#
+# Also accepts ``device_id=ip`` (skip discovery, bind that device straight to
+# an IP) and ``device_id=ip!`` (same, plus mark it write-only: skip the
+# read-health gate and write-confirm readback for firmware that accepts LAN
+# writes but never answers a scan or devStatus read — issue #164). See
+# ``api.lan.parse_lan_device_overrides``.
 CONF_LAN_TARGETS: Final = "lan_targets"
 
 # Some Govee thermometer/hygrometer SKUs report temperatures in Fahrenheit via

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -56,6 +56,7 @@ from .api.lan import (
     async_get_lan_interface_ips,
     async_scan_lan_devices,
     expand_lan_targets,
+    parse_lan_device_overrides,
 )
 from .api.lan_client import (
     GoveeLanClient,
@@ -397,6 +398,15 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         self._lan_client: GoveeLanClient | None = None
         # Correlated LAN devices keyed by coordinator device_id.
         self._lan_devices: dict[str, LanDeviceInfo] = {}
+        # device_ids bound via a manual write-only CONF_LAN_TARGETS override
+        # (issue #164) — firmware that accepts LAN writes but never answers a
+        # devStatus read, even from its own subnet (not a VLAN artifact — a
+        # scan reply not crossing VLANs is the separate, non-write-only case
+        # the bare device_id=ip form of the same override already covers).
+        # The read-health gate and write-confirm readback are skipped for
+        # these; the periodic LAN read poll excludes them too so they are
+        # never miss-demoted back out of _lan_devices.
+        self._lan_write_only: set[str] = set()
         # Scan records that matched no device_id (counted for diagnostics).
         self._lan_unmatched: list[Mapping[str, Any]] = []
         # Consecutive solicited-read misses per device, for demotion (LAN-011).
@@ -907,6 +917,49 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # the socket opens stops the client before propagating (#57, blocking #5).
         await self._async_setup_lan()
 
+    def _resolve_lan_overrides(self) -> dict[str, LanDeviceInfo]:
+        """Manual ``device_id=ip[!]`` overrides from ``CONF_LAN_TARGETS`` (#164).
+
+        Bypasses scan/devStatus discovery for a device pinned this way,
+        binding it straight to the given IP. Also (re)populates
+        :attr:`_lan_write_only` from any ``!``-suffixed entries — called once
+        per setup/rescan cycle, so it is the single source of truth for which
+        devices are write-only at any given moment (a user can remove the
+        ``!`` and a later rescan un-marks the device).
+
+        An override naming a ``device_id`` this account doesn't have (typo,
+        removed device) is skipped with a debug log rather than raising —
+        the same "one bad entry never blocks the rest" contract as
+        ``expand_lan_targets``.
+        """
+        raw_targets = self._config_entry.options.get(CONF_LAN_TARGETS, "")
+        overrides = parse_lan_device_overrides(
+            raw_targets if isinstance(raw_targets, str) else ""
+        )
+        now = time.monotonic()
+        resolved: dict[str, LanDeviceInfo] = {}
+        self._lan_write_only = set()
+        for device_id, (ip, write_only) in overrides.items():
+            device = self._devices.get(device_id)
+            if device is None:
+                _LOGGER.debug(
+                    "Ignoring %s override for unknown device_id %r",
+                    CONF_LAN_TARGETS,
+                    device_id,
+                )
+                continue
+            resolved[device_id] = LanDeviceInfo(
+                device_id=device_id,
+                ip=ip,
+                mac=device_id,
+                sku=device.sku,
+                firmware="",
+                last_correlated_ts=now,
+            )
+            if write_only:
+                self._lan_write_only.add(device_id)
+        return resolved
+
     async def _async_setup_lan(self) -> None:
         """Set up the LAN (UDP) transport — the LAST step of coordinator setup.
 
@@ -985,10 +1038,17 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             matched, unmatched = correlate_scan(
                 scan, set(self._devices), time.monotonic()
             )
+            # Manual device_id=ip[!] overrides (#164) fill in devices scan
+            # correlation can never reach on a segmented network — its reply
+            # is multicast and can't cross the VLAN boundary back to us. A
+            # fresh scan match still wins over a possibly-stale manual entry.
+            for device_id, info in self._resolve_lan_overrides().items():
+                matched.setdefault(device_id, info)
             if not matched:
                 # Auto-enable gate not met: the scan answered but nothing
-                # correlated to a device_id. Don't hold sockets for nothing —
-                # stop the client and stay disabled.
+                # correlated to a device_id, and no override filled the gap.
+                # Don't hold sockets for nothing — stop the client and stay
+                # disabled.
                 _LOGGER.debug(
                     "Govee LAN: scan answered but no device correlated "
                     "(%d unmatched) — LAN disabled",
@@ -1202,7 +1262,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         ip_to_device = {
             info.ip: device_id
             for device_id, info in self._lan_devices.items()
-            if info.ip
+            # Write-only devices (#164) never answer a read — polling them
+            # would just accumulate misses and demote them straight back out
+            # of _lan_devices every LAN_READ_MISS_DEMOTE_THRESHOLD cycles.
+            if info.ip and device_id not in self._lan_write_only
         }
         if not ip_to_device:
             return
@@ -1273,6 +1336,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             return
 
         matched, unmatched = correlate_scan(scan, set(self._devices), now)
+        # Re-apply manual overrides each rescan too (#164) — a fresh scan
+        # match still wins for any device_id it actually found.
+        for device_id, info in self._resolve_lan_overrides().items():
+            matched.setdefault(device_id, info)
         self._merge_lan_correlation(matched, unmatched)
 
     def _merge_lan_correlation(
@@ -3087,9 +3154,15 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         #     read yet (TransportHealth defaults is_available=False, so the
         #     FIRST control after startup falls through HERE until the first LAN
         #     read marks it available) — must fall back to MQTT/REST.
-        health = self._transport.get(device_id, "lan")
-        if health is None or not health.is_available:
-            return False
+        #
+        #     Skipped for a write-only override (#164): that device has never
+        #     answered a read and never will, so this gate could never pass —
+        #     the user's explicit ``device_id=ip!`` override is what stands in
+        #     for read-proven health here.
+        if device_id not in self._lan_write_only:
+            health = self._transport.get(device_id, "lan")
+            if health is None or not health.is_available:
+                return False
 
         # [4.5] Write-suppression cooldown (issue #57): this device's recent LAN
         #     writes did not confirm, so skip the LAN write attempt AND its
@@ -3124,6 +3197,26 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         #     confirm read blocks for up to LAN_WRITE_CONFIRM_TIMEOUT.
         self._apply_optimistic_update(device_id, command)
         self.async_set_updated_data(self._states)
+
+        # [7.5] Write-only override (#164): this device has never answered a
+        #     read, so waiting on one here would just burn LAN_WRITE_CONFIRM_
+        #     TIMEOUT for a reply that will never come, and — worse — count as
+        #     a write-confirm miss every single time, eventually tripping
+        #     write suppression on a device that is, in fact, working exactly
+        #     as its firmware allows. Treat the successful send itself as the
+        #     confirmation: it is the only signal this firmware ever gives.
+        if device_id in self._lan_write_only:
+            self._record_transport_send(device_id, "lan")
+            self._record_transport_success(device_id, "lan")
+            self._record_local_command(
+                device_id,
+                device.sku,
+                "lan",
+                command,
+                delivered=True,
+                detail="write-only device (#164) — send is the only confirmation available",
+            )
+            return True
 
         # [8] Verify-by-read: a LAN write is unacked, so read the device back and
         #     require the reported value to match what we sent.

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -93,7 +93,7 @@
           "water_detector_poll_interval": "How often standalone Govee water/leak detectors (e.g. H5054) are checked for a leak. These RF-only sensors have no push channel, so a leak surfaces with up to this much delay. Lower reacts faster but makes more account API calls; raise it if you have many detectors. Range 60\u20133600 seconds, default 120. Requires email/password login; ignored if you have no such detectors.",
           "enable_groups": "Surfaces the device groups you created in the Govee app as single light entities. A command to a group is sent once and synced to all members by Govee's cloud, so it syncs better than grouping the lights with Home Assistant helpers. State is best-effort (groups can't be polled), and group lights only support power/brightness/color.",
           "enable_mqtt_control": "Routes power/brightness/color commands through Govee's MQTT channel instead of the REST cloud API, reducing latency and bypassing REST rate limits. Requires email/password login (MQTT credentials). Falls back to REST automatically when MQTT is unavailable. Experimental — uses an undocumented channel; leave off if commands behave unexpectedly.",
-          "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network."
+          "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network. Advanced: if a device still isn't found because its scan reply can't cross the VLAN, pin it with device_id=ip (AA:BB:CC:DD:EE:FF:00:11=10.20.0.51) to skip discovery for that device. Add a trailing ! (=10.20.0.51!) only for firmware that accepts LAN commands but never answers a status read \u2014 that turns off every LAN health check for the device, so a wrong IP will look like it is working while the device never responds."
         }
       },
       "select_segment_devices": {
@@ -112,7 +112,8 @@
       }
     },
     "error": {
-      "invalid_lan_targets": "One of the LAN device addresses is not a valid IP, broadcast address, or subnet (/24 or smaller). Example: 10.20.0.51, 10.20.0.255, 10.20.0.0/24"
+      "invalid_lan_targets": "One of the LAN device addresses is not a valid IP, broadcast address, subnet (/24 or smaller), or device_id=ip override. Example: 10.20.0.51, 10.20.0.255, 10.20.0.0/24, AA:BB:CC:DD:EE:FF:00:11=10.20.0.51",
+      "unknown_lan_device": "A device_id=ip override names a device that isn't on this Govee account. Copy the device ID exactly as it appears in the device's diagnostics (for example AA:BB:CC:DD:EE:FF:00:11)."
     }
   },
   "entity": {

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -93,7 +93,7 @@
           "water_detector_poll_interval": "How often standalone Govee water/leak detectors (e.g. H5054) are checked for a leak. These RF-only sensors have no push channel, so a leak surfaces with up to this much delay. Lower reacts faster but makes more account API calls; raise it if you have many detectors. Range 60\u20133600 seconds, default 120. Requires email/password login; ignored if you have no such detectors.",
           "enable_groups": "Surfaces the device groups you created in the Govee app as single light entities. A command to a group is sent once and synced to all members by Govee's cloud, so it syncs better than grouping the lights with Home Assistant helpers. State is best-effort (groups can't be polled), and group lights only support power/brightness/color.",
           "enable_mqtt_control": "Routes power/brightness/color commands through Govee's MQTT channel instead of the REST cloud API, reducing latency and bypassing REST rate limits. Requires email/password login (MQTT credentials). Falls back to REST automatically when MQTT is unavailable. Experimental — uses an undocumented channel; leave off if commands behave unexpectedly.",
-          "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network."
+          "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network. Advanced: if a device still isn't found because its scan reply can't cross the VLAN, pin it with device_id=ip (AA:BB:CC:DD:EE:FF:00:11=10.20.0.51) to skip discovery for that device. Add a trailing ! (=10.20.0.51!) only for firmware that accepts LAN commands but never answers a status read \u2014 that turns off every LAN health check for the device, so a wrong IP will look like it is working while the device never responds."
         }
       },
       "select_segment_devices": {
@@ -112,7 +112,8 @@
       }
     },
     "error": {
-      "invalid_lan_targets": "One of the LAN device addresses is not a valid IP, broadcast address, or subnet (/24 or smaller). Example: 10.20.0.51, 10.20.0.255, 10.20.0.0/24"
+      "invalid_lan_targets": "One of the LAN device addresses is not a valid IP, broadcast address, subnet (/24 or smaller), or device_id=ip override. Example: 10.20.0.51, 10.20.0.255, 10.20.0.0/24, AA:BB:CC:DD:EE:FF:00:11=10.20.0.51",
+      "unknown_lan_device": "A device_id=ip override names a device that isn't on this Govee account. Copy the device ID exactly as it appears in the device's diagnostics (for example AA:BB:CC:DD:EE:FF:00:11)."
     }
   },
   "entity": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -295,6 +295,93 @@ class TestLanTargetsOption:
         assert result["errors"] == {CONF_LAN_TARGETS: "invalid_lan_targets"}
 
 
+class TestLanDeviceOverrideOption:
+    """Form validation for the device_id=ip[!] override syntax (issue #164).
+
+    Runtime parsing skips a malformed override silently so the rest still bind.
+    The form must not: a typo that saves cleanly leaves the user with an
+    accepted form, a stored option and a device that never works, with nothing
+    on screen to say why.
+    """
+
+    DEVICE = "AA:BB:CC:DD:EE:FF:00:11"
+
+    @pytest.mark.asyncio
+    async def test_valid_override_saved(self):
+        flow, entry = _options_flow(devices={self.DEVICE: MagicMock(segment_count=0)})
+        raw = f"{self.DEVICE}=10.20.0.51"
+        result = await _run_init(
+            flow, entry, {CONF_POLL_INTERVAL: 60, CONF_LAN_TARGETS: raw}
+        )
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_LAN_TARGETS] == raw
+
+    @pytest.mark.asyncio
+    async def test_valid_write_only_override_saved(self):
+        flow, entry = _options_flow(devices={self.DEVICE: MagicMock(segment_count=0)})
+        raw = f"{self.DEVICE}=10.20.0.51!"
+        result = await _run_init(
+            flow, entry, {CONF_POLL_INTERVAL: 60, CONF_LAN_TARGETS: raw}
+        )
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_LAN_TARGETS] == raw
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "AA:BB:CC:DD:EE:FF:00:11=10.20.0.999",
+            "AA:BB:CC:DD:EE:FF:00:11=",
+            "AA:BB:CC:DD:EE:FF:00:11=not-an-ip!",
+            "=10.20.0.51",
+        ],
+    )
+    async def test_malformed_override_rejected(self, raw):
+        flow, entry = _options_flow(devices={self.DEVICE: MagicMock(segment_count=0)})
+        result = await _run_init(
+            flow, entry, {CONF_POLL_INTERVAL: 60, CONF_LAN_TARGETS: raw}
+        )
+        assert result["type"] == "form"
+        assert result["errors"] == {CONF_LAN_TARGETS: "invalid_lan_targets"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_device_id_rejected(self):
+        """A mistyped device ID binds nothing — catch it at the form."""
+        flow, entry = _options_flow(devices={self.DEVICE: MagicMock(segment_count=0)})
+        result = await _run_init(
+            flow,
+            entry,
+            {CONF_POLL_INTERVAL: 60, CONF_LAN_TARGETS: "AA:BB:CC:DD:EE:FF:00:99=10.20.0.51"},
+        )
+        assert result["type"] == "form"
+        assert result["errors"] == {CONF_LAN_TARGETS: "unknown_lan_device"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_device_check_skipped_without_a_device_list(self):
+        """Options can be opened before discovery has populated devices.
+
+        With no device list to check against, a correct id is indistinguishable
+        from a typo, and rejecting would lock the user out of their own options.
+        """
+        flow, entry = _options_flow(devices={})
+        result = await _run_init(
+            flow,
+            entry,
+            {CONF_POLL_INTERVAL: 60, CONF_LAN_TARGETS: f"{self.DEVICE}=10.20.0.51"},
+        )
+        assert result["type"] == "create_entry"
+
+    @pytest.mark.asyncio
+    async def test_override_mixed_with_plain_targets(self):
+        flow, entry = _options_flow(devices={self.DEVICE: MagicMock(segment_count=0)})
+        raw = f"10.20.0.0/24, {self.DEVICE}=10.20.0.51!"
+        result = await _run_init(
+            flow, entry, {CONF_POLL_INTERVAL: 60, CONF_LAN_TARGETS: raw}
+        )
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_LAN_TARGETS] == raw
+
+
 class TestWaterDetectorPollIntervalOption:
     """The leak-poll interval is exposed and bounded in the options flow."""
 

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -524,6 +524,62 @@ def test_parse_lan_device_overrides_skips_malformed_entries(raw):
     assert lan.parse_lan_device_overrides(raw) == {}
 
 
+# --- validate_lan_device_overrides ------------------------------------------
+#
+# The strict counterpart used by the options form. Runtime parsing stays
+# lenient so one bad token can't stop the others binding; the form must not be,
+# or a typo saves cleanly and then silently does nothing (#164).
+
+
+@pytest.mark.parametrize("raw", ["", None, "   "])
+def test_validate_lan_device_overrides_empty(raw):
+    assert lan.validate_lan_device_overrides(raw) == {}
+
+
+def test_validate_lan_device_overrides_returns_parsed_entries():
+    raw = "10.20.0.5, AA:BB=10.20.0.6!, CC:DD=10.20.0.7"
+    assert lan.validate_lan_device_overrides(raw) == {
+        "AA:BB": ("10.20.0.6", True),
+        "CC:DD": ("10.20.0.7", False),
+    }
+
+
+def test_validate_lan_device_overrides_ignores_plain_targets():
+    # Plain IPs/subnets are expand_lan_targets' business, not an override.
+    assert lan.validate_lan_device_overrides("10.20.0.5 10.20.0.0/24") == {}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "=192.168.3.210",  # empty device_id
+        "AA:BB=",  # empty ip
+        "AA:BB=!",  # empty ip, just the marker
+        "AA:BB=not-an-ip",  # invalid ip
+        "AA:BB=not-an-ip!",  # invalid ip, write-only marker
+        "AA:BB=192.168.1.999",  # out-of-range octet
+    ],
+)
+def test_validate_lan_device_overrides_raises_on_malformed(raw):
+    # The exact tokens parse_lan_device_overrides skips silently must raise
+    # here — this is the difference between the two functions.
+    with pytest.raises(lan.LanTargetError):
+        lan.validate_lan_device_overrides(raw)
+
+
+def test_validate_and_parse_disagree_only_on_malformed_input():
+    """The lenient/strict split is the point: same good input, same result."""
+    good = "AA:BB=10.20.0.6! CC:DD=10.20.0.7"
+    assert lan.validate_lan_device_overrides(good) == lan.parse_lan_device_overrides(
+        good
+    )
+
+    bad = "AA:BB=not-an-ip"
+    assert lan.parse_lan_device_overrides(bad) == {}
+    with pytest.raises(lan.LanTargetError):
+        lan.validate_lan_device_overrides(bad)
+
+
 # --- async_get_lan_interface_ips -------------------------------------------
 #
 # The single shared interface-IP enumeration hoisted out of diagnostics (#57) so

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -462,6 +462,68 @@ def test_expand_lan_targets_rejects_garbage():
         lan.expand_lan_targets("not-an-ip")
 
 
+def test_expand_lan_targets_skips_device_overrides():
+    # A device_id=ip[!] override (#164) is not a scan target — expand_lan_targets
+    # must not try to parse it as an IP/subnet and must not raise on it.
+    raw = "10.20.0.5 11:66:C0:EB:32:C1:19:FC=192.168.3.210!"
+    assert lan.expand_lan_targets(raw) == ["10.20.0.5"]
+
+
+# --- parse_lan_device_overrides ---------------------------------------------
+
+
+@pytest.mark.parametrize("raw", ["", None, "   "])
+def test_parse_lan_device_overrides_empty(raw):
+    assert lan.parse_lan_device_overrides(raw) == {}
+
+
+def test_parse_lan_device_overrides_plain_ip():
+    # No trailing "!" -> normal read/write/health treatment, not write-only.
+    raw = "11:66:C0:EB:32:C1:19:FC=192.168.3.210"
+    assert lan.parse_lan_device_overrides(raw) == {
+        "11:66:C0:EB:32:C1:19:FC": ("192.168.3.210", False),
+    }
+
+
+def test_parse_lan_device_overrides_write_only_marker():
+    raw = "11:66:C0:EB:32:C1:19:FC=192.168.3.210!"
+    assert lan.parse_lan_device_overrides(raw) == {
+        "11:66:C0:EB:32:C1:19:FC": ("192.168.3.210", True),
+    }
+
+
+def test_parse_lan_device_overrides_multiple_and_mixed_with_plain_targets():
+    raw = "10.20.0.5, AA:BB=10.20.0.6!, CC:DD=10.20.0.7"
+    assert lan.parse_lan_device_overrides(raw) == {
+        "AA:BB": ("10.20.0.6", True),
+        "CC:DD": ("10.20.0.7", False),
+    }
+    # And the plain IP is still picked up by expand_lan_targets, unaffected.
+    assert lan.expand_lan_targets(raw) == ["10.20.0.5"]
+
+
+def test_parse_lan_device_overrides_later_duplicate_wins():
+    raw = "AA:BB=10.20.0.6 AA:BB=10.20.0.9!"
+    assert lan.parse_lan_device_overrides(raw) == {"AA:BB": ("10.20.0.9", True)}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "=192.168.3.210",  # empty device_id
+        "AA:BB=",  # empty ip
+        "AA:BB=!",  # empty ip, just the marker
+        "AA:BB=not-an-ip",  # invalid ip
+        "AA:BB=not-an-ip!",  # invalid ip, write-only marker
+    ],
+)
+def test_parse_lan_device_overrides_skips_malformed_entries(raw):
+    # Malformed entries are skipped silently, never raised — a bad token must
+    # never abort the rest of parsing (matches expand_lan_targets' contract
+    # for its own errors, but overrides never raise at all).
+    assert lan.parse_lan_device_overrides(raw) == {}
+
+
 # --- async_get_lan_interface_ips -------------------------------------------
 #
 # The single shared interface-IP enumeration hoisted out of diagnostics (#57) so


### PR DESCRIPTION
Issue #164 (H1270 Ceiling Light Pro): this device's LAN control listener accepts `turn`/`brightness`/`colorwc` writes as fire-and-forget but never answers a `devStatus` read, even from its own subnet — a genuine firmware silence, confirmed by testing from a host on the device's own VLAN. That's separate from why scan-based discovery also can't reach it: a scan reply is multicast, and multicast never crosses the VLAN boundary back to the listener regardless of firmware — a plain networking limitation, not a device quirk.

Both break LAN control today, for different reasons: `correlate_scan` can never learn the device's IP (multicast reply blocked by the VLAN), and even once bound to a known IP, the existing write-health gate (which requires a prior successful LAN read) can never pass for a device whose `devStatus` is silent.

`CONF_LAN_TARGETS` now also accepts `device_id=ip[!]` tokens:

- `device_id=ip` binds a specific coordinator device straight to an IP, routing around the VLAN-blocked scan reply. Normal read/write/health treatment applies once bound — for a device whose `devStatus` does answer, this alone is enough.
- `device_id=ip!` additionally marks the device write-only, for one whose `devStatus` never answers either: the read-health gate and the write-confirm readback are both skipped (a device that has never once answered a read can never satisfy either), and the periodic LAN read poll excludes it so it is never miss-demoted back out of the LAN device map.

Verified end-to-end against real hardware on a segmented network: with `lan_targets = "11:66:C0:EB:32:C1:19:FC=192.168.3.210!"`, the standard `light.turn_on`/`light.turn_off` services now reliably control the device over LAN, in both directions, confirmed physically through the actual entity.