### PR TITLE
feat(ble): encrypted BLE transport for newer SKUs

### DIFF
--- a/custom_components/govee/api/ble.py
+++ b/custom_components/govee/api/ble.py
@@ -44,6 +44,7 @@ See ``docs/_research/2026-04-08_ble-direct-support.md`` and
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -58,6 +59,11 @@ from bleak_retry_connector import (  # type: ignore[attr-defined]
     establish_connection,
 )
 
+from .ble_crypto import (
+    GoveeBLESession,
+    async_establish_session,
+    async_supports_encryption,
+)
 from .ble_packet import build_packet
 
 if TYPE_CHECKING:
@@ -75,7 +81,13 @@ BLE_DISCOVERY_NAMES: tuple[str, ...] = ("Govee_", "ihoment_", "GBK_")
 
 # SKUs that use the segmented color encoding. Lifted directly from
 # Beshelmek/govee_ble_lights `SEGMENTED_MODELS` (light.py:35).
-SEGMENTED_MODELS: frozenset[str] = frozenset({"H6053", "H6072", "H6102", "H6199"})
+#
+# H1270 is not in that reference list but requires the segmented encoding:
+# field testing showed it silently discards the single-zone frame (the colour
+# read-back stays black) and only acts on mode 0x15.
+SEGMENTED_MODELS: frozenset[str] = frozenset(
+    {"H6053", "H6072", "H6102", "H6199", "H1270"}
+)
 
 # SKUs with verified BLE command support. BLE command dispatch is only
 # attempted for devices on this list — advertising over BLE is not
