### PR TITLE
fix(bff): surface rejected account tokens and re-login instead of failing silently

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -282,6 +282,51 @@ def _bff_reading(
     return None
 
 
+def _raise_for_bff_status(data: Any, context: str) -> None:
+    """Raise when a BFF response carries an error in its *body* (issue #132).
+
+    Govee's BFF answers an expired or rejected token with **HTTP 200** and an
+    error envelope — ``{"status": 401, "message": "..."}`` with no ``data`` key
+    at all. Every device-list caller then reads ``data["data"]["devices"]``,
+    gets ``[]`` from the missing key, and carries on as though the account
+    genuinely owns no devices.
+
+    Nothing about that is visible to the user. Battery levels and
+    gateway-bridged readings simply stop, MQTT keeps working (it authenticates
+    with long-lived certificates rather than this token), and the integration
+    reports itself healthy. Two accounts on #132 sat in exactly that state,
+    both showing a ``{"status": "int", "message": "str"}`` response skeleton
+    with no ``devices`` anywhere in it.
+
+    The login path has always checked the in-body status; the BFF paths never
+    did. This is that check, shared by all of them.
+
+    Args:
+        data: Parsed JSON body.
+        context: Short description of the call, used in the error message.
+
+    Raises:
+        GoveeAuthError: Body status is 401 — the token is no longer accepted.
+        GoveeApiError: Body status is any other non-success value.
+    """
+    if not isinstance(data, dict):
+        return
+    status = data.get("status")
+    # A missing status is fine: not every BFF endpoint sets one on success.
+    if status is None or status == 200:
+        return
+    message = data.get("message") or f"status {status}"
+    _LOGGER.debug(
+        "BFF %s returned an in-body error: status=%s message=%r",
+        context,
+        status,
+        message,
+    )
+    if status == 401:
+        raise GoveeAuthError(f"BFF {context} rejected the token: {message}", code=401)
+    raise GoveeApiError(f"BFF {context} failed: {message}", code=status)
+
+
 def _derive_client_id(email: str) -> str:
     """Derive a stable client_id from the account email.
 
@@ -663,6 +708,7 @@ class GoveeAuthClient:
                 raise GoveeApiError(
                     f"BFF device list failed: {message}", code=response.status
                 )
+            _raise_for_bff_status(data, "device topics")
             devices = data.get("data", {}).get("devices", [])
             self._gateway_routes = self._extract_gateway_routes(devices)
             return self._extract_topics_from_devices(devices)
@@ -792,6 +838,7 @@ class GoveeAuthClient:
                         code=response.status,
                     )
 
+                _raise_for_bff_status(data, "thermo-hygrometer list")
                 devices = data.get("data", {}).get("devices", [])
                 # Retain for the diagnostics census (#87 / #86 triage).
                 self._last_bff_raw_devices = (
@@ -962,6 +1009,7 @@ class GoveeAuthClient:
                     )
 
                 sensors: list[dict[str, Any]] = []
+                _raise_for_bff_status(data, "leak-sensor list")
                 devices = data.get("data", {}).get("devices", [])
                 # Retain for the diagnostics census + skeleton (PII-free; #87).
                 self._last_bff_raw_devices = (
@@ -1208,6 +1256,7 @@ class GoveeAuthClient:
                         f"BFF device list failed: {message}", code=response.status
                     )
 
+                _raise_for_bff_status(data, "device list")
                 for device in data.get("data", {}).get("devices", []):
                     raw_id = device.get("device", "")
                     key = raw_id.replace(":", "").upper()

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -239,6 +239,12 @@ SEGMENT_MODE_BOTH: Final = "both"
 CONFIG_VERSION: Final = 2
 
 # Keys for storing cached data in hass.data[DOMAIN]
+# Minimum gap between account re-login attempts after the BFF rejects the
+# stored token (issue #132). Repeated logins are what trips Govee's own 2FA
+# hardening, so a persistently failing account must back off rather than retry
+# on every 5-minute poll.
+IOT_RELOGIN_MIN_INTERVAL: Final = 900  # 15 minutes
+
 KEY_IOT_CREDENTIALS: Final = "iot_credentials"
 KEY_IOT_LOGIN_FAILED: Final = "iot_login_failed"
 

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -10,7 +10,7 @@ import asyncio
 import dataclasses
 import logging
 import time
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -18,11 +18,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .api import (
+    Govee2FARequiredError,
     GoveeApiClient,
     GoveeApiError,
     GoveeAuthError,
@@ -31,7 +33,7 @@ from .api import (
     GoveeIotCredentials,
     GoveeRateLimitError,
 )
-from .api.auth import GoveeAuthClient
+from .api.auth import GoveeAuthClient, _derive_client_id
 from .api.ble_packet import DIY_STYLE_NAMES
 from .api.openapi_events import GoveeOpenApiEventClient
 from .ble_passthrough import BlePassthroughManager
@@ -67,14 +69,19 @@ from .api.lan_client import (
 from .api.lan_control import command_to_lan, lan_brightness_to_device
 from .const import (
     CONF_API_TEMPERATURE_UNIT,
+    CONF_EMAIL,
     CONF_ENABLE_MQTT_CONTROL,
     CONF_LAN_TARGETS,
+    CONF_PASSWORD,
     CONF_WATER_DETECTOR_POLL_INTERVAL,
     DEFAULT_API_TEMPERATURE_UNIT,
     DEFAULT_ENABLE_MQTT_CONTROL,
     DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DEVICE_REDISCOVERY_INTERVAL,
     DOMAIN,
+    IOT_RELOGIN_MIN_INTERVAL,
+    KEY_IOT_CREDENTIALS,
+    KEY_IOT_LOGIN_FAILED,
     LAN_CORRELATION_TTL_SECONDS,
     LAN_READ_MISS_DEMOTE_THRESHOLD,
     LAN_RESCAN_INTERVAL,
@@ -366,6 +373,9 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # clear) — backs the sensor's changed_at attribute and restart
         # restore (#118).
         self._water_full_changed_at: dict[str, datetime] = {}
+        # Monotonic stamp of the last account re-login attempt, throttling
+        # recovery from an expired token (#132).
+        self._last_iot_relogin: float = -IOT_RELOGIN_MIN_INTERVAL
         self._leak_hubs: dict[str, dict[str, Any]] = {}
         self._sno_to_sensor_id: dict[tuple[str, int], str] = {}
         # (hub_device_id, sno) -> thermo device_id. The hub's multiSync thermo
@@ -1684,6 +1694,139 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if changed_at is not None:
             self._water_full_changed_at.setdefault(device_id, changed_at)
 
+    async def _async_refresh_iot_credentials(self) -> bool:
+        """Log in again to replace an account token the BFF has stopped accepting.
+
+        The token obtained at setup is cached in ``entry.data`` and reused
+        indefinitely — nothing ever refreshed it, and the stored
+        ``refresh_token`` was never used at all. When it eventually expires,
+        every BFF call fails while MQTT keeps working (it authenticates with
+        long-lived certificates, not this token), so the integration looks
+        healthy while battery levels and gateway-bridged readings quietly stop
+        (issue #132).
+
+        Re-logging in with the stored credentials is the recovery. Throttled to
+        one attempt per ``IOT_RELOGIN_MIN_INTERVAL`` so a persistent failure
+        can't hammer Govee's login endpoint — repeated logins are also what
+        triggers their 2FA hardening, which would turn a recoverable problem
+        into one needing the user.
+
+        Returns:
+            True when new credentials were obtained and stored.
+        """
+        email = self._config_entry.data.get(CONF_EMAIL)
+        password = self._config_entry.data.get(CONF_PASSWORD)
+        if not email or not password:
+            # API-key-only setup: nothing to log in with, and no BFF data was
+            # ever expected. Nothing to recover.
+            return False
+
+        now = time.monotonic()
+        if (now - self._last_iot_relogin) < IOT_RELOGIN_MIN_INTERVAL:
+            _LOGGER.debug("Skipping IoT re-login: attempted too recently")
+            return False
+        self._last_iot_relogin = now
+
+        _LOGGER.info("Account token rejected by the BFF — logging in again (#132)")
+        try:
+            async with GoveeAuthClient(hass=self.hass) as auth_client:
+                credentials = await auth_client.login(
+                    email,
+                    password,
+                    client_id=_derive_client_id(email),
+                )
+        except Govee2FARequiredError:
+            # Can't be solved here — a verification code needs the user. Say so
+            # once, loudly, instead of failing every poll in silence.
+            _LOGGER.warning(
+                "Account token expired and re-login needs email verification. "
+                "Use Reconfigure to enter a new verification code; "
+                "battery levels and gateway-bridged sensor readings stay "
+                "unavailable until then."
+            )
+            self._async_create_iot_reauth_issue("mqtt_2fa_required")
+            return False
+        except GoveeAuthError as err:
+            _LOGGER.warning(
+                "Account token expired and re-login was rejected: %s. "
+                "Use Reconfigure to update the account credentials.",
+                err,
+            )
+            self._async_create_iot_reauth_issue("mqtt_token_expired")
+            return False
+        except Exception as err:
+            _LOGGER.warning("Account re-login failed: %s", err)
+            return False
+
+        self._iot_credentials = credentials
+        self._persist_refreshed_credentials(credentials)
+        ir.async_delete_issue(
+            self.hass, DOMAIN, f"mqtt_token_expired_{self._config_entry.entry_id}"
+        )
+        _LOGGER.info("Account token refreshed — BFF data should resume")
+        return True
+
+    def _persist_refreshed_credentials(self, credentials: GoveeIotCredentials) -> None:
+        """Store refreshed credentials in ``entry.data`` so a reload reuses them.
+
+        Mirrors ``_persist_iot_credentials`` in ``__init__.py``; kept here
+        rather than imported to avoid a circular import between the coordinator
+        and the integration entry point.
+        """
+        new_data = dict(self._config_entry.data)
+        new_data[KEY_IOT_CREDENTIALS] = dataclasses.asdict(credentials)
+        new_data.pop(KEY_IOT_LOGIN_FAILED, None)
+        self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
+
+    def _async_create_iot_reauth_issue(self, translation_key: str) -> None:
+        """Surface a repair when only the user can restore BFF access."""
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"{translation_key}_{self._config_entry.entry_id}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=translation_key,
+            translation_placeholders={"entry_title": self._config_entry.title},
+        )
+
+    async def _async_bff_call(
+        self,
+        operation: Callable[[GoveeAuthClient, str], Awaitable[Any]],
+        description: str,
+    ) -> Any:
+        """Run a BFF call, re-logging in once if the token has expired (#132).
+
+        ``operation`` receives an open client and the current token, so a
+        caller that also needs client-side extras (the diagnostics census, the
+        gateway routes) can collect them before the client closes.
+
+        A ``GoveeAuthError`` here means the token was rejected — either as an
+        HTTP 401 or as the in-body error envelope Govee returns with HTTP 200
+        (see ``_raise_for_bff_status``). Both are recoverable by logging in
+        again, so that is tried exactly once; anything the retry raises reaches
+        the caller's own error handling unchanged.
+        """
+        if not self._iot_credentials:
+            return None
+
+        try:
+            async with GoveeAuthClient(hass=self.hass) as auth_client:
+                return await operation(auth_client, self._iot_credentials.token)
+        except GoveeAuthError as err:
+            _LOGGER.debug("BFF %s rejected the token: %s", description, err)
+
+        credentials = (
+            self._iot_credentials
+            if await self._async_refresh_iot_credentials()
+            else None
+        )
+        if credentials is None:
+            return None
+
+        async with GoveeAuthClient(hass=self.hass) as auth_client:
+            return await operation(auth_client, credentials.token)
+
     async def _fetch_device_topics(self) -> None:
         """Fetch device-specific MQTT topics from undocumented Govee API.
 
@@ -1694,19 +1837,19 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if not self._iot_credentials:
             return
 
+        async def _op(auth_client: GoveeAuthClient, token: str) -> None:
+            self._device_topics = await auth_client.fetch_device_topics(token)
+            # Gateway-attached BLE devices only act on commands published to
+            # their gateway's topic, not their own (#135).
+            self._gateway_routes = auth_client.gateway_routes()
+            _LOGGER.info(
+                "Fetched MQTT topics for %d devices (%d via a gateway)",
+                len(self._device_topics),
+                len(self._gateway_routes),
+            )
+
         try:
-            async with GoveeAuthClient(hass=self.hass) as auth_client:
-                self._device_topics = await auth_client.fetch_device_topics(
-                    self._iot_credentials.token
-                )
-                # Gateway-attached BLE devices only act on commands published to
-                # their gateway's topic, not their own (#135).
-                self._gateway_routes = auth_client.gateway_routes()
-                _LOGGER.info(
-                    "Fetched MQTT topics for %d devices (%d via a gateway)",
-                    len(self._device_topics),
-                    len(self._gateway_routes),
-                )
+            await self._async_bff_call(_op, "device topics")
         except GoveeApiError as err:
             _LOGGER.warning("Failed to fetch device topics: %s", err)
             # Continue without device topics - ptReal commands won't work
@@ -1723,23 +1866,23 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if not self._iot_credentials:
             return
 
+        async def _op(auth_client: GoveeAuthClient, token: str) -> Any:
+            result = await auth_client.fetch_bff_leak_sensors(token)
+            # Capture the PII-free census + skeleton before the client
+            # closes (#87).
+            self._bff_device_census = auth_client.bff_device_census()
+            self._bff_response_skeleton = auth_client.bff_response_skeleton()
+            self._bff_device_values = auth_client.bff_device_values()
+            return result
+
         try:
-            # Create a short-lived auth client per call, consistent with
+            # A short-lived auth client per call, consistent with
             # _fetch_device_topics(). The hass= param shares HA's managed
             # aiohttp.ClientSession, so no new TCP connections are created.
-            async with GoveeAuthClient(hass=self.hass) as auth_client:
-                (
-                    sensor_data,
-                    hub_data,
-                    thermo_readings,
-                ) = await auth_client.fetch_bff_leak_sensors(
-                    self._iot_credentials.token
-                )
-                # Capture the PII-free census + skeleton before the client
-                # closes (#87).
-                self._bff_device_census = auth_client.bff_device_census()
-                self._bff_response_skeleton = auth_client.bff_response_skeleton()
-                self._bff_device_values = auth_client.bff_device_values()
+            fetched = await self._async_bff_call(_op, "leak-sensor list")
+            if fetched is None:
+                return
+            sensor_data, hub_data, thermo_readings = fetched
 
             self._leak_hubs = hub_data
             for sensor in sensor_data:
@@ -1981,16 +2124,19 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if not self._iot_credentials:
             return
 
+        async def _op(auth_client: GoveeAuthClient, token: str) -> Any:
+            result = await auth_client.fetch_bff_thermo_hygrometers(token)
+            # Refresh the PII-free census so a diagnostics download shows the
+            # thermo-hygro SKU flags even when no leak sensors are present.
+            self._bff_device_census = auth_client.bff_device_census()
+            self._bff_response_skeleton = auth_client.bff_response_skeleton()
+            self._bff_device_values = auth_client.bff_device_values()
+            return result
+
         try:
-            async with GoveeAuthClient(hass=self.hass) as auth_client:
-                sensors = await auth_client.fetch_bff_thermo_hygrometers(
-                    self._iot_credentials.token
-                )
-                # Refresh the PII-free census so a diagnostics download shows the
-                # thermo-hygro SKU flags even when no leak sensors are present.
-                self._bff_device_census = auth_client.bff_device_census()
-                self._bff_response_skeleton = auth_client.bff_response_skeleton()
-                self._bff_device_values = auth_client.bff_device_values()
+            sensors = await self._async_bff_call(_op, "thermo-hygrometer list")
+            if sensors is None:
+                return
 
             for sensor in sensors:
                 device_id = sensor["device_id"]
@@ -2094,12 +2240,14 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             return
 
         try:
-            async with GoveeAuthClient(hass=self.hass) as auth_client:
-                sensors = await auth_client.fetch_bff_thermo_hygrometers(
-                    self._iot_credentials.token
-                )
+            sensors = await self._async_bff_call(
+                lambda client, token: client.fetch_bff_thermo_hygrometers(token),
+                "thermo-hygrometer refresh",
+            )
         except Exception as err:
             _LOGGER.debug("BFF thermo-hygrometer refresh failed: %s", err)
+            return
+        if sensors is None:
             return
 
         changed = False
@@ -2257,17 +2405,16 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         try:
             # Short-lived auth client, consistent with _fetch_device_topics()
             # and _discover_leak_sensors(). hass= reuses HA's aiohttp session.
-            async with GoveeAuthClient(hass=self.hass) as auth_client:
-                (
-                    sensor_data,
-                    _hub_data,
-                    thermo_readings,
-                ) = await auth_client.fetch_bff_leak_sensors(
-                    self._iot_credentials.token
-                )
+            fetched = await self._async_bff_call(
+                lambda client, token: client.fetch_bff_leak_sensors(token),
+                "leak-sensor poll",
+            )
         except Exception as err:
             _LOGGER.debug("BFF poll failed: %s", err)
             return
+        if fetched is None:
+            return
+        sensor_data, _hub_data, thermo_readings = fetched
 
         # Pick up leak sensors added to a hub after startup (issue #101). These
         # are BFF-only sub-devices, so they never appear in the Developer-API

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -385,6 +385,10 @@
     "mqtt_2fa_required": {
       "title": "Govee account requires verification",
       "description": "Your Govee account now requires email verification (2FA) to enable real-time MQTT updates for {entry_title}. Go to the integration page and select **Reconfigure** to re-enter your credentials with a verification code.\n\nThe integration will continue to work using polling until this is resolved."
+    },
+    "mqtt_token_expired": {
+      "title": "Govee account sign-in expired",
+      "description": "The saved Govee account sign-in for {entry_title} has expired, and signing in again was rejected \u2014 usually because the account password changed.\n\nWhile it is expired, battery levels and readings for sensors that reach Govee through a gateway (for example an H5310 or H5112 behind an H5044) stop updating. Lights and everything using the API key are unaffected.\n\nGo to the integration page and select **Reconfigure** to enter the current account password."
     }
   }
 }

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -385,6 +385,10 @@
     "mqtt_2fa_required": {
       "title": "Govee account requires verification",
       "description": "Your Govee account now requires email verification (2FA) to enable real-time MQTT updates for {entry_title}. Go to the integration page and select **Reconfigure** to re-enter your credentials with a verification code.\n\nThe integration will continue to work using polling until this is resolved."
+    },
+    "mqtt_token_expired": {
+      "title": "Govee account sign-in expired",
+      "description": "The saved Govee account sign-in for {entry_title} has expired, and signing in again was rejected \u2014 usually because the account password changed.\n\nWhile it is expired, battery levels and readings for sensors that reach Govee through a gateway (for example an H5310 or H5112 behind an H5044) stop updating. Lights and everything using the API key are unaffected.\n\nGo to the integration page and select **Reconfigure** to enter the current account password."
     }
   }
 }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2043,6 +2043,61 @@ class TestBffReadingHelper:
         )
 
 
