### PR TITLE
Add a "both" segment mode — grouped and individual segments together

### DIFF
--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -61,6 +61,7 @@ from .const import (
     KEY_IOT_LOGIN_FAILED,
     MAX_WATER_DETECTOR_POLL_INTERVAL,
     MIN_WATER_DETECTOR_POLL_INTERVAL,
+    SEGMENT_MODE_BOTH,
     SEGMENT_MODE_DISABLED,
     SEGMENT_MODE_GROUPED,
     SEGMENT_MODE_INDIVIDUAL,
@@ -851,6 +852,7 @@ class GoveeOptionsFlow(OptionsFlow):
                             SEGMENT_MODE_DISABLED,
                             SEGMENT_MODE_GROUPED,
                             SEGMENT_MODE_INDIVIDUAL,
+                            SEGMENT_MODE_BOTH,
                         ]
                     ),
                 }

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -198,6 +198,12 @@ GOVEE_BLE_MANUFACTURER_IDS: Final = (0x8803,)  # 34819
 SEGMENT_MODE_DISABLED: Final = "disabled"
 SEGMENT_MODE_GROUPED: Final = "grouped"
 SEGMENT_MODE_INDIVIDUAL: Final = "individual"
+# Both the 12 individual segment entities AND one grouped entity that
+# controls all of them together — the individual entities stay the source of
+# truth per-segment; the grouped entity is a convenience "all segments" light
+# on top, not a replacement for either the individual entities or a native HA
+# Light Group helper (which needs no integration support at all).
+SEGMENT_MODE_BOTH: Final = "both"
 
 # Config entry schema version. Bumped to 2 in sprint-4 when IoT credentials
 # moved from hass.data[DOMAIN] to entry.data (see async_migrate_entry).

--- a/custom_components/govee/light.py
+++ b/custom_components/govee/light.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_ENABLE_SCENES,
     DEFAULT_ENABLE_SCENES,
     DEFAULT_SEGMENT_MODE,
+    SEGMENT_MODE_BOTH,
     SEGMENT_MODE_GROUPED,
     SEGMENT_MODE_INDIVIDUAL,
 )
@@ -104,7 +105,11 @@ async def async_setup_entry(
                 device.segment_count,
             )
 
-            if segment_mode == SEGMENT_MODE_GROUPED:
+            # SEGMENT_MODE_BOTH creates every entity SEGMENT_MODE_GROUPED and
+            # SEGMENT_MODE_INDIVIDUAL would create on their own — the grouped
+            # entity is a convenience "all segments" light layered on top,
+            # never a replacement for the individual per-segment entities.
+            if segment_mode in (SEGMENT_MODE_GROUPED, SEGMENT_MODE_BOTH):
                 _LOGGER.debug(
                     "Creating grouped segment entity for %s",
                     device.name,
@@ -115,7 +120,7 @@ async def async_setup_entry(
                         device=device,
                     )
                 )
