### PR TITLE
fix(mqtt): decode gateway thermometer frames from the H5044 hub

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -759,7 +759,7 @@ class GoveeAuthClient:
         Returns:
             List of dicts, each with keys: device_id, name, sku, sw_version,
             hw_version, battery, online, temperature (°C or None), humidity
-            (%RH or None).
+            (%RH or None), hub_device_id, hub_sku, sno.
         """
         if self._session is None:
             self._session = aiohttp.ClientSession()
@@ -880,6 +880,10 @@ class GoveeAuthClient:
                             "humidity": _bff_reading(ld, _BFF_HUMIDITY_KEYS),
                             "hub_device_id": gateway_info.get("device", ""),
                             "hub_sku": gateway_info.get("sku", ""),
+                            # Slot on the gateway. Routes the hub's multiSync
+                            # thermo frames back to this device (#151) — the
+                            # frames identify the sub-device by slot only.
+                            "sno": settings.get("sno"),
                             # Instrumentation only — not applied to readings (#86).
                             "fah_open": fah_open,
                             "tem_cali": tem_cali,

--- a/custom_components/govee/api/mqtt.py
+++ b/custom_components/govee/api/mqtt.py
@@ -48,6 +48,39 @@ RECONNECT_MAX = 300
 CONNECTION_TIMEOUT = 60
 MAX_RECONNECT_ATTEMPTS = 50
 
+# --- multiSync 0xEE 0x34 sub-device frames ------------------------------------
+#
+# A leak hub (H5043/H5044) wraps its BLE sub-devices' reports in ``multiSync``
+# 0xEE 0x34 frames. Byte 3 identifies the sub-device class, and it is the ONLY
+# byte separating a leak report from a thermometer report — both share the
+# 0xEE 0x34 header and the byte-5 battery slot:
+#
+#   leak (H5054/H5058/H5059):  ee 34 <slot> 02 00 64 ...   (issue #87)
+#   thermo (H5310 via H5044):  ee 34 <slot> 08 00 64 ...   (issues #151, #157)
+#
+# Only the exact thermo signature is diverted; anything else keeps the leak
+# path, so an unknown leak SKU can never be silenced by this discrimination.
+MULTISYNC_SUBTYPE_THERMO = 0x08
+
+# Thermo frame temperature encoding (issue #151).
+#
+#   T[°C] = (byte13 + THERMO_TEMP_OFFSET) / 10
+#
+# Established by @Araknus13 against 30 on-the-hour frames paired with the
+# cloud reading they produced, spanning 24.4-29.5 °C over 31 hours: least
+# squares gives T = 0.10010 * b13 + 11.1647, reproducing every point within
+# 0.1 K. Two earlier candidates from the single-labelled-point capture in #157
+# (°F + 113 and °C + 170) miss the same data by 19.3 K and 38.1 K — they had
+# been indistinguishable only because they intersect at 31.25 °C, right where
+# that lone reading sat.
+#
+# The byte is unsigned, so the representable span is 11.2-36.7 °C, and the
+# capture only spans 24-30 °C. Both endpoints are treated as sentinels rather
+# than readings (see _decode_thermo_frame) since the rest of the frame uses
+# 0x00/0xFF the same way.
+THERMO_TEMP_OFFSET = 112
+THERMO_TEMP_SCALE = 10.0
+
 # Amazon Root CA 1 - Required for AWS IoT server certificate verification
 # Source: https://www.amazontrust.com/repository/AmazonRootCA1.pem
 AMAZON_ROOT_CA1 = """-----BEGIN CERTIFICATE-----
@@ -77,6 +110,52 @@ StateUpdateCallback = Callable[[str, dict[str, Any]], None]
 GiveUpCallback = Callable[[int, str], None]
 """Invoked when the reconnect loop exhausts MAX_RECONNECT_ATTEMPTS.
 Args: (attempts_made, last_error_message)."""
