### PR TITLE
feat(sensor): read the second probe on dual-probe thermometers (H5112)

### DIFF
--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -243,6 +243,19 @@ _BFF_HUMIDITY_KEYS = (
     ("sensorHumidity", False),
     ("currentHumidity", False),
 )
+# Second temperature probe. Dual-probe SKUs (the H5112 fridge/freezer
+# thermometer, issue #150) report each probe separately: ``tem`` is probe 1 and
+# ``tem2`` is probe 2, and the settings carry a matching second set of
+# ``probeName2`` / ``temMin2`` / ``temMax2`` / ``temCali2`` fields.
+#
+# Either probe can be absent independently — an unplugged probe 1 reports the
+# ``-1`` sentinel while probe 2 reads normally. Reporter diagnostics on #150
+# showed exactly that on two of three units, which is why they surfaced no
+# temperature at all despite a working probe.
+_BFF_TEMP2_KEYS = (
+    ("tem2", True),
+    ("temperature2", False),
+)
 
 # u16 "no reading / no sensor" sentinels Govee reports for a missing centi value
 # (e.g. the H5310 pool thermometer has no hygrometer and reports hum == 0xFFFF,
@@ -804,7 +817,8 @@ class GoveeAuthClient:
 
         Returns:
             List of dicts, each with keys: device_id, name, sku, sw_version,