@@ -91,6 +103,11 @@ SEGMENTED_MODELS: frozenset[str] = frozenset({"H6053", "H6072", "H6102", "H6199"
 BLE_COMMAND_SUPPORTED_MODELS: frozenset[str] = frozenset(
     {
         "H6199",  # RGBIC — confirmed working per issue #59 (at-9 report, ~10s lag).
+        # H1270 accepts commands only over the encrypted protocol; plaintext
+        # frames are dropped without any error, which is why it read as
+        # "advertises BLE but ignores writes" before ble_crypto existed.
+        # Field-tested on hardware: power, brightness and colour all confirmed.
+        "H1270",
     }
 )
 
@@ -248,6 +265,9 @@ class GoveeBLEDevice:
         self._refresh_ble_device = refresh_ble_device
         self._segmented = segmented
         self._client: BleakClient | None = None
+        # Set only for devices speaking the encrypted protocol, and only for
+        # as long as the connection that negotiated it lives.
+        self._session: GoveeBLESession | None = None
         self._state = GoveeBLEState()
         self._lock = asyncio.Lock()
         self._callbacks: list[Callable[[GoveeBLEState], None]] = []
@@ -326,6 +346,9 @@ class GoveeBLEDevice:
     def _on_disconnected(self, _client: BleakClient) -> None:
         """Callback fired by bleak when the GATT link drops."""
         self._client = None
+        # Frame counters restart at 1 on the next connection, so reusing this
+        # session would encrypt with nonces the device has already seen.
+        self._session = None
 
     async def _ensure_connected(self) -> BleakClient:
         """Open or return the cached ``BleakClient`` for this device.
@@ -362,12 +385,37 @@ class GoveeBLEDevice:
             max_attempts=_MAX_CONNECT_ATTEMPTS,
             use_services_cache=True,
         )
+
+        try:
+            if await async_supports_encryption(self._client):
+                self._session = await async_establish_session(
+                    self._client, WRITE_CHARACTERISTIC_UUID, READ_CHARACTERISTIC_UUID
+                )
+                _LOGGER.debug("Negotiated encrypted BLE session with %s", self.address)
+        except Exception:
+            # Drop the link rather than caching a connected-but-unnegotiated
+            # client. Keeping it would send the next command as plaintext,
+            # which an encrypted device discards without raising — so the
+            # caller would record a success and skip the cloud fallback. A
+            # dropped link just fails this one command and renegotiates next
+            # time.
+            client, self._client, self._session = self._client, None, None
+            with contextlib.suppress(Exception):
+                await client.disconnect()
+            raise
+
         return self._client
 
     async def _write(self, frame: bytes) -> None:
-        """Send a single 20-byte frame to the control characteristic."""
+        """Send a single 20-byte frame to the control characteristic.
+
+        Devices on the encrypted protocol take the identical frame wrapped in
+        the session cipher, so every command encoding above is shared.
+        """
         async with self._lock:
             client = await self._ensure_connected()
+            if self._session is not None:
+                frame = self._session.wrap(frame)
             await client.write_gatt_char(
                 WRITE_CHARACTERISTIC_UUID, frame, response=False
             )
@@ -444,3 +492,4 @@ class GoveeBLEDevice:
                         self.address,
                     )
             self._client = None
+            self._session = None

--- a/custom_components/govee/api/ble_crypto.py
+++ b/custom_components/govee/api/ble_crypto.py
@@ -1,0 +1,244 @@
+"""Encrypted BLE transport (protocol version 2) for newer Govee devices.
+
+Newer Govee SKUs silently discard the plaintext 20-byte frames that
+``ble.py`` builds. They accept the very same frames wrapped in AES-GCM after
+a session handshake. This module is only that wrapper: it establishes the
+session and encrypts/decrypts frames. Every command encoding stays in
+``ble.py`` untouched.
+
+Reverse-engineered from the Govee Home Android app and confirmed against a
+real H1270 (power, brightness and colour all verified on hardware). The
+device proves the scheme itself: its encrypted handshake reply decrypts to
+its own SKU and MAC, which we check below.
+
+Keys are fixed constants compiled into the vendor app and shipped in every
+device. They are not user secrets and grant nothing beyond talking to a
+light you are already next to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from bleak import BleakClient
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+_LOGGER = logging.getLogger(__name__)
+
+# Reports the protocol version this device speaks (a "BgcInfo" record).
+VERSION_CHARACTERISTIC_UUID = "00010203-0405-0607-0809-0a0b0c0d2b12"
+
+# Static keys extracted from the vendor app.
+_KEY_HANDSHAKE = bytes.fromhex("fc03783c7c42cb83e202a1643648aff6")
+_KEY_DEVICE = bytes.fromhex("ae028b630bae6ecc4bff1b249e22f955")
+
+# Byte 1 of the version characteristic carries the protocol version. Byte 0
+# is something else and reads 0x01 on a version-2 device, so keying off it
+# selects the wrong protocol and the device then never answers at all.
+_VERSION_BYTE_INDEX = 1
+_PROTOCOL_V2 = 2
+
+_HANDSHAKE_REQUEST_HEADER = bytes((0xE7, 0x11, 0x01))
+_HANDSHAKE_RESPONSE_HEADER = bytes((0xE7, 0x11, 0x00))
+
+_IV_LEN = 12
+_IV_KEY_LEN = 8
+_COUNTER_LEN = 4
+_DEVICE_INFO_LEN = 11
+_SKU_LEN = 5
+
+# The GCM tag is 16 bytes. Public write-ups of this protocol say 12; with a
+# 12-byte tag the device accepts the write at GATT level and then ignores it
+# completely — no reply, no state change, no error anywhere.
+_TAG_LEN = 16
+
+
+def _counter_bytes(counter: int) -> bytes:
+    """Encode a frame counter as the 4-byte big-endian prefix/AAD."""
+    return counter.to_bytes(_COUNTER_LEN, "big")
+
+
+def derive_device_key(device_info: bytes) -> bytes:
+    """Derive the per-device data key from the identity the device returned.
+
+    ``device_info`` is the 11-byte blob from the handshake reply, which is
+    zero-padded to one AES block and encrypted with the static device key.
+    """
+    padded = device_info.ljust(16, b"\x00")
+    # ECB is the vendor's choice, not ours. It encrypts exactly one block of
+    # device identity to derive a key, so the usual ECB pattern leak does not
+    # arise here.
+    encryptor = Cipher(algorithms.AES(_KEY_DEVICE), modes.ECB()).encryptor()
+    return bytes(encryptor.update(padded) + encryptor.finalize())
+
+
+@dataclass
+class GoveeBLESession:
+    """Live encryption session for one GATT connection.
+
+    Counters restart at 1 for each direction on every new connection, so a
+    session must not outlive the connection that created it.
+    """
+
+    device_key: bytes
+    tx_iv_key: bytes
+    rx_iv_key: bytes
+    _tx_counter: int = field(default=0, repr=False)
+
+    def wrap(self, frame: bytes) -> bytes:
+        """Encrypt one plaintext command frame for transmission."""
+        self._tx_counter += 1
+        counter = _counter_bytes(self._tx_counter)
+        sealed = AESGCM(self.device_key).encrypt(
+            self.tx_iv_key + counter, frame, counter
+        )
+        return counter + sealed
+
+    def unwrap(self, packet: bytes) -> bytes:
+        """Decrypt one notification packet from the device.
+
+        The device's counter is carried in the packet, so replies can be
+        decrypted without tracking receive state.
+        """
+        counter = packet[:_COUNTER_LEN]
+        return bytes(
+            AESGCM(self.device_key).decrypt(
+                self.rx_iv_key + counter, packet[_COUNTER_LEN:], counter
+            )
+        )
+
+
+def parse_handshake_response(response: bytes, handshake_key: bytes) -> tuple[bytes, bytes]:
+    """Decrypt the handshake reply into ``(rx_iv_key, device_info)``."""
+    aad = response[: 3 + _IV_LEN]
+    iv = response[3 : 3 + _IV_LEN]
+    plaintext = AESGCM(handshake_key).decrypt(iv, response[3 + _IV_LEN :], aad)
+    return plaintext[:_IV_KEY_LEN], plaintext[_IV_KEY_LEN:]
+
+
+def build_handshake_request(iv: bytes, tx_iv_key: bytes) -> bytes:
+    """Build the handshake request carrying our half of the session keys."""
+    header = _HANDSHAKE_REQUEST_HEADER + iv + bytes((16,))
+    return header + AESGCM(_KEY_HANDSHAKE).encrypt(iv, tx_iv_key, header)
+
+
+def _log_identity(address: str, device_info: bytes) -> None:
+    """Log whether the decrypted reply matches the device we dialled.
+
+    The reply carries the device's own SKU and its MAC reversed, so a match
+    turns "the write was accepted" into proof we hold the right key. This is
+    advisory only and must never raise: on macOS ``address`` is a CoreBluetooth
+    UUID rather than a MAC, so there is nothing to compare against.
+    """
+    if len(device_info) < _DEVICE_INFO_LEN:
+        _LOGGER.debug("Govee BLE handshake reply is short: %s", device_info.hex())
+        return
+    try:
+        expected_mac = bytes(reversed(bytes.fromhex(address.replace(":", ""))))
+    except ValueError:
+        return
+    if device_info[_SKU_LEN:] != expected_mac:
+        _LOGGER.debug(
+            "Govee BLE handshake identity mismatch for %s: %s",
+            address,
+            device_info.hex(),
+        )
+
+
+async def async_supports_encryption(client: BleakClient) -> bool:
+    """Return True if this device speaks the encrypted protocol.
+
+    Probing the device beats maintaining an allowlist of SKUs. A device that
+    does not expose the characteristic at all is plaintext, and that is decided
+    from the service cache without any I/O.
+
+    A read that fails deliberately propagates rather than answering "plaintext".
+    Answering plaintext on a device that only accepts encrypted frames is the
+    worst outcome available: writes use ``response=False``, so the frames the
+    device discards raise nothing, the caller records a transport success, and
+    the working cloud fallback is skipped. A raised error costs one failed
+    command and falls through to the next transport.
+    """
+    if client.services.get_characteristic(VERSION_CHARACTERISTIC_UUID) is None:
+        _LOGGER.debug("No BLE version characteristic on %s", client.address)
+        return False
+    info = await client.read_gatt_char(VERSION_CHARACTERISTIC_UUID)
+    return (
+        len(info) > _VERSION_BYTE_INDEX and info[_VERSION_BYTE_INDEX] == _PROTOCOL_V2
+    )
+
+
+async def async_establish_session(
+    client: BleakClient,
+    write_uuid: str,
+    notify_uuid: str,
+    *,
+    timeout: float = 5.0,
+    on_frame: Callable[[bytes], None] | None = None,
+) -> GoveeBLESession:
+    """Perform the handshake and return the session for this connection.
+
+    Notifications are left enabled afterwards. The device is only known to
+    honour encrypted writes with notifications subscribed, and the reply is
+    also the only acknowledgement a command ever gets.
+
+    Once the session is up, every further notification is decrypted and passed
+    to ``on_frame`` as a plaintext 20-byte frame. Only one subscription to the
+    notify characteristic is possible, so this callback is the sole way for a
+    caller to see the device's replies.
+    """
+    loop = asyncio.get_running_loop()
+    reply: asyncio.Future[bytes] = loop.create_future()
+    established: dict[str, GoveeBLESession] = {}
+
+    def _on_notify(_sender: object, data: bytearray) -> None:
+        payload = bytes(data)
+        if not reply.done() and payload.startswith(_HANDSHAKE_RESPONSE_HEADER):
+            reply.set_result(payload)
+            return
+        session = established.get("session")
+        if session is None or on_frame is None:
+            return
+        try:
+            on_frame(session.unwrap(payload))
+        except (InvalidTag, ValueError, IndexError):
+            # The device also emits frames we have no counter context for.
+            _LOGGER.debug("Undecryptable Govee BLE notification: %s", payload.hex())
+
+    await client.start_notify(notify_uuid, _on_notify)
+
+    try:
+        iv = os.urandom(_IV_LEN)
+        tx_iv_key = os.urandom(_IV_KEY_LEN)
+        await client.write_gatt_char(
+            write_uuid, build_handshake_request(iv, tx_iv_key), response=False
+        )
+
+        async with asyncio.timeout(timeout):
+            response = await reply
+
+        rx_iv_key, device_info = parse_handshake_response(response, _KEY_HANDSHAKE)
+    except BaseException:
+        # Only one subscription to the notify characteristic is possible, so a
+        # handler left behind here would hold the only slot for this connection
+        # and block every later attempt.
+        with contextlib.suppress(Exception):
+            await client.stop_notify(notify_uuid)
+        raise
+
+    _log_identity(client.address, device_info)
+
+    session = GoveeBLESession(
+        device_key=derive_device_key(device_info),
+        tx_iv_key=tx_iv_key,
+        rx_iv_key=rx_iv_key,
+    )
+    established["session"] = session
+    return session

--- a/custom_components/govee/ble_advertisement.py
+++ b/custom_components/govee/ble_advertisement.py
@@ -60,6 +60,18 @@ def sku_from_ble_name(name: str | None) -> str | None:
     return None
 
 
+def ble_address_from_device_id(device_id: str) -> str | None:
+    """Derive the BLE MAC from a cloud device ID.
+
+    Cloud IDs carry the BLE MAC with two extra leading octets, e.g.
+    ``11:66:C0:EB:32:C1:19:FC`` for MAC ``C0:EB:32:C1:19:FC``.
+    """
+    parts = device_id.split(":")
+    if len(parts) < 6:
+        return None
+    return ":".join(parts[-6:]).upper()
+
+
 class BleAdvertisementHandler:
     """Subscribe to and correlate Govee BLE advertisements.
 
@@ -116,6 +128,47 @@ class BleAdvertisementHandler:
             GOVEE_BLE_MANUFACTURER_IDS,
         )
         return unsubs
+
+    @callback
+    def enroll_from_cache(self) -> None:
+        """Enrol eligible devices from Home Assistant's advertisement cache.
+
+        The advertisement callbacks only deliver while a connectable scanner
+        is running. Bluetooth proxies are themselves integrations, and they
+        usually register their scanners after this one has set up, so at setup
+        time the scanner count is zero and every advertisement is refused. The
+        device then stays cloud-only until somebody reloads the entry by hand.
+
+        Reading the cache on each refresh closes that gap without depending on
+        a fresh advertisement arriving at the right moment.
+        """
+        if not HAS_BLUETOOTH:
+            return
+
+        coord = self._coord
+        for device_id, device in list(coord._devices.items()):
+            if device_id in coord._ble_devices or device.is_group:
+                continue
+            if device.sku not in BLE_COMMAND_SUPPORTED_MODELS:
+                continue
+            address = ble_address_from_device_id(device_id)
+            if address is None:
+                continue
+            try:
+                info = bt_component.async_last_service_info(
+                    coord.hass, address, connectable=True
+                )
+            except Exception as err:  # noqa: BLE001 — runs inside the poll
+                # Never let a Bluetooth hiccup fail the whole state refresh.
+                _LOGGER.debug("BLE cache lookup failed for %s: %s", address, err)
+                continue
+            if info is not None:
+                _LOGGER.debug(
+                    "Enrolling %s (%s) from the BLE advertisement cache",
+                    device_id,
+                    address,
+                )
+                self.handle_advertisement(info)
 
     @callback
     def handle_advertisement(self, service_info: Any) -> None:

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -2919,6 +2919,11 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if not self._devices:
             return self._states
 
+        # Bluetooth proxies register their scanners after this integration
+        # sets up, so the advertisement callbacks are refused at setup time and
+        # BLE-capable devices would stay cloud-only until a manual reload.
+        self._ble_handler.enroll_from_cache()
+
         # Create tasks for parallel fetching
         tasks = [
             self._fetch_device_state(device_id, device)

--- a/tests/test_api_ble.py
+++ b/tests/test_api_ble.py
@@ -31,6 +31,24 @@ from custom_components.govee.api.ble import (
     _build_rgb_segmented_frame,
     _build_rgb_single_frame,
 )
+from custom_components.govee.api.ble_crypto import GoveeBLESession
+
+
+@pytest.fixture(autouse=True)
+def _plaintext_device():
+    """Treat the mocked device as speaking the plaintext protocol.
+
+    ``_ensure_connected`` probes every connection for the encrypted protocol,
+    which reads a GATT characteristic. The clients here are MagicMocks, so
+    that read would be awaited on a non-awaitable. The encrypted path has its
+    own tests in ``test_ble_crypto.py`` and ``TestEncryptedTransport`` below.
+    """
+    with patch(
+        "custom_components.govee.api.ble.async_supports_encryption",
+        AsyncMock(return_value=False),
+    ):
+        yield
+
 
 # ==============================================================================
 # Module constants
@@ -52,9 +70,17 @@ class TestConstants:
         """All three known Govee BLE advertising name prefixes are listed."""
         assert BLE_DISCOVERY_NAMES == ("Govee_", "ihoment_", "GBK_")
 
-    def test_segmented_models_matches_beshelmek(self):
-        """Segmented model whitelist matches Beshelmek light.py:35 exactly."""
-        assert SEGMENTED_MODELS == frozenset({"H6053", "H6072", "H6102", "H6199"})
+    def test_segmented_models_covers_beshelmek(self):
+        """Segmented whitelist keeps every SKU from Beshelmek light.py:35."""
+        assert SEGMENTED_MODELS >= frozenset({"H6053", "H6072", "H6102", "H6199"})
+
+    def test_segmented_models_includes_h1270(self):
+        """H1270 ignores the single-zone frame and needs mode 0x15.
+
+        Not in the Beshelmek list — added from field testing, where the colour
+        read-back stayed black until the segmented encoding was used.
+        """
+        assert "H1270" in SEGMENTED_MODELS
 
     def test_command_byte_values(self):
         """Command bytes match the reference protocol."""
@@ -703,3 +729,150 @@ class TestStop:
 
         await device.stop()  # must not raise
         assert device._client is None
+
+
+# ==============================================================================
+# Encrypted transport wiring
+# ==============================================================================
+
+
+class TestEncryptedTransport:
+    """Frames must be encrypted when a session was negotiated, and only then."""
+
+    @staticmethod
+    def _connected_device() -> tuple[GoveeBLEDevice, MagicMock]:
+        device = GoveeBLEDevice(_make_ble_device())
+        client = MagicMock()
+        client.is_connected = True
+        client.write_gatt_char = AsyncMock()
+        device._client = client
+        return device, client
+
+    @staticmethod
+    def _session() -> GoveeBLESession:
+        return GoveeBLESession(
+            device_key=bytes(16), tx_iv_key=bytes(8), rx_iv_key=bytes(8)
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_sends_plaintext_without_session(self):
+        """Devices on the plaintext protocol must be unaffected."""
+        device, client = self._connected_device()
+
+        await device.turn_on()
+
+        assert client.write_gatt_char.call_args[0][1] == _build_power_frame(True)
+
+    @pytest.mark.asyncio
+    async def test_write_encrypts_the_same_command_frame(self):
+        """The wrapped frame must decrypt back to the identical command."""
+        device, client = self._connected_device()
+        device._session = self._session()
+
+        await device.turn_on()
+
+        sent = client.write_gatt_char.call_args[0][1]
+        assert sent != _build_power_frame(True)
+        # The peer decrypts our transmissions with our tx key as its rx key.
+        peer = GoveeBLESession(
+            device_key=bytes(16), tx_iv_key=bytes(8), rx_iv_key=bytes(8)
+        )
+        assert peer.unwrap(sent) == _build_power_frame(True)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_session(self):
+        """A stale session would reuse nonces the device has already seen."""
+        device, _client = self._connected_device()
+        device._session = self._session()
+
+        device._on_disconnected(MagicMock())
+
+        assert device._session is None
+
+
+class TestNegotiationFailureNeverDowngrades:
+    """A failed negotiation must not leave a usable plaintext connection.
+
+    Writes use ``response=False``, so plaintext frames sent to an encrypted
+    device raise nothing. The caller would then record a transport success and
+    skip the LAN/MQTT/REST fallback, leaving the device untouched while HA
+    shows the command as applied.
+    """
+
+    @staticmethod
+    def _patches(establish_side_effect=None, supports=True):
+        client = MagicMock()
+        client.is_connected = True
+        client.write_gatt_char = AsyncMock()
+        client.disconnect = AsyncMock()
+        return client, patch(
+            "custom_components.govee.api.ble.establish_connection",
+            AsyncMock(return_value=client),
+        ), patch(
+            "custom_components.govee.api.ble.close_stale_connections_by_address",
+            AsyncMock(),
+        ), patch(
+            "custom_components.govee.api.ble.async_supports_encryption",
+            AsyncMock(return_value=supports),
+        ), patch(
+            "custom_components.govee.api.ble.async_establish_session",
+            AsyncMock(side_effect=establish_side_effect),
+        )
+
+    @pytest.mark.asyncio
+    async def test_handshake_failure_drops_the_connection_and_raises(self):
+        device = GoveeBLEDevice(_make_ble_device())
+        client, p1, p2, p3, p4 = self._patches(TimeoutError("no reply"))
+
+        with p1, p2, p3, p4, pytest.raises(TimeoutError):
+            await device._ensure_connected()
+
+        # Nothing cached, so the next command renegotiates instead of
+        # silently writing plaintext down a half-negotiated link.
+        assert device._client is None
+        assert device._session is None
+        client.disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_drops_the_connection_and_raises(self):
+        device = GoveeBLEDevice(_make_ble_device())
+        client = MagicMock()
+        client.is_connected = True
+        client.disconnect = AsyncMock()
+
+        with patch(
+            "custom_components.govee.api.ble.establish_connection",
+            AsyncMock(return_value=client),
+        ), patch(
+            "custom_components.govee.api.ble.close_stale_connections_by_address",
+            AsyncMock(),
+        ), patch(
+            "custom_components.govee.api.ble.async_supports_encryption",
+            AsyncMock(side_effect=TimeoutError("proxy busy")),
+        ), pytest.raises(TimeoutError):
+            await device._ensure_connected()
+
+        assert device._client is None
+        client.disconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_command_after_a_failed_handshake_renegotiates(self):
+        """The failure must not be sticky for the life of the link."""
+        device = GoveeBLEDevice(_make_ble_device())
+        session = GoveeBLESession(
+            device_key=bytes(16), tx_iv_key=bytes(8), rx_iv_key=bytes(8)
+        )
+        client, p1, p2, p3, _ = self._patches()
+        establish = AsyncMock(side_effect=[TimeoutError("no reply"), session])
+
+        with p1, p2, p3, patch(
+            "custom_components.govee.api.ble.async_establish_session", establish
+        ):
+            with pytest.raises(TimeoutError):
+                await device.turn_on()
+            await device.turn_on()  # must try again, and succeed
+
+        assert establish.await_count == 2
+        assert device._session is session
+        sent = client.write_gatt_char.call_args[0][1]
+        assert sent != _build_power_frame(True)  # it went out encrypted

--- a/tests/test_ble_crypto.py
+++ b/tests/test_ble_crypto.py
@@ -1,0 +1,185 @@
+"""Tests for the encrypted Govee BLE transport.
+
+The key derivation vector below was captured from a real H1270 during the
+work that reverse-engineered this protocol, so these are known-answer tests
+against hardware rather than against our own implementation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from custom_components.govee.api.ble_crypto import (
+    GoveeBLESession,
+    async_establish_session,
+    async_supports_encryption,
+    build_handshake_request,
+    derive_device_key,
+    parse_handshake_response,
+)
+
+# Captured from a real H1270 (MAC C0:EB:32:C1:19:FC).
+_REAL_DEVICE_INFO = bytes.fromhex("4831323730fc19c132ebc0")
+_REAL_DEVICE_KEY = bytes.fromhex("6180f19566dedc80a3adef2f8b936184")
+
+_HANDSHAKE_KEY = bytes.fromhex("fc03783c7c42cb83e202a1643648aff6")
+
+
+def _session() -> GoveeBLESession:
+    return GoveeBLESession(
+        device_key=_REAL_DEVICE_KEY,
+        tx_iv_key=bytes.fromhex("0011223344556677"),
+        rx_iv_key=bytes.fromhex("8899aabbccddeeff"),
+    )
+
+
+def test_device_key_matches_real_device() -> None:
+    """Key derivation reproduces the key a real H1270 session used."""
+    assert derive_device_key(_REAL_DEVICE_INFO) == _REAL_DEVICE_KEY
+
+
+def test_device_info_carries_sku_and_reversed_mac() -> None:
+    """The identity check that proves the handshake decrypted correctly."""
+    assert _REAL_DEVICE_INFO[:5] == b"H1270"
+    mac = bytes.fromhex("C0EB32C119FC".lower())
+    assert _REAL_DEVICE_INFO[5:] == bytes(reversed(mac))
+
+
+def test_wrap_uses_a_sixteen_byte_tag() -> None:
+    """A 12-byte tag is silently ignored by the device, so pin the length."""
+    frame = bytes(20)
+    wrapped = _session().wrap(frame)
+    # 4-byte counter prefix + ciphertext the size of the frame + 16-byte tag.
+    assert len(wrapped) == 4 + 20 + 16
+
+
+def test_wrap_counter_starts_at_one_and_increments() -> None:
+    """Counters start at 1 per connection and advance by one per frame."""
+    session = _session()
+    assert session.wrap(bytes(20))[:4] == (1).to_bytes(4, "big")
+    assert session.wrap(bytes(20))[:4] == (2).to_bytes(4, "big")
+
+
+def test_wrap_never_repeats_a_nonce() -> None:
+    """Identical frames must still encrypt differently."""
+    session = _session()
+    frame = bytes(range(20))
+    assert session.wrap(frame) != session.wrap(frame)
+
+
+def test_unwrap_round_trips_a_wrapped_frame() -> None:
+    """Decryption recovers the exact plaintext command frame."""
+    # One session encrypts with tx; the peer decrypts with the same key, so
+    # mirror the IV keys to model the far end.
+    sender = _session()
+    receiver = GoveeBLESession(
+        device_key=_REAL_DEVICE_KEY,
+        tx_iv_key=sender.rx_iv_key,
+        rx_iv_key=sender.tx_iv_key,
+    )
+    frame = bytes.fromhex("330100000000000000000000000000000000000032")[:20]
+    assert receiver.unwrap(sender.wrap(frame)) == frame
+
+
+def test_unwrap_rejects_a_tampered_frame() -> None:
+    """Authentication actually holds — a flipped bit must not decrypt."""
+    session = _session()
+    wrapped = bytearray(session.wrap(bytes(20)))
+    wrapped[-1] ^= 0x01
+    peer = GoveeBLESession(
+        device_key=_REAL_DEVICE_KEY,
+        tx_iv_key=session.rx_iv_key,
+        rx_iv_key=session.tx_iv_key,
+    )
+    with pytest.raises(Exception):  # noqa: B017 — InvalidTag from cryptography
+        peer.unwrap(bytes(wrapped))
+
+
+def test_handshake_request_layout() -> None:
+    """The request header and IV sit where the device expects them.
+
+    The request's AAD is the full 16-byte header including the trailing tag
+    length byte, one byte longer than the reply's — hence the two are parsed
+    separately rather than sharing a helper.
+    """
+    iv = bytes(range(12))
+    tx_iv_key = bytes.fromhex("0011223344556677")
+    request = build_handshake_request(iv, tx_iv_key)
+
+    assert request[:3] == bytes((0xE7, 0x11, 0x01))
+    assert request[3:15] == iv
+    assert request[15] == 16
+    # 16-byte header + the 8-byte key sealed under a 16-byte tag.
+    assert len(request) == 16 + 8 + 16
+
+
+def test_parse_handshake_response_recovers_keys_and_identity() -> None:
+    """The reply parser uses the 15-byte AAD and offsets the device uses."""
+    rx_iv_key = bytes.fromhex("8a10ed17775ef1f4")
+    iv = bytes(range(12))
+    header = bytes((0xE7, 0x11, 0x00)) + iv
+    body = AESGCM(_HANDSHAKE_KEY).encrypt(iv, rx_iv_key + _REAL_DEVICE_INFO, header)
+
+    parsed_key, parsed_info = parse_handshake_response(header + body, _HANDSHAKE_KEY)
+
+    assert parsed_key == rx_iv_key
+    assert parsed_info == _REAL_DEVICE_INFO
+    assert derive_device_key(parsed_info) == _REAL_DEVICE_KEY
+
+
+class TestEncryptionProbe:
+    """The probe must never answer "plaintext" just because a read failed.
+
+    Writes are fire-and-forget, so a wrong "plaintext" answer makes an
+    encrypted device discard every frame silently while the caller records a
+    transport success and skips the cloud fallback.
+    """
+
+    @pytest.mark.asyncio
+    async def test_absent_characteristic_means_plaintext(self):
+        """A device without the characteristic is plaintext, decided with no I/O."""
+        client = MagicMock()
+        client.services.get_characteristic.return_value = None
+        client.read_gatt_char = AsyncMock()
+
+        assert await async_supports_encryption(client) is False
+        client.read_gatt_char.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_read_failure_propagates_rather_than_downgrading(self):
+        """A timed-out read must raise, not silently select the plaintext path."""
+        client = MagicMock()
+        client.services.get_characteristic.return_value = object()
+        client.read_gatt_char = AsyncMock(side_effect=TimeoutError("proxy busy"))
+
+        with pytest.raises(TimeoutError):
+            await async_supports_encryption(client)
+
+    @pytest.mark.asyncio
+    async def test_version_two_is_detected_from_byte_one(self):
+        """Byte 1 carries the version. Byte 0 reads 0x01 on a v2 device."""
+        client = MagicMock()
+        client.services.get_characteristic.return_value = object()
+        client.read_gatt_char = AsyncMock(return_value=bytes([0x01, 0x02, 0x00]))
+
+        assert await async_supports_encryption(client) is True
+
+
+class TestHandshakeCleanup:
+    """A failed handshake must not strand the single notify subscription."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_releases_the_notify_subscription(self):
+        client = MagicMock()
+        client.address = "C0:EB:32:C1:19:FC"
+        client.start_notify = AsyncMock()
+        client.stop_notify = AsyncMock()
+        client.write_gatt_char = AsyncMock()  # device never replies
+
+        with pytest.raises(TimeoutError):
+            await async_establish_session(client, "w", "n", timeout=0.05)
+
+        client.stop_notify.assert_awaited_once_with("n")

--- a/tests/test_ble_enrollment.py
+++ b/tests/test_ble_enrollment.py
@@ -1,0 +1,150 @@
+"""Tests for BLE enrolment from Home Assistant's advertisement cache.
+
+Bluetooth proxies register their scanners after this integration sets up, so
+the advertisement callbacks are refused at setup time. Without the cache
+sweep a BLE-capable device stays cloud-only until a manual reload — which is
+exactly what happened on real hardware before ``enroll_from_cache`` existed.
+
+``homeassistant.components.bluetooth`` is not installed in the test
+environment, so ``HAS_BLUETOOTH`` is False and the module never binds its
+Bluetooth symbols. The helper below injects them.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from custom_components.govee.ble_advertisement import (
+    BleAdvertisementHandler,
+    ble_address_from_device_id,
+)
+
+_MODULE = "custom_components.govee.ble_advertisement"
+
+
+class TestBleAddressFromDeviceId:
+    """Cloud device IDs carry the BLE MAC with two extra leading octets."""
+
+    def test_strips_the_two_leading_octets(self):
+        assert (
+            ble_address_from_device_id("11:66:C0:EB:32:C1:19:FC")
+            == "C0:EB:32:C1:19:FC"
+        )
+
+    def test_uppercases_the_address(self):
+        assert (
+            ble_address_from_device_id("11:66:c0:eb:32:c1:19:fc")
+            == "C0:EB:32:C1:19:FC"
+        )
+
+    def test_plain_mac_is_returned_unchanged(self):
+        assert ble_address_from_device_id("C0:EB:32:C1:19:FC") == "C0:EB:32:C1:19:FC"
+
+    def test_too_short_returns_none(self):
+        assert ble_address_from_device_id("C0:EB:32") is None
+
+
+def _coordinator(sku: str = "H1270", device_id: str = "11:66:C0:EB:32:C1:19:FC"):
+    device = MagicMock()
+    device.sku = sku
+    device.is_group = False
+    coord = MagicMock()
+    coord._devices = {device_id: device}
+    coord._ble_devices = {}
+    coord.hass = MagicMock()
+    return coord
+
+
+@contextmanager
+def _bluetooth(handler, *, found=None, side_effect=None):
+    """Make the module behave as if HA's Bluetooth component were present."""
+    bt = MagicMock()
+    if side_effect is not None:
+        bt.async_last_service_info.side_effect = side_effect
+    else:
+        bt.async_last_service_info.return_value = found
+    with patch(f"{_MODULE}.HAS_BLUETOOTH", True), patch(
+        f"{_MODULE}.bt_component", bt, create=True
+    ), patch(
+        f"{_MODULE}.BLE_COMMAND_SUPPORTED_MODELS", frozenset({"H1270"}), create=True
+    ), patch.object(handler, "handle_advertisement") as handle:
+        yield bt, handle
+
+
+class TestEnrollFromCache:
+    """The sweep must enrol exactly the devices that are eligible."""
+
+    def test_enrolls_a_supported_device_found_in_cache(self):
+        handler = BleAdvertisementHandler(_coordinator())
+        info = MagicMock()
+
+        with _bluetooth(handler, found=info) as (bt, handle):
+            handler.enroll_from_cache()
+
+        handle.assert_called_once_with(info)
+        # Commands can only ride a connectable scanner.
+        assert bt.async_last_service_info.call_args.kwargs["connectable"] is True
+        # And it must look up the BLE MAC, not the cloud device ID.
+        assert bt.async_last_service_info.call_args[0][1] == "C0:EB:32:C1:19:FC"
+
+    def test_skips_a_device_already_enrolled(self):
+        coord = _coordinator()
+        coord._ble_devices = {"11:66:C0:EB:32:C1:19:FC": MagicMock()}
+        handler = BleAdvertisementHandler(coord)
+
+        with _bluetooth(handler, found=MagicMock()) as (bt, handle):
+            handler.enroll_from_cache()
+
+        handle.assert_not_called()
+        bt.async_last_service_info.assert_not_called()
+
+    def test_skips_a_sku_not_on_the_allowlist(self):
+        handler = BleAdvertisementHandler(_coordinator(sku="H9999"))
+
+        with _bluetooth(handler, found=MagicMock()) as (bt, handle):
+            handler.enroll_from_cache()
+
+        handle.assert_not_called()
+        bt.async_last_service_info.assert_not_called()
+
+    def test_skips_group_devices(self):
+        coord = _coordinator()
+        next(iter(coord._devices.values())).is_group = True
+        handler = BleAdvertisementHandler(coord)
+
+        with _bluetooth(handler, found=MagicMock()) as (_bt, handle):
+            handler.enroll_from_cache()
+
+        handle.assert_not_called()
+
+    def test_does_nothing_when_the_device_is_not_in_cache(self):
+        handler = BleAdvertisementHandler(_coordinator())
+
+        with _bluetooth(handler, found=None) as (_bt, handle):
+            handler.enroll_from_cache()
+
+        handle.assert_not_called()
+
+    def test_a_cache_lookup_error_never_breaks_the_refresh(self):
+        """This runs inside the coordinator poll, so it must not raise."""
+        handler = BleAdvertisementHandler(_coordinator())
+
+        with _bluetooth(handler, side_effect=RuntimeError("bluetooth is down")) as (
+            _bt,
+            handle,
+        ):
+            handler.enroll_from_cache()  # must not raise
+
+        handle.assert_not_called()
+
+    def test_is_a_noop_without_the_bluetooth_component(self):
+        """Installs without HA Bluetooth must be unaffected."""
+        handler = BleAdvertisementHandler(_coordinator())
+
+        with patch(f"{_MODULE}.HAS_BLUETOOTH", False), patch.object(
+            handler, "handle_advertisement"
+        ) as handle:
+            handler.enroll_from_cache()  # must not raise
+
+        handle.assert_not_called()


### PR DESCRIPTION
Newer Govee SKUs silently drop our plaintext BLE frames. They accept the **same** frames wrapped in AES-GCM after a session handshake, so this adds only that transport wrapper — every command encoding is untouched.

Field-tested on an H1270: power, brightness and colour all confirmed, driven from HA through an ESPHome Bluetooth proxy.

### How it decides
Devices are **probed** for the protocol version, not allowlisted. No version characteristic means plaintext, decided from the service cache with no I/O. Plaintext devices are unaffected.

### Why it fails closed
Writes are `response=False`, so plaintext frames sent to an encrypted device raise *nothing*. Left to fail open, the caller records a transport **success** and skips the LAN/MQTT/REST fallback — device untouched, HA showing the command applied. So a failed probe read propagates, and a failed handshake drops the connection rather than caching a half-negotiated client that later writes would downgrade.

### Two things that cost real time
- **The GCM tag is 16 bytes.** Public write-ups say 12. With 12 the device accepts the write and ignores it silently — indistinguishable from a wrong key.
- **H1270 needs the segmented colour encoding.** It discards the single-zone frame; the colour read-back just stays black.

### Second commit
BLE enrolment only ran from advertisement callbacks, which are refused while the connectable scanner count is zero. Bluetooth proxies register their scanners *after* this integration sets up, so every restart left BLE devices cloud-only until someone reloaded the config entry by hand. Now the advertisement cache is swept on each refresh. Verified across three restarts.

### Keys
The static keys are compiled into the vendor app and ship on every device. They are not user secrets and grant nothing beyond talking to a light you are already standing next to.

### Checks
1691 tests pass. Lint is identical to master's baseline — no new findings. The negotiation-failure tests were confirmed to fail without the fix.