+
+
+def _decode_thermo_frame(raw: bytes) -> dict[str, Any] | None:
+    """Decode a gateway-bridged thermometer report (issue #151).
+
+    Frame layout, from 64 frames in the #157 diagnostics and 44 in #151::
+
+        ee 34 00 08 00 64 29 15 c2 6a 7e ca 3c 89 ba cc ff 80 00 2a
+        └──┬──┘ │  │  │  └──┬──┘ └────┬────┘ │  └────┬────┘ └─┬─┘ │
+         header │  │  │   per-dev   epoch    │    per-dev    ?  cksum
+                │  │  battery      seconds   temperature
+                │  sub-device class (0x08)
+                slot (sno on the hub)
+
+    Bytes 9-12 are a big-endian Unix timestamp — on the #151 capture it tracks
+    receive time to within 3 seconds across all 44 frames, which is what makes
+    it usable as a staleness check rather than just a decoded curiosity.
+
+    Args:
+        raw: The decoded multiSync packet.
+
+    Returns:
+        ``{"sensor_slot", "temperature_c", "battery", "frame_ts"}``, or None if
+        the frame is too short or byte 13 reads as a sentinel rather than a
+        temperature.
+    """
+    if len(raw) < 14:
+        return None
+
+    temp_byte = raw[13]
+    # 0x00 / 0xFF are the frame's own no-data markers (byte 16 sits at 0xFF
+    # permanently on the temperature-only H5310, and BFF reports its absent
+    # humidity as 0xFFFF). Decoding them would surface a confident 11.2 °C or
+    # 36.7 °C, which is worse than reporting nothing.
+    if temp_byte in (0x00, 0xFF):
+        return None
+
+    battery = raw[5] if raw[5] <= 100 else None
+    frame_ts = int.from_bytes(raw[9:13], "big") if len(raw) >= 13 else None
+
+    return {
+        "sensor_slot": raw[2],
+        "temperature_c": (temp_byte + THERMO_TEMP_OFFSET) / THERMO_TEMP_SCALE,
+        "battery": battery,
+        "frame_ts": frame_ts,
+    }
 
 
 class GoveeAwsIotClient:
@@ -570,7 +649,36 @@ class GoveeAwsIotClient:
 
             sensor_slot = raw[2]
 