+class TestBffInBodyErrorStatus:
+    """A BFF error returned with HTTP 200 must raise, not read as "no devices".
+
+    Govee answers an expired or rejected token with HTTP 200 and an error
+    envelope — ``{"status": 401, "message": "..."}`` with no ``data`` key at
+    all. Before #132 every caller read ``data["data"]["devices"]``, got ``[]``
+    from the missing key, and carried on as though the account owned no
+    devices: battery levels and gateway-bridged readings silently stopped
+    while MQTT (certificate-authenticated, so unaffected) kept the integration
+    looking healthy.
+    """
+
+    ERROR_BODY = {"status": 401, "message": "token is invalid"}
+
+    @pytest.mark.asyncio
+    async def test_thermo_list_raises_auth_error_on_body_401(self):
+        session = make_session_get(make_mock_response(200, self.ERROR_BODY))
+        client = GoveeAuthClient(session=session)
+        with pytest.raises(GoveeAuthError):
+            await client.fetch_bff_thermo_hygrometers(token="tok")
+
+    @pytest.mark.asyncio
+    async def test_leak_list_raises_auth_error_on_body_401(self):
+        session = make_session_get(make_mock_response(200, self.ERROR_BODY))
+        client = GoveeAuthClient(session=session)
+        with pytest.raises(GoveeAuthError):
+            await client.fetch_bff_leak_sensors(token="tok")
+
+    @pytest.mark.asyncio
+    async def test_non_401_body_status_raises_api_error(self):
+        session = make_session_get(
+            make_mock_response(200, {"status": 500, "message": "server busy"})
+        )
+        client = GoveeAuthClient(session=session)
+        with pytest.raises(GoveeApiError):
+            await client.fetch_bff_thermo_hygrometers(token="tok")
+
+    @pytest.mark.asyncio
+    async def test_success_status_is_not_treated_as_an_error(self):
+        body = _bff_response([])
+        body["status"] = 200
+        session = make_session_get(make_mock_response(200, body))
+        client = GoveeAuthClient(session=session)
+        assert await client.fetch_bff_thermo_hygrometers(token="tok") == []
+
+    @pytest.mark.asyncio
+    async def test_missing_status_is_not_treated_as_an_error(self):
+        """Not every BFF endpoint sets a status on success."""
+        body = _bff_response([])
+        body.pop("status", None)
+        session = make_session_get(make_mock_response(200, body))
+        client = GoveeAuthClient(session=session)
+        assert await client.fetch_bff_thermo_hygrometers(token="tok") == []
+
+
 class TestBffThermoHygrometerDiscovery:
     """H5301 thermo-hygrometers are discovered via the BFF list (issue #86)."""
 