-            elif segment_mode == SEGMENT_MODE_INDIVIDUAL:
+            if segment_mode in (SEGMENT_MODE_INDIVIDUAL, SEGMENT_MODE_BOTH):
                 _LOGGER.debug(
                     "Creating %d individual segment entities for %s",
                     device.segment_count,

--- a/custom_components/govee/platforms/grouped_segment.py
+++ b/custom_components/govee/platforms/grouped_segment.py
@@ -18,9 +18,10 @@ from homeassistant.components.light import (  # type: ignore[attr-defined]
     ColorMode,
     LightEntity,
 )
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from ..const import SUFFIX_GROUPED_SEGMENT
+from ..const import DOMAIN, SUFFIX_GROUPED_SEGMENT
 from ..coordinator import GoveeCoordinator
 from ..entity import GoveeEntity
 from ..models import GoveeDevice, RGBColor, SegmentColorCommand
@@ -28,6 +29,28 @@ from ..models import GoveeDevice, RGBColor, SegmentColorCommand
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+
+def segments_optimistic_signal(device_id: str) -> str:
+    """Per-device dispatcher signal carrying the grouped entity's last write.
+
+    SEGMENT_MODE_BOTH runs the grouped entity and the individual segment
+    entities side by side, and Govee never reports real per-segment state
+    back (both are purely optimistic — see the class docstrings), so nothing
+    else keeps them honest with each other. The grouped entity sends
+    ``(is_on, brightness, rgb_color)`` on this signal after every write;
+    ``GoveeSegmentEntity`` listens and mirrors it, so a `light.turn_off` on
+    the group doesn't leave the 12 individual entities still showing "on".
+    Mirrors the existing ``f"{DOMAIN}_leak_update"`` dispatcher pattern
+    (coordinator.py / sensor.py).
+
+    Deliberately one-way. Writing an individual segment does NOT update the
+    grouped entity, so the group can show a stale colour after a single
+    segment is changed on its own. Syncing back would need a loop guard on
+    both sides for little gain: the group is a write-mostly convenience, and
+    "all segments" is not meaningfully wrong just because one of them moved.
+    """
+    return f"{DOMAIN}_segments_optimistic_{device_id}"
 
 
 class GoveeGroupedSegmentEntity(GoveeEntity, LightEntity, RestoreEntity):
@@ -129,6 +152,13 @@ class GoveeGroupedSegmentEntity(GoveeEntity, LightEntity, RestoreEntity):
 
         self._is_on = True
         self.async_write_ha_state()
+        async_dispatcher_send(
+            self.hass,
+            segments_optimistic_signal(self._device_id),
+            self._is_on,
+            self._brightness,
+            self._rgb_color,
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the segments off (set to black).
@@ -162,6 +192,13 @@ class GoveeGroupedSegmentEntity(GoveeEntity, LightEntity, RestoreEntity):
 
         self._is_on = False
         self.async_write_ha_state()
+        async_dispatcher_send(
+            self.hass,
+            segments_optimistic_signal(self._device_id),
+            self._is_on,
+            self._brightness,
+            self._rgb_color,
+        )
 
     async def async_added_to_hass(self) -> None:
         """Restore previous state."""

--- a/custom_components/govee/platforms/segment.py
+++ b/custom_components/govee/platforms/segment.py
@@ -19,12 +19,15 @@ from homeassistant.components.light import (  # type: ignore[attr-defined]
     ColorMode,
     LightEntity,
 )
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from ..const import SUFFIX_SEGMENT
 from ..coordinator import GoveeCoordinator
 from ..entity import GoveeEntity
 from ..models import GoveeDevice, RGBColor, SegmentColorCommand
+from .grouped_segment import segments_optimistic_signal
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -165,7 +168,13 @@ class GoveeSegmentEntity(GoveeEntity, LightEntity, RestoreEntity):
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
-        """Restore previous state."""
+        """Restore previous state, then listen for grouped-entity writes.
+
+        SEGMENT_MODE_BOTH runs this entity alongside GoveeGroupedSegmentEntity
+        for the same segment. Govee never reports real per-segment state, so
+        without this a `light.turn_off` on the grouped "all segments" entity
+        would leave this entity still optimistically showing "on".
+        """
         await super().async_added_to_hass()
 
         last_state = await self.async_get_last_state()
@@ -177,3 +186,24 @@ class GoveeSegmentEntity(GoveeEntity, LightEntity, RestoreEntity):
 
             if last_state.attributes.get("rgb_color"):
                 self._rgb_color = tuple(last_state.attributes["rgb_color"])
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                segments_optimistic_signal(self._device_id),
+                self._handle_group_update,
+            )
+        )
+
+    @callback
+    def _handle_group_update(
+        self,
+        is_on: bool,
+        brightness: int,
+        rgb_color: tuple[int, int, int],
+    ) -> None:
+        """Mirror a write made through the grouped "all segments" entity."""
+        self._is_on = is_on
+        self._brightness = brightness
+        self._rgb_color = rgb_color
+        self.async_write_ha_state()