-            if raw[1] == 0x34:
+            if raw[1] == 0x34 and raw[3] == MULTISYNC_SUBTYPE_THERMO:
+                # Gateway-bridged thermometer report (H5310 via H5044, #151).
+                # Diverted before the leak branch: these frames carry battery
+                # in the same byte 5 a leak report uses, so letting them fall
+                # through would emit a spurious dry-event for whatever leak
+                # sensor happens to share this slot on the hub.
+                reading = _decode_thermo_frame(raw)
+                if reading is None:
+                    _LOGGER.debug(
+                        "Thermo frame from %s not decodable: %s",
+                        hub_device_id,
+                        raw.hex(),
+                    )
+                    continue
+
+                _LOGGER.debug(
+                    "Thermo report from hub %s: slot=%d temp=%.1f°C battery=%s",
+                    hub_device_id,
+                    reading["sensor_slot"],
+                    reading["temperature_c"],
+                    reading["battery"],
+                )
+
+                event_data = {
+                    "_thermo_frame": True,
+                    "hub_device_id": hub_device_id,
+                    **reading,
+                }
+
+            elif raw[1] == 0x34:
                 # Leak/dry event. Probe-state bytes 14/16 carry the H5059 wet
                 # flag (issue #87); byte 5 is battery. OR both so older SKUs
                 # decoded off byte 5 keep working and H5059 is added.

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -65,9 +65,11 @@ from .api.lan_client import (
 )
 from .api.lan_control import command_to_lan, lan_brightness_to_device
 from .const import (
+    CONF_API_TEMPERATURE_UNIT,
     CONF_ENABLE_MQTT_CONTROL,
     CONF_LAN_TARGETS,
     CONF_WATER_DETECTOR_POLL_INTERVAL,
+    DEFAULT_API_TEMPERATURE_UNIT,
     DEFAULT_ENABLE_MQTT_CONTROL,
     DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DEVICE_REDISCOVERY_INTERVAL,
@@ -81,6 +83,7 @@ from .const import (
     MAX_WATER_DETECTOR_POLL_INTERVAL,
     MIN_WATER_DETECTOR_POLL_INTERVAL,
     OPTIMISTIC_GRACE_CAP_SECONDS,
+    resolve_fahrenheit_conversion,
 )
 from .models import (
     GoveeDevice,
@@ -364,6 +367,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         self._water_full_changed_at: dict[str, datetime] = {}
         self._leak_hubs: dict[str, dict[str, Any]] = {}
         self._sno_to_sensor_id: dict[tuple[str, int], str] = {}
+        # (hub_device_id, sno) -> thermo device_id. The hub's multiSync thermo
+        # frames name their sub-device by slot only, so this is what turns an
+        # ee34/0x08 frame into a reading on the right entity (#151).
+        self._sno_to_thermo_id: dict[tuple[str, int], str] = {}
         # Last time the account device list was re-checked for newly added
         # devices (#101). Seeded to "now" so the first re-check waits a full
         # interval rather than firing right after setup discovery.
@@ -1878,6 +1885,21 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if isinstance(fah_open, bool):
             self._display_fahrenheit[device_id] = fah_open
 
+    def _note_thermo_slot(self, device_id: str, sensor: dict[str, Any]) -> None:
+        """Map a gateway slot to this thermometer so its frames can be routed.
+
+        The hub's multiSync thermo frames carry only the slot (``sno``), never
+        the sub-device id, so without this pairing a decoded reading has
+        nowhere to go (issue #151). Registered for every BFF-listed
+        thermometer, including ones still on the Developer poll — the frame
+        path is a reading source, not an ownership claim.
+        """
+        hub_device_id = sensor.get("hub_device_id") or ""
+        sno = sensor.get("sno")
+        if not hub_device_id or not isinstance(sno, int) or isinstance(sno, bool):
+            return
+        self._sno_to_thermo_id[(hub_device_id, sno)] = device_id
+
     async def _discover_bff_thermometers(self) -> None:
         """Discover thermo-hygrometers (H5301) via the BFF device list (issue #86).
 
@@ -1909,6 +1931,7 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                     continue
 
                 self._note_display_unit(device_id, sensor)
+                self._note_thermo_slot(device_id, sensor)
 
                 # A device already discovered via the Developer API (e.g. the
                 # H5179 WiFi thermometer, #141) whose live reading only comes
@@ -2433,6 +2456,100 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         self._bff_poll_task = self.hass.async_create_task(self._poll_bff_leak_state())
 
     @callback
+    def _handle_thermo_frame(self, state_data: dict[str, Any]) -> None:
+        """Apply a decoded gateway thermometer frame (issue #151).
+
+        This is the live reading source for a gateway-bridged thermometer. It
+        matters most where nothing else works: when Govee leaves
+        ``deviceExt.lastDeviceData`` empty for the sub-device, the BFF path has
+        no value to serve and the Developer poll returns nothing either, so the
+        entity sits at ``unknown`` indefinitely. It also beats the BFF value on
+        freshness even when that path does work — the reporter measured the
+        H5044 pushing hourly at hh:56 with the cloud copy landing 5-7 minutes
+        later, and this frame IS that push.
+
+        The decode yields canonical °C, so the value is converted into whatever
+        unit the entity will read it back in rather than claiming ownership of
+        the device. That keeps this coexisting with the Developer poll — both
+        writers leave ``sensor_temperature`` in one consistent unit, and an
+        account whose poll works does not lose it if the gateway goes quiet.
+        """
+        hub_id = state_data["hub_device_id"]
+        sno = state_data["sensor_slot"]
+
+        device_id = self._sno_to_thermo_id.get((hub_id, sno))
+        if not device_id:
+            _LOGGER.debug(
+                "Thermo frame for unmapped sensor: hub=%s slot=%d temp=%.1f°C",
+                hub_id,
+                sno,
+                state_data["temperature_c"],
+            )
+            return
+
+        device = self._devices.get(device_id)
+        if device is None:
+            return
+
+        state = self._states.get(device_id) or GoveeDeviceState.create_empty(device_id)
+        previous_temperature = state.sensor_temperature
+
+        state.sensor_temperature = self._thermo_frame_temperature(
+            device_id, device.sku, state_data["temperature_c"]
+        )
+        if state_data.get("battery") is not None:
+            state.battery = state_data["battery"]
+        # The frame is proof of life from the sub-device itself. Govee's own
+        # ``online`` flag flaps false between the hourly uploads (#97), so a
+        # frame arriving is the better signal.
+        state.online = True
+        self._states[device_id] = state
+
+        # Last *change*, not last confirmation — same semantic as the poll
+        # path's _note_sensor_reading_change (#83). The first frame stamps too.
+        if (
+            previous_temperature != state.sensor_temperature
+            or device_id not in self._sensor_reading_changed_at
+        ):
+            self._sensor_reading_changed_at[device_id] = dt_util.utcnow()
+
+        self._ensure_transport_health(device_id)
+        self._record_transport_success(device_id, "mqtt")
+
+        _LOGGER.debug(
+            "Thermo frame applied to %s: %.1f°C (stored %.1f) battery=%s",
+            device.name,
+            state_data["temperature_c"],
+            state.sensor_temperature,
+            state.battery,
+        )
+        self.async_set_updated_data(self._states)
+
+    def _thermo_frame_temperature(
+        self, device_id: str, sku: str, celsius: float
+    ) -> float:
+        """Put a decoded °C reading into the unit the entity expects.
+
+        The temperature sensor converts °F→°C for SKUs in
+        FAHRENHEIT_REPORTING_SKUS — which includes the H5310 — unless the
+        device is BFF-owned, in which case it trusts the stored value as °C.
+        Writing raw °C into the first case would surface a pool at 24.9 °C as
+        -4 °C, so the value is pre-converted to match (the same round-tripping
+        the BFF read path does, #96/#83).
+        """
+        if self.is_bff_thermometer(device_id):
+            return celsius
+
+        api_unit = self._config_entry.options.get(
+            CONF_API_TEMPERATURE_UNIT,
+            DEFAULT_API_TEMPERATURE_UNIT,
+        )
+        unit_hint = self.account_temperature_unit(device_id)
+        if resolve_fahrenheit_conversion(sku, api_unit, unit_hint):
+            return celsius * (9.0 / 5.0) + 32.0
+        return celsius
+
+    @callback
     def _handle_button_press(self, state_data: dict[str, Any]) -> None:
         """Handle a button press event from MQTT multiSync message."""
         sensor_id = state_data["device_id"]
@@ -2461,6 +2578,11 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # Handle leak sensor events (from multiSync messages)
         if state_data.get("_leak_event"):
             self._handle_leak_event(state_data)
+            return
+
+        # Handle gateway-bridged thermometer frames (issue #151)
+        if state_data.get("_thermo_frame"):
+            self._handle_thermo_frame(state_data)
             return
 
         # Handle button press events

--- a/docs/govee-protocol-reference.md
+++ b/docs/govee-protocol-reference.md
@@ -2497,39 +2497,57 @@ Battery thermo-hygrometer that reaches the cloud through an **H5044 gateway**; n
 - The pool probe is **temperature-only**: `sensorHumidity` comes back as `655.35` (= `0xFFFF / 100`, a "no-data" sentinel). Treat the sentinel as unavailable rather than a real 655% reading (#100).
 - Rides the gateway with **no direct MQTT topic** (`device_topic_count=0`); the H5044 pushes 20-byte `ee34…` multi-sync frames. Richer cached state (`tem`/`hum`/`avgDay…`) is in BFF `lastDeviceData`.
 
-##### Thermo `ee34` frame layout — partially decoded (issues #151, #157)
+##### Thermo `ee34` frame layout — decoded (issues #151, #157)
 
-An H5044 bridging an H5310 pushes an `ee34` frame every ~10 minutes. The
-integration currently decodes `0xEE 0x34` **only** as a leak/dry report, so these
-frames are recorded into the `recent_multisync` diagnostics ring and then
-discarded — which is why a gateway-bridged H5310 whose BFF `lastDeviceData` is
-empty has no reading source at all (#151).
-
-Analysis of 64 consecutive frames from one H5310 (#157 diagnostics, 2026-08-11):
+An H5044 bridging an H5310 pushes an `ee34` frame every ~10 minutes (some
+accounts see one per hour, at hh:56). These frames are the **origin** of the
+reading everything else mirrors: the cloud copy in BFF `lastDeviceData` lands
+5–7 minutes later, and for some accounts Govee never fills it at all, leaving a
+gateway-bridged H5310 with no reading source whatsoever (#151).
 
 ```
-ee 34 00 08 00 64 25 14 A8 6A 7A B5 BE C5 82 CC FF 20 00 60
-└──┬──┘ └─────┬─────┘ └┬ └─────┬─────┘ └┬ └────┬────┘ └┬ └┬
- header    constant    ?    epoch ts    ?   constant   ?  cksum
+ee 34 00 08 00 64 29 15 c2 6a 7e ca 3c 89 ba cc ff 80 00 2a
+└──┬──┘ │  │  │  └──┬──┘ └────┬────┘ │  └────┬────┘ └─┬─┘ │
+ header │  │  │   per-dev   epoch ts   │    per-dev    ?  cksum
+        │  │  battery              temperature
+        │  sub-device class
+        slot (sno)
 ```
 
 | Byte | Finding |
 |------|---------|
-| `0-1` | `0xEE 0x34` header |
-| `2-7` | Constant across every frame (`00 08 00 64 25 14`) — note `0x64` sits where the leak decoder reads battery |
-| `8` | Varies 147-168 across the day, **not** monotone with temperature |
-| `9-12` | **Big-endian Unix epoch seconds**, matching the receive time exactly — confirmed on all 64 frames |
-| `13` | Varies 196-201, **rising monotonically as the day warms** — the temperature candidate |
-| `14-18` | Constant (`82 CC FF 20 00`) |
+| `0-1` | `0xEE 0x34` header — shared with leak reports |
+| `2` | Slot (`sno`) of the sub-device on the gateway |
+| `3` | **Sub-device class: `0x02` = leak sensor, `0x08` = thermometer.** The only byte separating the two frame types |
+| `4-5` | `00 64` — byte 5 is battery %, same slot both frame types use |
+| `6-8` | Per-device constants; byte `8` varies without tracking temperature |
+| `9-12` | **Big-endian Unix epoch seconds.** Within 3 s of receive time across all 44 frames of the #151 capture |
+| `13` | **Temperature: `T[°C] = (byte13 + 112) / 10`** |
+| `14-18` | Per-device constants (`ba cc ff 80 00` here, `82 cc ff 20 00` on the #157 unit) |
 | `19` | Checksum (XOR-style, varies with payload) |
 
-**Not yet decodable.** Byte `13` is temperature-shaped, but the capture carries
-only ONE labelled reading (88.34 °F at the end of the window), and both
-`°F + 113` and `°C + 170` reproduce it exactly. The day's 5-unit swing fits °F
-better than °C for a pool, but that is an argument from plausibility, not proof.
-Shipping either would surface confidently wrong pool temperatures, so the decode
-stays unimplemented until a capture pairs several frames with the temperature the
-Govee app showed at those times.
+**How byte 13 was settled.** @Araknus13 paired 30 on-the-hour frames against
+their own logged cloud history for the same probe — pool water, 24.4–29.5 °C
+over 31 hours. Least squares gives `T = 0.10010 * b13 + 11.1647`, i.e. exactly
+0.1 °C per count, reproducing every point within 0.1 K. The two candidates from
+#157's single-labelled-point capture miss the same data by 19.3 K (`°F + 113`)
+and 38.1 K (`°C + 170`); they had looked indistinguishable only because they
+intersect at 31.25 °C = 88.25 °F, right where that lone 88.34 °F reading sat.
+The formula independently reproduces that #157 point from a different account.
+
+**Known limits.** Byte 13 is unsigned, so the representable span is
+11.2–36.7 °C and the validating capture only covers 24–30 °C — behaviour at
+the ends (whether the byte saturates, or a sign/scale switch exists for
+sub-11 °C readings) is unverified. `0x00` and `0xFF` are treated as the
+frame's own no-data markers rather than 11.2/36.7 °C readings.
+
+**Implementation.** `_decode_thermo_frame` in `api/mqtt.py` diverts byte-3
+`0x08` frames ahead of the leak branch — leak decoding stays the default for
+every other sub-device class, so an unknown leak SKU can never be silenced by
+the discrimination. `coordinator._handle_thermo_frame` routes the reading via
+`(gateway, sno) → device_id` and normalizes the decoded °C into the unit the
+entity reads back, so the frame path coexists with the Developer poll instead
+of claiming ownership of the device.
 
 #### H616C — LED Strip (NOT yet in Developer API backend)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2135,6 +2135,9 @@ class TestBffThermoHygrometerDiscovery:
         # Gateway hub for via_device linkage (#86)
         assert s["hub_device_id"] == "11:22:33:44:55:66:77:88"
         assert s["hub_sku"] == "H5044"
+        # Gateway slot — routes the hub's multiSync thermo frames back to this
+        # device, which name their sub-device by slot only (#151)
+        assert s["sno"] == 0
         # Instrumentation only — captured, NOT applied to readings (#86)
         assert s["fah_open"] is True
         assert s["tem_cali"] == -30

--- a/tests/test_mqtt_multisync.py
+++ b/tests/test_mqtt_multisync.py
@@ -262,3 +262,123 @@ class TestPerDeviceReceiveTimestamp:
         assert client.last_message_ts_for(other) is not None
         # Second message advanced the hub scalar past the first device's stamp.
         assert client.last_message_ts_for(other) >= client.last_message_ts_for(self.DEV)
+
+
+class TestThermoFrameDecode:
+    """0xEE 0x34 / byte3=0x08 thermometer frames (issues #151, #157).
+
+    A gateway-bridged H5310 reports through the same 0xEE 0x34 header its
+    stablemate leak sensors use. Byte 3 is the only discriminator: 0x02 for a
+    leak sub-device, 0x08 for a thermometer.
+
+    The temperature encoding is ``T[°C] = (byte13 + 112) / 10``, established
+    in #151 against 30 on-the-hour frames paired with the cloud reading each
+    produced. All frames below are verbatim from that capture, with the label
+    the reporter's own cloud history recorded for them.
+    """
+
+    # (hex, labelled °C) — the first, warmest, coldest and last of the capture.
+    LABELLED = [
+        ("ee34000800642915c26a7eca3c89baccff80002a", 24.9),
+        ("ee34000800642915bc6a7f56dcb7baccff800017", 29.5),
+        ("ee34000800642915bc6a7fff9b8abaccff8000c4", 25.0),
+        ("ee34000800642915bf6a80620caabaccff800012", 28.1),
+    ]
+
+    # H5310 via H5044 from a DIFFERENT account (#157) — one labelled reading
+    # of 88.34 °F at the end of that window, where byte 13 read 201.
+    H5310_OTHER_ACCOUNT = "ee34000800642514a86a7ab5bec982ccff200060"
+
+    def _decode_one(self, packet: bytes) -> dict:
+        """Run one packet through the handler; return the emitted event_data."""
+        cb = MagicMock()
+        client = _make_client()
+        client._on_state_update = cb
+        client._handle_multisync(HUB_ID, _multisync([packet]))
+        assert cb.call_count == 1
+        return cb.call_args[0][1]
+
+    def test_labelled_frames_decode_within_a_tenth(self):
+        """Every labelled frame reproduces its cloud reading within 0.1 K."""
+        for hex_frame, label in self.LABELLED:
+            event = self._decode_one(bytes.fromhex(hex_frame))
+            assert event["_thermo_frame"] is True
+            assert abs(event["temperature_c"] - label) <= 0.1, hex_frame
+
+    def test_second_account_frame_matches_its_own_label(self):
+        """The #157 capture's 88.34 °F reading = 31.3 °C, from byte 13 = 201.
+
+        Cross-account confirmation: a formula fitted only to #151's data
+        reproduces the one labelled point an unrelated reporter captured.
+        """
+        raw = bytes.fromhex(self.H5310_OTHER_ACCOUNT)
+        assert raw[13] == 201
+        event = self._decode_one(raw)
+        fahrenheit = event["temperature_c"] * (9.0 / 5.0) + 32.0
+        assert abs(fahrenheit - 88.34) <= 0.1
+
+    def test_epoch_timestamp_decoded(self):
+        """Bytes 9-12 are a big-endian Unix timestamp (2026-08-14 07:56Z)."""
+        event = self._decode_one(bytes.fromhex(self.LABELLED[0][0]))
+        assert event["frame_ts"] == 0x6A7ECA3C
+        assert 1786000000 < event["frame_ts"] < 1790000000
+
+    def test_battery_and_slot_decoded(self):
+        event = self._decode_one(bytes.fromhex(self.LABELLED[0][0]))
+        assert event["battery"] == 100
+        assert event["sensor_slot"] == 0
+
+    def test_leak_frame_is_not_diverted(self):
+        """Regression: a real leak frame keeps reaching the leak decoder.
+
+        Leak and thermo frames share the 0xEE 0x34 header, so a discriminator
+        that reads too broadly would silence leak detection — the one failure
+        this decode must never cause.
+        """
+        event = self._decode_one(
+            bytes.fromhex("ee34000200641e14ad6a1f4a58000103018000ff")
+        )
+        assert event["_leak_event"] is True
+        assert event.get("_thermo_frame") is None
+        assert event["is_wet"] is True
+
+    def test_thermo_frame_emits_no_leak_event(self):
+        """A thermo frame must not also report its slot dry.
+
+        Byte 5 is battery in both frame types, so before the discriminator an
+        H5310 report decoded as a leak-clear for whatever leak sensor shared
+        its slot on the hub.
+        """
+        event = self._decode_one(bytes.fromhex(self.LABELLED[0][0]))
+        assert event.get("_leak_event") is None
+        assert "is_wet" not in event
+
+    def test_sentinel_temperature_byte_is_dropped(self):
+        """0x00 / 0xFF at byte 13 are no-data markers, not 11.2/36.7 °C."""
+        cb = MagicMock()
+        client = _make_client()
+        client._on_state_update = cb
+        for sentinel in ("00", "ff"):
+            frame = bytes.fromhex(
+                "ee34000800642915c26a7eca3c" + sentinel + "baccff80002a"
+            )
+            client._handle_multisync(HUB_ID, _multisync([frame]))
+        assert cb.call_count == 0
+
+    def test_short_thermo_frame_ignored(self):
+        """A truncated frame has no byte 13 to read."""
+        cb = MagicMock()
+        client = _make_client()
+        client._on_state_update = cb
+        client._handle_multisync(
+            HUB_ID, _multisync([bytes.fromhex("ee34000800642915")])
+        )
+        assert cb.call_count == 0
+
+    def test_thermo_frames_still_recorded_for_diagnostics(self):
+        """Diverting the frame must not drop it from the ring buffer."""
+        client = _make_client()
+        client._handle_multisync(
+            HUB_ID, _multisync([bytes.fromhex(self.LABELLED[0][0])])
+        )
+        assert [rec["header"] for rec in client.recent_multisync] == ["ee34"]

--- a/tests/test_thermometer.py
+++ b/tests/test_thermometer.py
@@ -1078,3 +1078,139 @@ class TestBatteryCandidateDevices:
         )
         coordinator = self._coordinator({light.device_id: light})
         assert coordinator._battery_candidate_devices() == set()
+
+
+class TestGatewayThermoFrameRouting:
+    """Applying a decoded H5044 thermo frame to the right entity (issue #151).
+
+    The frames name their sub-device by gateway slot only, so routing depends
+    on the ``sno`` the BFF device list reports for each thermometer.
+    """
+
+    HUB = "07:23:5C:E7:53:5F:6F:0A"
+    DEV = "03:55:01:25:00:00:00:0B:FF:FF:00:41:FF:FF:00:33"
+
+    def _coordinator(self, *, options=None, sku="H5310"):
+        from types import SimpleNamespace
+
+        from custom_components.govee.coordinator import GoveeCoordinator
+        from custom_components.govee.transport_health import TransportHealthTracker
+
+        coordinator = GoveeCoordinator.__new__(GoveeCoordinator)
+        coordinator._config_entry = SimpleNamespace(options=options or {})
+        coordinator._devices = {
+            self.DEV: GoveeDevice.synthetic_thermometer(
+                device_id=self.DEV, sku=sku, name="Pool", hub_device_id=self.HUB
+            )
+        }
+        coordinator._states = {}
+        coordinator._sno_to_thermo_id = {}
+        coordinator._sensor_reading_changed_at = {}
+        coordinator._display_fahrenheit = {}
+        coordinator._bff_thermometer_ids = set()
+        coordinator._transport = TransportHealthTracker()
+        coordinator.async_set_updated_data = lambda _data: None
+        return coordinator
+
+    def _frame(self, *, slot=0, temperature_c=24.9, battery=100):
+        return {
+            "_thermo_frame": True,
+            "hub_device_id": self.HUB,
+            "sensor_slot": slot,
+            "temperature_c": temperature_c,
+            "battery": battery,
+            "frame_ts": 0x6A7ECA3C,
+        }
+
+    def test_slot_is_mapped_from_bff_listing(self):
+        coordinator = self._coordinator()
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        assert coordinator._sno_to_thermo_id == {(self.HUB, 0): self.DEV}
+
+    def test_listing_without_gateway_is_not_mapped(self):
+        """A direct-WiFi thermometer has no gateway slot to route to."""
+        coordinator = self._coordinator()
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": "", "sno": 0})
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB})
+        assert coordinator._sno_to_thermo_id == {}
+
+    def test_frame_lands_on_the_mapped_device(self):
+        coordinator = self._coordinator()
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        coordinator._handle_thermo_frame(self._frame())
+
+        state = coordinator._states[self.DEV]
+        assert state.battery == 100
+        assert state.online is True
+        assert self.DEV in coordinator._sensor_reading_changed_at
+
+    def test_unmapped_slot_is_dropped(self):
+        """A frame for a slot we have no thermometer for creates no state."""
+        coordinator = self._coordinator()
+        coordinator._handle_thermo_frame(self._frame(slot=3))
+        assert coordinator._states == {}
+
+    def test_reading_stored_as_fahrenheit_for_fahrenheit_skus(self):
+        """The H5310's entity converts °F→°C, so the frame must store °F.
+
+        Writing the decoded 24.9 °C straight through would surface the pool at
+        -4 °C — the same double-conversion class as #96/#83.
+        """
+        coordinator = self._coordinator()
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        coordinator._handle_thermo_frame(self._frame(temperature_c=24.9))
+
+        stored = coordinator._states[self.DEV].sensor_temperature
+        assert abs(stored - 76.82) < 0.01
+        # Round-trips back to the decoded value through the entity's conversion.
+        assert abs((stored - 32.0) * (5.0 / 9.0) - 24.9) < 0.01
+
+    def test_reading_stored_as_celsius_when_account_reports_celsius(self):
+        """A °C account's fahOpen=false hint wins over the SKU allowlist."""
+        coordinator = self._coordinator()
+        coordinator._note_display_unit(self.DEV, {"fah_open": False})
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        coordinator._handle_thermo_frame(self._frame(temperature_c=24.9))
+        assert coordinator._states[self.DEV].sensor_temperature == 24.9
+
+    def test_reading_stored_as_celsius_for_bff_owned_device(self):
+        """A BFF-owned device's entity trusts the stored value as °C."""
+        coordinator = self._coordinator()
+        coordinator._bff_thermometer_ids.add(self.DEV)
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        coordinator._handle_thermo_frame(self._frame(temperature_c=24.9))
+        assert coordinator._states[self.DEV].sensor_temperature == 24.9
+
+    def test_frame_records_mqtt_transport_health(self):
+        """The reading arrived over MQTT — diagnostics should say so.
+
+        The #151 reporter saw ``mqtt.last_received = null`` while the frames
+        were being received and discarded.
+        """
+        coordinator = self._coordinator()
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        coordinator._handle_thermo_frame(self._frame())
+
+        health = coordinator.get_transport_health(self.DEV, "mqtt")
+        assert health is not None
+        assert health.last_success_ts is not None
+
+    def test_unchanged_reading_does_not_restamp_change_time(self):
+        """Last Reading is a last-*change* timestamp, not last-poll (#83)."""
+        coordinator = self._coordinator()
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        coordinator._handle_thermo_frame(self._frame(temperature_c=24.9))
+        first = coordinator._sensor_reading_changed_at[self.DEV]
+
+        coordinator._handle_thermo_frame(self._frame(temperature_c=24.9))
+        assert coordinator._sensor_reading_changed_at[self.DEV] == first
+
+        coordinator._handle_thermo_frame(self._frame(temperature_c=25.1))
+        assert coordinator._sensor_reading_changed_at[self.DEV] > first
+
+    def test_dispatched_from_the_mqtt_state_callback(self):
+        """The frame reaches its handler through the normal MQTT entry point."""
+        coordinator = self._coordinator()
+        coordinator._note_thermo_slot(self.DEV, {"hub_device_id": self.HUB, "sno": 0})
+        coordinator._on_mqtt_state_update(self.HUB, self._frame())
+        assert coordinator._states[self.DEV].sensor_temperature is not None


### PR DESCRIPTION
## Summary

A gateway-bridged H5310 has no reliable reading source today. Govee leaves `deviceExt.lastDeviceData` empty for the sub-device on some accounts, and the Developer API lists nothing for it either, so the temperature entity sits at `unknown` indefinitely (#151).

The hub was pushing the reading the whole time. The H5044 sends it as an `ee34` multiSync frame, and the decoder threw those away — `0xEE 0x34` was handled only as a leak/dry report.

Fixes #151.

## Telling the two frame types apart

Byte 3 is the sub-device class, and it is the only byte separating them:

```
leak   (H5054/H5058/H5059):  ee 34 <slot> 02 00 64 ...   (#87)
thermo (H5310 via H5044):    ee 34 <slot> 08 00 64 ...   (#151, #157)
```

Only the exact thermo signature is diverted. Leak decoding stays the default for every other sub-device class, so an unknown leak SKU can never be silenced by this discrimination — a leak sensor must never under-report, and that invariant governed the shape of the check.

This also removes a latent bug. Thermo frames were falling through the leak branch and emitting a spurious dry-event for whatever leak sensor shared their slot on the hub. Byte 5 is battery in both frame types, so it never read as *wet* — only as a false *clear*.

## The temperature decode

```
T[°C] = (byte13 + 112) / 10
```

Established by @Araknus13 in #151 against 30 on-the-hour frames paired with the cloud reading each one produced — pool water, 24.4–29.5 °C over 31 hours. Least squares gives `T = 0.10010 * b13 + 11.1647`, i.e. exactly 0.1 °C per count, reproducing every point within 0.1 K.

The two candidates from #157's capture miss the same data by 19.3 K (`°F + 113`) and 38.1 K (`°C + 170`). They had looked indistinguishable only because they intersect at 31.25 °C = 88.25 °F, right where that capture's single labelled reading sat. The formula also reproduces that #157 point from an unrelated account — cross-account confirmation, not just a fit to one dataset.

Bytes 9–12 decode as a big-endian Unix timestamp, within 3 s of receive time across all 44 frames of the capture.

## Unit handling

`sensor_temperature` is stored in the unit the *entity* reads back, not canonically. The H5310 is in `FAHRENHEIT_REPORTING_SKUS`, so writing the decoded 24.9 °C straight through would have surfaced the pool at **−4 °C** — the same double-conversion class as #96/#83.

`_thermo_frame_temperature()` normalizes per device: raw °C when the device is BFF-owned or the account's `fahOpen` says celsius, pre-converted to °F otherwise.

The frame path deliberately **does not claim ownership** of the device (no `_bff_thermometer_ids` add). It coexists with the Developer poll — both writers leave the field in one consistent unit, and an account whose poll works doesn't lose it if the gateway goes quiet.

## Freshness

Worth noting even where the BFF path does work: @Araknus13 measured the H5044 pushing once an hour at hh:56, with the cloud copy landing 5–7 minutes later. This frame *is* that push, so it arrives first by construction. The coordinator now also records `mqtt` transport success for the device — their diagnostics showed `mqtt.last_received: null` while these frames were arriving and being discarded.

## Changes

- **`api/mqtt.py`** — `_decode_thermo_frame()` + byte-3 divert in `_handle_multisync`. Frames are still recorded to the diagnostics ring before any type filtering.
- **`api/auth.py`** — `fetch_bff_thermo_hygrometers` now returns `sno`. The frames name their sub-device by gateway slot only, so without it a decoded reading has nowhere to go.
- **`coordinator.py`** — `_sno_to_thermo_id` map, `_note_thermo_slot()`, `_handle_thermo_frame()`, dispatch in `_on_mqtt_state_update`, `mqtt` transport-health recording.
- **`docs/govee-protocol-reference.md`** — the `ee34` thermo section goes from "not yet decodable" to the settled byte map.

## Known limits

Byte 13 is unsigned, so the representable span is 11.2–36.7 °C, and the validating capture only covers 24–30 °C. Behaviour at the ends — whether the byte saturates, or a sign/scale switch exists below 11 °C — is unverified. `0x00` and `0xFF` are treated as the frame's own no-data markers rather than decoded to a confident 11.2/36.7 °C. Documented in the protocol reference.

## Verification

- 1692 tests pass (19 new), flake8 clean.
- The decoder was run against **all 30** labelled frames from #151: worst delta **0.10 K**, timestamps within 45 s of the rounded hh:56 labels.
- Regression test asserts a real H5059 leak frame still decodes `is_wet=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