--- a/tests/test_bff_token_refresh.py
+++ b/tests/test_bff_token_refresh.py
@@ -1,0 +1,238 @@
+"""Recovery from an expired Govee account token (issue #132).
+
+The token obtained at setup was cached in ``entry.data`` and reused
+indefinitely — nothing refreshed it, and the stored ``refresh_token`` was never
+used at all. Once it expired, every BFF call failed while MQTT kept working (it
+authenticates with long-lived certificates rather than this token), so battery
+levels and gateway-bridged sensor readings stopped with the integration still
+reporting itself healthy.
+
+Two accounts on #132 sat in exactly that state, both showing a
+``{"status": "int", "message": "str"}`` BFF response skeleton with no
+``devices`` in it at all.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.govee.api.auth import GoveeIotCredentials
+from custom_components.govee.api.exceptions import (
+    Govee2FARequiredError,
+    GoveeAuthError,
+)
+from custom_components.govee.const import IOT_RELOGIN_MIN_INTERVAL
+from custom_components.govee.coordinator import GoveeCoordinator
+
+STALE = GoveeIotCredentials(
+    token="stale",
+    refresh_token="r",
+    account_topic="GA/x",
+    iot_cert="c",
+    iot_key="k",
+    iot_ca=None,
+    client_id="cid",
+    endpoint="ep",
+)
+
+
+def _coordinator(*, email="a@b.c", password="pw", credentials=STALE):
+    """A coordinator with just the attributes the token paths touch."""
+    coordinator = GoveeCoordinator.__new__(GoveeCoordinator)
+    data = {}
+    if email:
+        data["email"] = email
+    if password:
+        data["password"] = password
+    coordinator._config_entry = SimpleNamespace(
+        data=data, options={}, entry_id="e1", title="Govee"
+    )
+    coordinator.hass = MagicMock()
+    coordinator._iot_credentials = credentials
+    coordinator._last_iot_relogin = -IOT_RELOGIN_MIN_INTERVAL * 10
+    coordinator._persist_refreshed_credentials = MagicMock()
+    return coordinator
+
+
+def _patched_client(auth_client):
+    """Patch the coordinator's GoveeAuthClient to yield ``auth_client``."""
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=auth_client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return patch(
+        "custom_components.govee.coordinator.GoveeAuthClient", return_value=ctx
+    )
+
+
+class TestBffCallRetry:
+    """_async_bff_call refreshes the token once and retries."""
+
+    @pytest.mark.asyncio
+    async def test_expired_token_is_refreshed_and_the_call_retried(self):
+        coordinator = _coordinator()
+        fresh = dataclasses.replace(STALE, token="fresh")
+        seen: list[str] = []
+
+        async def _op(_client, token):
+            seen.append(token)
+            if token == "stale":
+                raise GoveeAuthError("token is invalid", code=401)
+            return ["payload"]
+
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock(return_value=fresh)
+
+        with _patched_client(auth_client), patch(
+            "custom_components.govee.coordinator.ir"
+        ):
+            result = await coordinator._async_bff_call(_op, "test call")
+
+        # First attempt on the stale token, second on the refreshed one.
+        assert seen == ["stale", "fresh"]
+        assert result == ["payload"]
+        assert coordinator._iot_credentials.token == "fresh"
+        coordinator._persist_refreshed_credentials.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_successful_call_does_not_relogin(self):
+        coordinator = _coordinator()
+
+        async def _op(_client, token):
+            return {"token": token}
+
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock()
+
+        with _patched_client(auth_client):
+            result = await coordinator._async_bff_call(_op, "test call")
+
+        assert result == {"token": "stale"}
+        auth_client.login.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_short_circuits(self):
+        coordinator = _coordinator(credentials=None)
+        called = False
+
+        async def _op(_client, _token):
+            nonlocal called
+            called = True
+
+        assert await coordinator._async_bff_call(_op, "test call") is None
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_retry_failure_propagates_to_the_caller(self):
+        """A second rejection is the caller's to handle, not swallowed here."""
+        coordinator = _coordinator()
+        fresh = dataclasses.replace(STALE, token="fresh")
+
+        async def _op(_client, _token):
+            raise GoveeAuthError("still invalid", code=401)
+
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock(return_value=fresh)
+
+        with _patched_client(auth_client), patch(
+            "custom_components.govee.coordinator.ir"
+        ), pytest.raises(GoveeAuthError):
+            await coordinator._async_bff_call(_op, "test call")
+
+
+class TestRelogin:
+    """_async_refresh_iot_credentials and its guards."""
+
+    @pytest.mark.asyncio
+    async def test_api_key_only_setup_never_logs_in(self):
+        """No stored account credentials means nothing to recover."""
+        coordinator = _coordinator(email=None, password=None)
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock()
+
+        with _patched_client(auth_client):
+            assert await coordinator._async_refresh_iot_credentials() is False
+        auth_client.login.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_relogin_is_throttled(self):
+        """A persistently failing account must not hammer the login endpoint.
+
+        Repeated logins are what trips Govee's own 2FA hardening, which would
+        turn a recoverable expiry into one that needs the user.
+        """
+        coordinator = _coordinator()
+        fresh = dataclasses.replace(STALE, token="fresh")
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock(return_value=fresh)
+
+        with _patched_client(auth_client), patch(
+            "custom_components.govee.coordinator.ir"
+        ):
+            assert await coordinator._async_refresh_iot_credentials() is True
+            assert await coordinator._async_refresh_iot_credentials() is False
+
+        assert auth_client.login.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_2fa_raises_a_repair_instead_of_retrying_forever(self):
+        """A verification code needs the user — say so once, loudly."""
+        coordinator = _coordinator()
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock(side_effect=Govee2FARequiredError())
+
+        with _patched_client(auth_client), patch(
+            "custom_components.govee.coordinator.ir"
+        ) as ir_mod:
+            assert await coordinator._async_refresh_iot_credentials() is False
+
+        ir_mod.async_create_issue.assert_called_once()
+        assert (
+            ir_mod.async_create_issue.call_args.kwargs["translation_key"]
+            == "mqtt_2fa_required"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejected_password_raises_its_own_repair(self):
+        coordinator = _coordinator()
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock(side_effect=GoveeAuthError("bad password"))
+
+        with _patched_client(auth_client), patch(
+            "custom_components.govee.coordinator.ir"
+        ) as ir_mod:
+            assert await coordinator._async_refresh_iot_credentials() is False
+
+        assert (
+            ir_mod.async_create_issue.call_args.kwargs["translation_key"]
+            == "mqtt_token_expired"
+        )
+
+    @pytest.mark.asyncio
+    async def test_success_clears_the_expiry_repair(self):
+        coordinator = _coordinator()
+        fresh = dataclasses.replace(STALE, token="fresh")
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock(return_value=fresh)
+
+        with _patched_client(auth_client), patch(
+            "custom_components.govee.coordinator.ir"
+        ) as ir_mod:
+            assert await coordinator._async_refresh_iot_credentials() is True
+
+        ir_mod.async_delete_issue.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_is_not_fatal(self):
+        """A network hiccup must not take the poll loop down with it."""
+        coordinator = _coordinator()
+        auth_client = MagicMock()
+        auth_client.login = AsyncMock(side_effect=OSError("connection reset"))
+
+        with _patched_client(auth_client), patch(
+            "custom_components.govee.coordinator.ir"
+        ):
+            assert await coordinator._async_refresh_iot_credentials() is False


### PR DESCRIPTION
## What the diagnostics showed

Two accounts on #132 lost battery levels after an update and never got them back. Both diagnostics say the same thing:

| | matteo (H5109) | thrstnbecker (H5075×3, H5110×2) |
|---|---|---|
| `has_iot_credentials` | true | true |
| MQTT | connected | connected |
| `bff_response_skeleton` | `{"status": "int", "message": "str"}` | `{"status": "int", "message": "str"}` |
| `bff_device_census` | `[]` | `[]` |

That skeleton has **no `data.devices` key at all** — it's an error envelope. Compare a working account (#150), whose skeleton carries `data.devices: list[50]`.

Govee returns that envelope with **HTTP 200**, and every BFF caller does:

```python
devices = data.get("data", {}).get("devices", [])
```

→ `[]`, silently. The login path has always checked the in-body `status` (`auth.py:1553`); the four BFF device-list paths never did.

## Why nobody could see it

MQTT authenticates with long-lived certificates, not this token. So it stays connected, the integration reports itself healthy, and only the things that depend on the BFF — battery levels, gateway-bridged sensor readings — stop. @matteotomasoni reasonably concluded Govee had withdrawn the data.

Underneath that: the token obtained at setup is cached in `entry.data` and reused **forever**. Nothing refreshed it, and the `refresh_token` we store is never used anywhere in the codebase. Once it expires the account is stuck permanently — which is why an update, and the reload it triggers, appeared to cause it.

## Changes

**1. `_raise_for_bff_status()`** — checks the in-body status on all four BFF device-list paths. `401` → `GoveeAuthError`; any other non-success → `GoveeApiError`. A *missing* status stays fine, since not every endpoint sets one on success.

**2. `_async_bff_call()`** — runs a BFF operation and, if the token is rejected, logs in again and retries exactly once. All five BFF call sites now go through it. The operation receives the open client, so callers that also collect client-side extras (the diagnostics census, the gateway routes) still get them before it closes.

**3. `_async_refresh_iot_credentials()`** — re-logs in with the stored account credentials and persists the result so a reload reuses the fresh token.

Throttled to one attempt per 15 minutes. Repeated logins are what trips Govee's own 2FA hardening, and turning a recoverable expiry into one that needs the user would be worse than waiting.

When re-login can't succeed on its own — 2FA required, or a password that has since changed — it raises a repair issue naming what stopped working, instead of failing every poll in silence. `mqtt_token_expired` is a new string for the password case; the 2FA case reuses the existing one.

An API-key-only setup never attempts any of this: no account credentials to log in with, and no BFF data was ever expected.

## Scope note

This does **not** use the `refresh_token`, because I don't know Govee's refresh endpoint. It re-runs the normal login, which is a known-good path. If someone identifies the refresh endpoint later, swapping it in is a small change and would avoid the 2FA exposure entirely.

## Verification

15 new tests: the error envelope on both list endpoints, non-401 body statuses, success and missing-status cases, refresh-and-retry, no-credentials short circuit, retry-failure propagation, the throttle, both repair paths, and a network error during re-login.

1750 pass, flake8 clean.

## Expected impact beyond #132

Likely the same cause in **#145**, where @ftremblay91's H5058 battery is missing while leak detection works. Worth re-checking once this ships.

More broadly, anyone whose battery or gateway-bridged readings quietly stopped and who never filed an issue would be in this state, with no way to tell from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