--- a/tests/test_grouped_segment.py
+++ b/tests/test_grouped_segment.py
@@ -68,6 +68,11 @@ def _make_grouped_segment_entity(
     entity._brightness = 255
     entity._rgb_color = (255, 255, 255)
     entity.async_write_ha_state = MagicMock()
+    # async_turn_on/off now also fire a dispatcher signal (SEGMENT_MODE_BOTH
+    # sync, #164-adjacent) — real async_dispatcher_send() needs hass.data to
+    # be an actual dict to safely no-op against zero listeners.
+    entity.hass = MagicMock()
+    entity.hass.data = {}
 
     return entity
 
@@ -258,6 +263,8 @@ class TestGroupedSegmentEntity:
         entity._brightness = 255
         entity._rgb_color = (255, 255, 255)
         entity.async_write_ha_state = MagicMock()
+        entity.hass = MagicMock()
+        entity.hass.data = {}
 
         # Simulate main entity turn_off (sends PowerCommand directly)
         async def main_turn_off() -> None:
@@ -279,3 +286,53 @@ class TestGroupedSegmentEntity:
         # Only PowerCommand should have been sent, not SegmentColorCommand
         assert len(commands_sent) == 1
         assert isinstance(commands_sent[0], PowerCommand)
+
+
+class TestGroupedSegmentOptimisticSync:
+    """SEGMENT_MODE_BOTH: the grouped entity broadcasts its state so the 12
+    individual segment entities don't drift from what the group last set."""
+
+    @pytest.mark.asyncio
+    async def test_turn_on_broadcasts_the_signal_for_this_device(self):
+        entity = _make_grouped_segment_entity()
+        with patch(
+            "custom_components.govee.platforms.grouped_segment.async_dispatcher_send"
+        ) as mock_send:
+            await entity.async_turn_on()
+
+        mock_send.assert_called_once_with(
+            entity.hass,
+            "govee_segments_optimistic_AA:BB:CC:DD:EE:FF:00:11",
+            True,
+            255,
+            (255, 255, 255),
+        )
+
+    @pytest.mark.asyncio
+    async def test_turn_off_broadcasts_off_state(self):
+        entity = _make_grouped_segment_entity()
+        with patch(
+            "custom_components.govee.platforms.grouped_segment.async_dispatcher_send"
+        ) as mock_send:
+            await entity.async_turn_off()
+
+        args = mock_send.call_args[0]
+        assert args[1] == "govee_segments_optimistic_AA:BB:CC:DD:EE:FF:00:11"
+        assert args[2] is False
+
+    @pytest.mark.asyncio
+    async def test_turn_off_still_broadcasts_when_api_call_skipped(self):
+        """Even the already-off/power-off-pending skip path must broadcast —
+        the individual entities need to hear "off" regardless of whether a
+        fresh command was actually sent (issue #164-adjacent)."""
+        entity = _make_grouped_segment_entity(
+            power_state=True, power_off_pending=True
+        )
+        with patch(
+            "custom_components.govee.platforms.grouped_segment.async_dispatcher_send"
+        ) as mock_send:
+            await entity.async_turn_off()
+
+        entity.coordinator.async_control_device.assert_not_called()
+        mock_send.assert_called_once()
+        assert mock_send.call_args[0][2] is False

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -544,3 +544,49 @@ class TestBrightnessConversion:
         assert entity._device_to_ha_brightness(254) == 255
         assert entity._device_to_ha_brightness(127) == 127
         assert entity._device_to_ha_brightness(0) == 0
+
+
+class TestSegmentModeSetup:
+    """async_setup_entry's per-device segment_mode dispatch, incl. SEGMENT_MODE_BOTH."""
+
+    async def _setup(self, device, segment_mode):
+        from custom_components.govee import light as light_mod
+
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.options = {"segment_mode_by_device": {device.device_id: segment_mode}}
+        added: list = []
+        await light_mod.async_setup_entry(
+            MagicMock(), entry, lambda ents: added.extend(ents)
+        )
+        return added
+
+    def _counts(self, added):
+        grouped = sum(type(e).__name__ == "GoveeGroupedSegmentEntity" for e in added)
+        individual = sum(type(e).__name__ == "GoveeSegmentEntity" for e in added)
+        return grouped, individual
+
+    async def test_grouped_mode_creates_only_the_grouped_entity(
+        self, mock_rgbic_device
+    ):
+        added = await self._setup(mock_rgbic_device, "grouped")
+        assert self._counts(added) == (1, 0)
+
+    async def test_individual_mode_creates_only_individual_entities(
+        self, mock_rgbic_device
+    ):
+        added = await self._setup(mock_rgbic_device, "individual")
+        assert self._counts(added) == (0, mock_rgbic_device.segment_count)
+
+    async def test_both_mode_creates_grouped_and_individual_entities(
+        self, mock_rgbic_device
+    ):
+        """SEGMENT_MODE_BOTH: the grouped entity is additive, not a replacement."""
+        added = await self._setup(mock_rgbic_device, "both")
+        assert self._counts(added) == (1, mock_rgbic_device.segment_count)
+
+    async def test_disabled_mode_creates_no_segment_entities(self, mock_rgbic_device):
+        added = await self._setup(mock_rgbic_device, "disabled")
+        assert self._counts(added) == (0, 0)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -230,3 +230,30 @@ class TestSegmentTurnOffLogic:
         # Only PowerCommand should have been sent, not SegmentColorCommand
         assert len(commands_sent) == 1
         assert isinstance(commands_sent[0], PowerCommand)
+
+
+class TestSegmentOptimisticSync:
+    """SEGMENT_MODE_BOTH: a segment mirrors whatever the grouped "all
+    segments" entity last broadcast, since Govee gives no real per-segment
+    readback to arbitrate between them (issue #164-adjacent)."""
+
+    def test_handle_group_update_mirrors_state_and_writes(self):
+        entity = _make_segment_entity()
+
+        entity._handle_group_update(False, 128, (10, 20, 30))
+
+        assert entity._is_on is False
+        assert entity._brightness == 128
+        assert entity._rgb_color == (10, 20, 30)
+        entity.async_write_ha_state.assert_called_once()
+
+    def test_handle_group_update_on(self):
+        entity = _make_segment_entity()
+        entity._is_on = False
+        entity._brightness = 0
+
+        entity._handle_group_update(True, 255, (255, 255, 255))
+
+        assert entity._is_on is True
+        assert entity._brightness == 255
+        assert entity._rgb_color == (255, 255, 255)


### PR DESCRIPTION
`segment_mode` is currently exclusive — a device gets either the grouped "all segments" light *or* the individual per-segment lights, never both. They're genuinely useful together: the group for "set the whole strip to X", the individual entities for picking out particular segments.

Adds `both` as a fourth value alongside `disabled` / `grouped` / `individual`.

**The setup change is tiny** — the two entity-creation branches become independent rather than `if/elif`, so `both` runs each.

**The wiring it does need** is keeping the two views honest. Govee never reports real per-segment state, so both entity types are purely optimistic and nothing reconciles them — without this, a `light.turn_off` on the group would leave every individual entity still showing "on". The grouped entity broadcasts its last write on a per-device dispatcher signal and the segment entities mirror it, following the existing `f"{DOMAIN}_leak_update"` pattern.

That sync is **deliberately one-way**: writing a single segment doesn't update the group, so the group can show a stale colour afterwards. Syncing back needs a loop guard on both sides for little gain — the group is a write-mostly convenience, and "all segments" isn't meaningfully wrong because one segment moved.

**Existing modes are untouched** — a device not set to `both` gets exactly the entities it got before. No translation strings needed, since the `segment_mode` options aren't individually labelled today.

1669 tests pass.