-            hw_version, battery, online, temperature (°C or None), humidity
+            hw_version, battery, online, temperature (°C or None),
+            temperature_2 (°C or None — dual-probe SKUs, #150), humidity
             (%RH or None), hub_device_id, hub_sku, sno.
         """
         if self._session is None:
@@ -924,6 +938,7 @@ class GoveeAuthClient:
                             "battery": settings.get("battery"),
                             "online": ld.get("online", True),
                             "temperature": _bff_reading(ld, _BFF_TEMP_KEYS),
+                            "temperature_2": _bff_reading(ld, _BFF_TEMP2_KEYS),
                             "humidity": _bff_reading(ld, _BFF_HUMIDITY_KEYS),
                             "hub_device_id": gateway_info.get("device", ""),
                             "hub_sku": gateway_info.get("sku", ""),

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -339,6 +339,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # sensor missed at startup (issue #132), so a slow tick doesn't queue a
         # reload every 5 minutes while the reload is pending.
         self._battery_reload_scheduled = False
+        # Same one-shot guard for a second temperature probe that starts
+        # reporting after startup — plugging one in must not need a manual
+        # restart to get its entity (#150).
+        self._probe2_reload_scheduled = False
         # Leak sensor subsystem
         self._leak_sensors: dict[str, GoveeLeakSensor] = {}
         self._leak_states: dict[str, GoveeLeakSensorState] = {}
@@ -683,10 +687,15 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         semantic is last *change*, not last confirmation. First reading stamps
         too (device not yet in the map).
         """
-        if new_state.sensor_temperature is None and new_state.sensor_humidity is None:
+        if (
+            new_state.sensor_temperature is None
+            and new_state.sensor_temperature_2 is None
+            and new_state.sensor_humidity is None
+        ):
             return
         reading_changed = (
             new_state.sensor_temperature != existing_state.sensor_temperature
+            or new_state.sensor_temperature_2 != existing_state.sensor_temperature_2
             or new_state.sensor_humidity != existing_state.sensor_humidity
         )
         if reading_changed or device_id not in self._sensor_reading_changed_at:
@@ -2162,6 +2171,7 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 if device_id in self._devices:
                     if (
                         sensor.get("temperature") is None
+                        and sensor.get("temperature_2") is None
                         and sensor.get("humidity") is None
                     ):
                         _LOGGER.debug(
@@ -2179,6 +2189,8 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                     state.online = sensor.get("online", state.online)
                     if sensor.get("temperature") is not None:
                         state.sensor_temperature = sensor.get("temperature")
+                    if sensor.get("temperature_2") is not None:
+                        state.sensor_temperature_2 = sensor.get("temperature_2")
                     if sensor.get("humidity") is not None:
                         state.sensor_humidity = sensor.get("humidity")
                     if sensor.get("battery") is not None:
@@ -2208,6 +2220,7 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 state = GoveeDeviceState.create_empty(device_id)
                 state.online = sensor.get("online", True)
                 state.sensor_temperature = sensor.get("temperature")
+                state.sensor_temperature_2 = sensor.get("temperature_2")
                 state.sensor_humidity = sensor.get("humidity")
                 state.battery = sensor.get("battery")
                 self._states[device_id] = state
@@ -2258,7 +2271,11 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             # A device parked on the Developer poll because the BFF had nothing
             # for it (#151) takes over here as soon as a reading appears.
             if device_id in self._bff_thermo_pending:
-                if sensor.get("temperature") is None and sensor.get("humidity") is None:
+                if (
+                    sensor.get("temperature") is None
+                    and sensor.get("temperature_2") is None
+                    and sensor.get("humidity") is None
+                ):
                     continue
                 _LOGGER.info(
                     "BFF now reports %s — taking over its readings from the "
@@ -2280,6 +2297,28 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 if sensor.get("temperature") is not None
                 else existing.sensor_temperature
             )
+            new_state.sensor_temperature_2 = (
+                sensor.get("temperature_2")
+                if sensor.get("temperature_2") is not None
+                else existing.sensor_temperature_2
+            )
+            # A probe plugged in after startup has no entity yet: the sensor
+            # platform only creates one when a reading is already present.
+            # Reload once so it appears, mirroring the late-battery path (#150).
+            if (
+                existing.sensor_temperature_2 is None
+                and new_state.sensor_temperature_2 is not None
+                and not self._probe2_reload_scheduled
+            ):
+                self._probe2_reload_scheduled = True
+                _LOGGER.info(
+                    "Second temperature probe now reporting for %s — reloading "
+                    "the integration to add its sensor (#150)",
+                    sensor.get("name", device_id),
+                )
+                self.hass.config_entries.async_schedule_reload(
+                    self._config_entry.entry_id
+                )
             new_state.sensor_humidity = (
                 sensor.get("humidity")
                 if sensor.get("humidity") is not None

--- a/custom_components/govee/models/state.py
+++ b/custom_components/govee/models/state.py
@@ -253,6 +253,11 @@ class GoveeDeviceState:
     sensor_temperature: float | None = (
         None  # Raw from API (°C or °F; entity may normalize)
     )
+    # Second temperature probe on dual-probe SKUs (H5112, issue #150). Set
+    # only from the BFF ``tem2`` field — the Developer API exposes a single
+    # sensorTemperature and has no concept of a second probe. Independent of
+    # sensor_temperature: either probe can be unplugged while the other reads.
+    sensor_temperature_2: float | None = None
     sensor_humidity: float | None = None  # Relative humidity 0-100 %
     battery: int | None = None  # Battery level 0-100 % (BFF thermo-hygrometers)
 

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -85,6 +85,13 @@ async def async_setup_entry(
         entities.append(GoveeLastCommandSentSensor(coordinator, device))
         if device.supports_temperature_sensor:
             entities.append(GoveeTemperatureSensor(coordinator, device))
+        # Second probe on dual-probe SKUs (#150). Gated on a reading actually
+        # being present rather than on the SKU: the same model ships with one
+        # or two probes connected, and a device with nothing on probe 2 must
+        # not gain an entity that can only ever read unknown.
+        probe_state = coordinator.get_state(device.device_id)
+        if probe_state is not None and probe_state.sensor_temperature_2 is not None:
+            entities.append(GoveeSecondProbeTemperatureSensor(coordinator, device))
         if device.supports_humidity_sensor:
             entities.append(GoveeHumiditySensor(coordinator, device))
         # Air-quality index (H5106 monitor, H7124/H7126 purifiers) — read-only
@@ -320,12 +327,19 @@ class GoveeTemperatureSensor(_BffThermometerAvailabilityMixin, SensorEntity):
         self._attr_unique_id = f"{device.device_id}_temperature"
 
     @property
-    def native_value(self) -> float | None:
+    def _raw_reading(self) -> float | None:
+        """The stored reading this entity converts. Overridden per probe."""
         state = self.device_state
-        if not state or state.sensor_temperature is None:
+        return state.sensor_temperature if state else None
+
+    @property
+    def native_value(self) -> float | None:
+        raw = self._raw_reading
+        if raw is None:
             return None
 
-        value = float(state.sensor_temperature)
+        state = self.device_state
+        value = float(raw)
 
         # BFF-sourced readings (lastDeviceData) are already canonical °C from
         # _bff_reading's centi-scaling, so the SKU-based °F conversion below —
@@ -363,6 +377,41 @@ class GoveeTemperatureSensor(_BffThermometerAvailabilityMixin, SensorEntity):
             return (value - 32.0) * (5.0 / 9.0)
 
         return value
+
+
+class GoveeSecondProbeTemperatureSensor(GoveeTemperatureSensor):
+    """The second temperature probe on a dual-probe SKU (H5112, issue #150).
+
+    These fridge/freezer thermometers carry two independent probes and report
+    them separately — ``tem`` and ``tem2`` in the BFF payload, with a matching
+    second set of ``probeName2`` / ``temMin2`` / ``temMax2`` settings. The
+    Developer API exposes a single ``sensorTemperature`` and has no concept of
+    the second one, so this reading exists only on the BFF path.
+
+    The probes are genuinely independent: reporter diagnostics on #150 showed
+    two of three units with probe 1 unplugged (reporting the ``-1`` sentinel)
+    while probe 2 read normally, which is why those devices surfaced no
+    temperature at all. Created only when a probe-2 reading is actually
+    present, so single-probe devices don't gain a permanently-unknown entity.
+
+    Everything else — the °F/°C normalization, availability, device class —
+    is inherited; only which stored field is read differs.
+    """
+
+    _attr_translation_key = "sensor_temperature_2"
+
+    def __init__(
+        self,
+        coordinator: GoveeCoordinator,
+        device: GoveeDevice,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.device_id}_temperature_2"
+
+    @property
+    def _raw_reading(self) -> float | None:
+        state = self.device_state
+        return state.sensor_temperature_2 if state else None
 
 
 class GoveeAirQualitySensor(GoveeEntity, SensorEntity):

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -216,6 +216,9 @@
       "sensor_temperature": {
         "name": "Temperature"
       },
+      "sensor_temperature_2": {
+        "name": "Probe 2 temperature"
+      },
       "sensor_humidity": {
         "name": "Humidity"
       },

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -216,6 +216,9 @@
       "sensor_temperature": {
         "name": "Temperature"
       },
+      "sensor_temperature_2": {
+        "name": "Probe 2 temperature"
+      },
       "sensor_humidity": {
         "name": "Humidity"
       },

--- a/tests/test_dual_probe.py
+++ b/tests/test_dual_probe.py
@@ -1,0 +1,153 @@
+"""Second temperature probe on dual-probe SKUs (issue #150).
+
+The H5112 fridge/freezer thermometer carries two independent probes and reports
+them separately: ``tem`` is probe 1 and ``tem2`` is probe 2, with a matching
+second set of ``probeName2`` / ``temMin2`` / ``temMax2`` / ``temCali2``
+settings. Only ``tem`` was ever read.
+
+Either probe can be absent on its own. Reporter diagnostics on #150 showed
+three H5112s behind one H5044 where two had probe 1 unplugged — reporting the
+``-1`` sentinel that correctly decodes to "no reading" — while probe 2 read
+normally. Those two devices surfaced no temperature at all, despite carrying a
+perfectly good reading the integration never looked at.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.govee.api.auth import GoveeAuthClient
+from custom_components.govee.sensor import (
+    GoveeSecondProbeTemperatureSensor,
+    GoveeTemperatureSensor,
+)
+
+from .test_auth import _bff_response, make_mock_response, make_session_get
+
+
+def _h5112(*, tem, hum, tem2, sno=1):
+    """A BFF device entry shaped like the #150 reporter's H5112s."""
+    return {
+        "sku": "H5112",
+        "device": f"00:00:00:00:00:00:00:00:0{sno}:8D:DB:48:C2:06:12:5D",
+        "deviceName": f"Freezer {sno}",
+        "deviceExt": json.dumps(
+            {
+                "deviceSettings": json.dumps(
+                    {
+                        "battery": 100,
+                        "sno": sno,
+                        "fahOpen": False,
+                        "gatewayInfo": {
+                            "device": "11:22:33:44:55:66:77:88",
+                            "sku": "H5044",
+                        },
+                    }
+                ),
+                "lastDeviceData": json.dumps(
+                    {"online": False, "tem": tem, "hum": hum, "tem2": tem2}
+                ),
+            }
+        ),
+    }
+
+
+class TestSecondProbeParsing:
+    """``tem2`` is read alongside ``tem``, and each can be absent alone."""
+
+    @pytest.mark.asyncio
+    async def test_both_probes_present(self):
+        """The unit whose probe 1 works also has a probe 2 we ignored before."""
+        session = make_session_get(
+            make_mock_response(200, _bff_response([_h5112(tem=-1710, hum=6920, tem2=660, sno=3)]))
+        )
+        sensor = (await GoveeAuthClient(session=session).fetch_bff_thermo_hygrometers(token="t"))[0]
+        assert sensor["temperature"] == -17.1
+        assert sensor["temperature_2"] == 6.6
+        assert sensor["humidity"] == 69.2
+
+    @pytest.mark.asyncio
+    async def test_probe_one_unplugged_still_yields_probe_two(self):
+        """The #150 case: tem is the -1 sentinel, tem2 holds the real value."""
+        session = make_session_get(
+            make_mock_response(200, _bff_response([_h5112(tem=-1, hum=65535, tem2=-420, sno=1)]))
+        )
+        sensor = (await GoveeAuthClient(session=session).fetch_bff_thermo_hygrometers(token="t"))[0]
+        # Both sentinels correctly decode to "absent"...
+        assert sensor["temperature"] is None
+        assert sensor["humidity"] is None
+        # ...and the reading that does exist is no longer thrown away.
+        assert sensor["temperature_2"] == -4.2
+
+    @pytest.mark.asyncio
+    async def test_single_probe_device_has_no_second_reading(self):
+        """A device with no tem2 must not gain a phantom probe."""
+        device = _h5112(tem=2350, hum=4500, tem2=None)
+        ext = json.loads(device["deviceExt"])
+        last = json.loads(ext["lastDeviceData"])
+        del last["tem2"]
+        ext["lastDeviceData"] = json.dumps(last)
+        device["deviceExt"] = json.dumps(ext)
+
+        session = make_session_get(make_mock_response(200, _bff_response([device])))
+        sensor = (await GoveeAuthClient(session=session).fetch_bff_thermo_hygrometers(token="t"))[0]
+        assert sensor["temperature"] == 23.5
+        assert sensor["temperature_2"] is None
+
+    @pytest.mark.asyncio
+    async def test_second_probe_sentinel_is_absent_too(self):
+        session = make_session_get(
+            make_mock_response(200, _bff_response([_h5112(tem=2350, hum=4500, tem2=-1)]))
+        )
+        sensor = (await GoveeAuthClient(session=session).fetch_bff_thermo_hygrometers(token="t"))[0]
+        assert sensor["temperature_2"] is None
+
+
+class TestSecondProbeEntity:
+    """The probe-2 entity reuses probe 1's conversion, reading a different field."""
+
+    def _stub(self, *, temperature, temperature_2, sku="H5112", bff=True):
+        state = SimpleNamespace(
+            sensor_temperature=temperature,
+            sensor_temperature_2=temperature_2,
+        )
+        coordinator = SimpleNamespace(
+            config_entry=SimpleNamespace(options={}),
+            is_bff_thermometer=lambda _device_id: bff,
+            account_temperature_unit=lambda _device_id: None,
+        )
+        return SimpleNamespace(
+            device_state=state,
+            coordinator=coordinator,
+            _device=SimpleNamespace(sku=sku),
+            _device_id="AA:BB:CC:DD:EE:FF:00:11",
+        )
+
+    def test_reads_the_second_field_not_the_first(self):
+        stub = self._stub(temperature=-17.1, temperature_2=6.6)
+        raw = GoveeSecondProbeTemperatureSensor._raw_reading.fget(stub)
+        assert raw == 6.6
+
+    def test_primary_entity_still_reads_the_first(self):
+        stub = self._stub(temperature=-17.1, temperature_2=6.6)
+        assert GoveeTemperatureSensor._raw_reading.fget(stub) == -17.1
+
+    def test_absent_second_probe_reads_none(self):
+        stub = self._stub(temperature=23.5, temperature_2=None)
+        assert GoveeSecondProbeTemperatureSensor._raw_reading.fget(stub) is None
+
+    def test_unit_conversion_is_shared_with_probe_one(self):
+        """A °F-reporting SKU converts probe 2 exactly as it converts probe 1."""
+        stub = self._stub(temperature=32.0, temperature_2=212.0, sku="H5109", bff=False)
+        stub._raw_reading = 212.0
+        assert abs(GoveeSecondProbeTemperatureSensor.native_value.fget(stub) - 100.0) < 1e-6
+
+    def test_distinct_unique_id_from_probe_one(self):
+        """Sharing a unique_id would make HA drop one of the two entities."""
+        assert (
+            GoveeSecondProbeTemperatureSensor._attr_translation_key
+            != GoveeTemperatureSensor._attr_translation_key
+        )

--- a/tests/test_thermometer.py
+++ b/tests/test_thermometer.py
@@ -195,6 +195,9 @@ class TestTemperatureSensorFahrenheitConversion:
             coordinator=coordinator,
             _device=SimpleNamespace(sku=sku),
             _device_id="AA:BB:CC:DD:EE:FF:00:11",
+            # native_value reads the stored value through this hook so the
+            # second probe reuses the same conversion path (#150).
+            _raw_reading=raw_value,
         )
         return GoveeTemperatureSensor.native_value.fget(stub)
 
@@ -247,6 +250,7 @@ class TestTemperatureSensorFahrenheitConversion:
             coordinator=coordinator,
             _device=SimpleNamespace(sku="H5109"),
             _device_id="AA:BB:CC:DD:EE:FF:00:11",
+            _raw_reading=state.sensor_temperature,
         )
         # Default is auto -> known °F SKU converts.
         result = GoveeTemperatureSensor.native_value.fget(stub)
@@ -271,6 +275,7 @@ class TestTemperatureSensorFahrenheitConversion:
             coordinator=coordinator,
             _device=SimpleNamespace(sku="H5179"),
             _device_id="AA:BB:CC:DD:EE:FF:00:11",
+            _raw_reading=state.sensor_temperature,
         )
         assert GoveeTemperatureSensor.native_value.fget(stub) == 4.9
 


### PR DESCRIPTION
> **Stacked on #169** (the #132 BFF fix) — both touch the same BFF discovery paths, so basing this on master would have meant resolving the overlap twice. Review/merge #169 first; the diff here is only the second-probe work.

## What the diagnostics showed

Two of the three H5112s in @mikejhendricks' diagnostics showed no temperature at all. Their BFF payloads say why:

| `sno` | `tem` | `hum` | `tem2` | In HA |
|---|---|---|---|---|
| 3 | `-1710` | `6920` | `660` | **−17.1 °C, 69.2%** ✓ |
| 2 | `-1` | `65535` | `660` | blank |
| 1 | `-1` | `65535` | `-420` | blank |

`-1` and `65535` are already handled correctly as no-reading sentinels, so those two devices genuinely had nothing to show — *from `tem` and `hum`*. The reading was sitting in **`tem2`** the whole time, and nothing ever looked at it.

The H5112 is a dual-probe fridge/freezer thermometer. `tem` is probe 1, `tem2` is probe 2, and `deviceSettings` carries a matching second set of `probeName2` / `temMin2` / `temMax2` / `temCali2` fields. The probes are independent — an unplugged probe 1 reports the sentinel while probe 2 reads normally, which is what those two units were doing.

**This isn't a fallback.** `sno=3` has *both* populated (−17.1 °C and 6.6 °C), so it's a second reading we were discarding on every unit, including the one that appeared to work. Adding `tem2` to the fallback chain would have unblocked the two broken devices while continuing to hide probe 2 on the third.

## Changes

- `_BFF_TEMP2_KEYS` parses `tem2`, returned as `temperature_2`.
- `GoveeDeviceState.sensor_temperature_2` carries it.
- `GoveeSecondProbeTemperatureSensor` subclasses `GoveeTemperatureSensor` and overrides only *which field it reads* — the °F/°C normalization, availability rules and device class are shared rather than duplicated. `native_value` now reads through a `_raw_reading` hook to make that possible.
- Created **only when a probe-2 reading is present**. The same SKU ships with one or two probes connected, so gating on the SKU would hand single-probe owners an entity that can only ever read unknown.
- The "BFF has nothing for this device" check now considers probe 2 — otherwise the two affected units stay parked on a Developer poll that returns nothing for them (the #151 gate).
- A probe plugged in after startup triggers one reload so its entity appears, mirroring the existing late-battery path. Without it, plugging in a probe needs a manual restart.

## Verification

Replayed the reporter's verbatim payloads through the parser:

```
 sno     tem    tem2 |   probe1   probe2     hum   before -> after
   3   -1710     660 |    -17.1      6.6    69.2   -17.1 °C -> probe1 -17.1 °C, probe2 6.6 °C
   2      -1     660 |     None      6.6    None   blank -> probe2 6.6 °C
   1      -1    -420 |     None     -4.2    None   blank -> probe2 -4.2 °C
```

All three devices now produce readings. 9 new tests cover both probes present, probe 1 unplugged, no `tem2` at all, a probe-2 sentinel, and the entity reading the right field through the shared conversion. 1759 pass, flake8 clean.

## Note for @mikejhendricks

Two of your three units have nothing connected to probe 1 — that's a physical thing, not a bug. After this ships you'll get a "Probe 2 temperature" entity on each, and the third unit gains one alongside its existing reading. If you expected probe 1 to be live on those two, worth checking the connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
