### PR TITLE
feat(fan): drive Tower Fan 2 (H7105/H7107) oscillation over AWS IoT ptReal

### DIFF
--- a/custom_components/govee/api/ble_packet.py
+++ b/custom_components/govee/api/ble_packet.py
@@ -158,6 +158,40 @@ def build_diy_scene_packet(scene_id: int) -> bytes:
     return build_packet(data)
 
 
+# Tower Fan oscillation (H7105/H7107 "Tower Fan 2" family). Reverse-engineered
+# from homebridge-govee lib/device/fan-H7107.js (2026-08, hardware-confirmed).
+# The dev-API oscillationToggle is a no-op for this family; only these raw
+# ptReal/multiSync frames move the sweep motor. The ON frame carries 4
+# "swing-range" bytes copied from the fan's own inbound aa1d status frame so the
+# physically-configured arc is preserved; OFF is a bare zero-padded frame.
+FAN_OSC_PTREAL_PREFIX = 0x33
+FAN_OSC_MULTISYNC_PREFIX = 0x3A
+FAN_OSC_COMMAND = 0x1D
+
+
+def build_fan_oscillation_packet(
+    enabled: bool,
+    swing_tail: list[int] | None = None,
+    *,
+    prefix: int = FAN_OSC_PTREAL_PREFIX,
+) -> bytes:
+    """Build a Tower-Fan oscillation on/off packet.
+
+    Args:
+        enabled: True = oscillate (sweep), False = hold still.
+        swing_tail: 4 swing-range bytes copied from the fan's aa1d report,
+                    used only for the ON frame; None sends a bare ON.
+        prefix: 0x33 for the ptReal frame, 0x3A for the multiSync twin.
+
+    Returns:
+        20-byte packet (19 data bytes + XOR checksum).
+    """
+    data = [prefix, FAN_OSC_COMMAND, 0x01 if enabled else 0x00]
+    if enabled and swing_tail:
+        data.extend(int(b) & 0xFF for b in swing_tail[:4])
+    return build_packet(data)
+
+
 def encode_packet_base64(packet: bytes) -> str:
     """Base64 encode a packet for ptReal command.
 

--- a/custom_components/govee/api/mqtt.py
+++ b/custom_components/govee/api/mqtt.py
@@ -212,6 +212,14 @@ class GoveeAwsIotClient:
         # undecoded hub packets (e.g. the H5059's 0xEE 0x35 wet alarm in #87)
         # without asking end users to enable verbose logging.
         self._recent_multisync: deque[dict[str, Any]] = deque(maxlen=64)
+        # Latest Tower-Fan swing-range tail bytes per device_id, harvested from
+        # inbound aa1d status frames. Used to rebuild the oscillation-ON packet
+        # so the fan resumes its own physically-configured sweep arc.
+        self._fan_swing_tail: dict[str, list[int]] = {}
+
+    def fan_swing_tail(self, device_id: str) -> list[int] | None:
+        """Return the last-seen Tower-Fan swing-range tail (4 bytes) or None."""
+        return self._fan_swing_tail.get(device_id)
 
     @property
     def last_messages(self) -> dict[str, dict[str, Any]]:
@@ -515,6 +523,21 @@ class GoveeAwsIotClient:
             # events (multiSync) count as activity, not just state updates.
             self._last_message_ts = datetime.now(timezone.utc)
             self._last_message_per_device[device_id] = self._last_message_ts
+
+            # Harvest Tower-Fan swing-range tail bytes from any inbound
+            # BLE-format frame (aa 1d ..) carried in op.command[]. This runs
+            # before the multiSync/state branches so it captures the tail
+            # regardless of how the fan frames its report. Bytes 3-6 are the
+            # swing range (homebridge fan-H7107.js), replayed on oscillation ON.
+            op = data.get("op")
+            if isinstance(op, dict):
+                for _b64frame in op.get("command", []) or []:
+                    try:
+                        _fb = base64.b64decode(_b64frame)
+                    except (binascii.Error, ValueError):
+                        continue
+                    if len(_fb) >= 7 and _fb[0] == 0xAA and _fb[1] == 0x1D:
+                        self._fan_swing_tail[device_id] = list(_fb[3:7])
 
             # Handle multiSync messages (leak sensor events)
             cmd = data.get("cmd")

--- a/custom_components/govee/ble_passthrough.py
+++ b/custom_components/govee/ble_passthrough.py
@@ -12,8 +12,10 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .api.ble_packet import (
+    FAN_OSC_MULTISYNC_PREFIX,
     build_diy_scene_packet,
     build_dreamview_packet,
+    build_fan_oscillation_packet,
     build_music_mode_packet,
     encode_packet_base64,
 )
@@ -122,6 +124,58 @@ class BlePassthroughManager:
         packet = build_dreamview_packet(enabled)
         encoded = encode_packet_base64(packet)
         return await self.async_send_ble_packet(device_id, sku, encoded)
+
+    async def async_send_fan_oscillation(
+        self,
+        device_id: str,
+        sku: str,
+        enabled: bool,
+        swing_tail: list[int] | None = None,
+    ) -> bool:
+        """Send a Tower-Fan oscillation on/off command via BLE passthrough.
+
+        Sends the ptReal 0x33 0x1d frame and the multiSync 0x3a 0x1d twin
+        (homebridge sends both; the fan honours one and the OFF twin is what
+        makes "stop" reliable). Returns the ptReal publish result.
+
+        Args:
+            device_id: Device identifier.
+            sku: Device SKU.
+            enabled: True = oscillate, False = hold still.
+            swing_tail: 4 swing-range bytes for the ON frame (None = bare ON).
+
+        Returns:
+            True if the primary ptReal frame was sent.
+        """
+        client = self._get_mqtt_client()
+        if client is None:
+            return False
+
+        device_topic = await self._ensure_device_topic(device_id)
+
+        ptreal_b64 = encode_packet_base64(
+            build_fan_oscillation_packet(enabled, swing_tail)
+        )
+        ok: bool = await client.async_publish_ptreal(
+            device_id, sku, ptreal_b64, device_topic
+        )
+
+        # multiSync twin (0x3a) — non-fatal if it fails.
+        try:
+            multi_b64 = encode_packet_base64(
+                build_fan_oscillation_packet(
+                    enabled, swing_tail, prefix=FAN_OSC_MULTISYNC_PREFIX
+                )
+            )
+            await client.async_publish_command(
+                device_topic,
+                "multiSync",
+                {"command": [multi_b64], "device": device_id, "sku": sku},
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("multiSync oscillation twin failed (non-fatal): %s", err)
+
+        return ok
 
     async def async_send_diy_scene(
         self,

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -3382,6 +3382,28 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             self._record_transport_failure(device_id, "cloud_api", str(err))
             return err
 
+    async def async_send_fan_oscillation(
+        self, device_id: str, enabled: bool
+    ) -> bool:
+        """Send a Tower-Fan oscillation on/off frame over MQTT.
+
+        Reverse-engineered path for the H7105/H7107 family, whose oscillation
+        the dev-API oscillationToggle cannot control (no-op). Returns False if
+        the device is unknown or MQTT has no client, so the caller can fall
+        back to the REST OscillationCommand.
+        """
+        device = self._devices.get(device_id)
+        if not device:
+            return False
+        tail = (
+            self._mqtt_client.fan_swing_tail(device_id)
+            if self._mqtt_client
+            else None
+        )
+        return await self._ble_manager.async_send_fan_oscillation(
+            device_id, device.sku, enabled, tail
+        )
+
     async def async_control_device(
         self,
         device_id: str,

--- a/custom_components/govee/fan.py
+++ b/custom_components/govee/fan.py
@@ -77,6 +77,15 @@ PRESET_MODE_ALIASES = {
     "turbo": "turbo",
 }
 
+# Tower Fan 2 family: oscillation obeys ONLY the AWS-IoT MQTT ptReal/multiSync
+# frames — the Platform-API oscillationToggle returns 200 and does nothing
+# (govee2mqtt #438/#709, disforw/goveelife #70). Gated to the SKUs with a
+# hardware-confirmed frame (H7107: this integration + homebridge-govee
+# v11.33.0; H7105: homebridge-govee v11.34.0). H7106/H7108 are the same family
+# and likely candidates, but are left on the REST path until someone confirms.
+# Every other fan SKU keeps the existing REST OscillationCommand.
+MQTT_OSCILLATION_SKUS = {"H7105", "H7107"}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -608,8 +617,32 @@ class GoveeFanEntity(GoveeEntity, FanEntity):
         self._last_mode_values[work_mode] = mode_value
 
     async def async_oscillate(self, oscillating: bool) -> None:
-        """Oscillate the fan."""
+        """Oscillate the fan.
+
+        Tower Fan 2 family: route through the MQTT ptReal/multiSync frame path
+        (the only channel that moves the sweep motor), falling back to the REST
+        OscillationCommand if MQTT is down or the send fails — so behaviour is
+        never worse than before this path existed.
+        """
         _LOGGER.debug("Setting oscillation: %s", oscillating)
+
+        if (
+            self._device.sku in MQTT_OSCILLATION_SKUS
+            and self.coordinator.mqtt_connected
+        ):
+            try:
+                if await self.coordinator.async_send_fan_oscillation(
+                    self._device_id, oscillating
+                ):
+                    state = self.device_state
+                    if state is not None:
+                        state.apply_optimistic_oscillation(oscillating)
+                        self.async_write_ha_state()
+                    return
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "MQTT oscillation send failed (%s); falling back to REST", err
+                )
 
         await self.coordinator.async_control_device(
             self._device_id,

--- a/docs/govee-protocol-reference.md
+++ b/docs/govee-protocol-reference.md
@@ -2159,7 +2159,35 @@ Key observations:
 Key observations:
 - 12 speed levels (vs 8 on H7101) — fan speed count varies by model
 - Different work mode numbering than H7101 (Auto=2 vs Auto=3)
-- `oscillationToggle` for fan oscillation control
+- `oscillationToggle` is **advertised but a no-op** on the Tower Fan 2 family
+  (H7105/H7106/H7107/H7108): the Platform API returns HTTP 200 and the sweep
+  motor does not react (govee2mqtt #438/#709, disforw/goveelife #70). The
+  state readback works; only the write is dead.
+
+**Oscillation over AWS IoT (ptReal) — the channel that works.** Reverse-engineered
+in homebridge-govee `lib/device/fan-H7107.js` (v11.33.0, hardware-confirmed on
+H7107; identical fix for H7105 in v11.34.0) and verified on an H7107 by this
+integration (2026-08-26: OFF stops the sweep in <1 s, ON resumes it; the fan
+ACKs each frame with `state.result: 1` on its `GA/…` reporting topic).
+
+| Frame | Bytes (0-2) | Base64 (20-byte packet) | Notes |
+|-------|-------------|--------------------------|-------|
+| ptReal OFF | `33 1d 00` + zero pad + XOR | `Mx0AAAAAAAAAAAAAAAAAAAAAAC4=` | byte-exact to homebridge |
+| ptReal ON | `33 1d 01 [t0 t1 t2 t3]` + pad + XOR | — | tail = 4 swing-range bytes, optional |
+| multiSync twin | `3a 1d <on>` (same body, 0x3a prefix) | — | sent alongside each ptReal frame |
+
+- Publish the ptReal frame with the standard `{"msg": {"cmd": "ptReal", "data": {"command": [b64]}}}`
+  envelope on the device topic; the twin goes out as `cmd: "multiSync"` with the same
+  `command: [b64]` list.
+- The 4 tail bytes are the fan's configured sweep arc, echoed from its own inbound
+  `aa 1d` BLE-format status frame (bytes 3-6). A bare ON (`33 1d 01`, no tail) also
+  resumes the sweep on the H7107; the tail is replayed when seen so the fan keeps its
+  physically-configured arc.
+- There is **no angle/range SET command** — oscillation is a boolean; the rest position
+  after OFF is wherever the sweep stopped.
+- In this integration: `fan.py` routes `async_oscillate` for `MQTT_OSCILLATION_SKUS`
+  through `BlePassthroughManager.async_send_fan_oscillation` when the AWS IoT session
+  is up, falling back to the REST `OscillationCommand` otherwise.
 
 #### H1310 — Ceiling Fan + Light (`devices.types.light`)
 

--- a/tests/test_ble_packet.py
+++ b/tests/test_ble_packet.py
@@ -10,11 +10,15 @@ from custom_components.govee.api.ble_packet import (
     DIY_MODE_INDICATOR,
     DREAMVIEW_COMMAND,
     DREAMVIEW_INDICATOR,
+    FAN_OSC_COMMAND,
+    FAN_OSC_MULTISYNC_PREFIX,
+    FAN_OSC_PTREAL_PREFIX,
     MUSIC_MODE_COMMAND,
     MUSIC_MODE_INDICATOR,
     MUSIC_PACKET_PREFIX,
     build_diy_scene_packet,
     build_dreamview_packet,
+    build_fan_oscillation_packet,
     build_music_mode_packet,
     build_packet,
     calculate_checksum,
@@ -574,3 +578,71 @@ class TestDiyScenePacketIntegration:
         # Verify scene ID preserved
         recovered_id = int.from_bytes(decoded[3:7], byteorder="little")
         assert recovered_id == scene_id
+
+
+# ==============================================================================
+# Tower Fan Oscillation Packet Tests
+# ==============================================================================
+
+
+def _xor(data: bytes) -> int:
+    """XOR-fold bytes (the packet checksum)."""
+    result = 0
+    for b in data:
+        result ^= b
+    return result
+
+
+class TestBuildFanOscillationPacket:
+    """Test the Tower Fan 2 (H7105/H7107) oscillation packet builder."""
+
+    # Hardware-confirmed OFF frame from homebridge-govee lib/device/fan-H7107.js.
+    HOMEBRIDGE_OFF_B64 = "Mx0AAAAAAAAAAAAAAAAAAAAAAC4="
+
+    def test_off_matches_homebridge_frame(self):
+        """OFF is byte-exact to the frame homebridge-govee proved on hardware."""
+        packet = build_fan_oscillation_packet(False)
+        assert encode_packet_base64(packet) == self.HOMEBRIDGE_OFF_B64
+
+    def test_off_layout(self):
+        """OFF = 0x33 0x1d 0x00, zero-padded, XOR checksum."""
+        packet = build_fan_oscillation_packet(False)
+        assert len(packet) == 20
+        assert packet[0] == FAN_OSC_PTREAL_PREFIX
+        assert packet[1] == FAN_OSC_COMMAND
+        assert packet[2] == 0x00
+        assert packet[3:19] == bytes(16)
+        assert packet[19] == _xor(packet[:19])
+
+    def test_on_bare(self):
+        """ON without a swing tail = 0x33 0x1d 0x01, zero-padded."""
+        packet = build_fan_oscillation_packet(True)
+        assert packet[:3] == bytes([0x33, 0x1D, 0x01])
+        assert packet[3:19] == bytes(16)
+        assert packet[19] == _xor(packet[:19])
+
+    def test_on_with_swing_tail(self):
+        """ON carries the 4 swing-range bytes right after the enable byte."""
+        packet = build_fan_oscillation_packet(True, [0x01, 0x06, 0x03, 0x50])
+        assert packet[:7] == bytes([0x33, 0x1D, 0x01, 0x01, 0x06, 0x03, 0x50])
+        assert packet[7:19] == bytes(12)
+        assert packet[19] == _xor(packet[:19])
+
+    def test_on_tail_truncated_to_four_bytes(self):
+        """Only the first 4 tail bytes are used, each masked to a byte."""
+        packet = build_fan_oscillation_packet(True, [1, 2, 3, 0x1FF, 5, 6])
+        assert packet[3:7] == bytes([1, 2, 3, 0xFF])
+        assert packet[7] == 0x00
+
+    def test_off_ignores_tail(self):
+        """The swing tail is an ON-only payload."""
+        with_tail = build_fan_oscillation_packet(False, [1, 2, 3, 4])
+        assert with_tail == build_fan_oscillation_packet(False)
+
+    def test_multisync_prefix(self):
+        """The multiSync twin swaps the 0x33 prefix for 0x3a."""
+        packet = build_fan_oscillation_packet(False, prefix=FAN_OSC_MULTISYNC_PREFIX)
+        assert packet[0] == 0x3A
+        assert packet[1] == FAN_OSC_COMMAND
+        assert packet[2] == 0x00
+        assert packet[19] == _xor(packet[:19])

--- a/tests/test_ble_passthrough.py
+++ b/tests/test_ble_passthrough.py
@@ -1,0 +1,109 @@
+"""Tests for the BLE passthrough manager's Tower Fan oscillation path.
+
+The Tower Fan 2 family (H7105/H7107) ignores the Developer-API
+``oscillationToggle``; the sweep motor only obeys raw ptReal / multiSync
+frames on the AWS IoT session (homebridge-govee ``fan-H7107.js``).
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.govee.ble_passthrough import BlePassthroughManager
+
+DEVICE_ID = "AA:BB:CC:DD:EE:FF:00:44"
+SKU = "H7107"
+TOPIC = "GD/device-topic"
+# Hardware-confirmed OFF frame from homebridge-govee lib/device/fan-H7107.js.
+HOMEBRIDGE_OFF_B64 = "Mx0AAAAAAAAAAAAAAAAAAAAAAC4="
+
+
+def _make_client() -> MagicMock:
+    """Build a fake AWS IoT client with async publish methods."""
+    client = MagicMock()
+    client.connected = True
+    client.async_publish_ptreal = AsyncMock(return_value=True)
+    client.async_publish_command = AsyncMock(return_value=True)
+    return client
+
+
+def _make_manager(client: MagicMock | None) -> BlePassthroughManager:
+    """Build a manager wired to the given (possibly absent) client."""
+    return BlePassthroughManager(
+        get_mqtt_client=lambda: client,
+        device_topics={DEVICE_ID: TOPIC},
+        ensure_device_topic=AsyncMock(return_value=TOPIC),
+    )
+
+
+class TestSendFanOscillation:
+    """async_send_fan_oscillation publishes ptReal + multiSync twin."""
+
+    @pytest.mark.asyncio
+    async def test_off_sends_homebridge_frame_and_multisync_twin(self):
+        """OFF publishes the byte-exact homebridge frame plus its 0x3a twin."""
+        client = _make_client()
+        manager = _make_manager(client)
+
+        result = await manager.async_send_fan_oscillation(DEVICE_ID, SKU, False)
+
+        assert result is True
+        client.async_publish_ptreal.assert_awaited_once_with(
+            DEVICE_ID, SKU, HOMEBRIDGE_OFF_B64, TOPIC
+        )
+        client.async_publish_command.assert_awaited_once()
+        topic, cmd, payload = client.async_publish_command.call_args[0]
+        assert topic == TOPIC
+        assert cmd == "multiSync"
+        assert payload["device"] == DEVICE_ID
+        assert payload["sku"] == SKU
+        twin = base64.b64decode(payload["command"][0])
+        assert twin[:3] == bytes([0x3A, 0x1D, 0x00])
+
+    @pytest.mark.asyncio
+    async def test_on_carries_swing_tail_in_both_frames(self):
+        """ON replays the harvested swing-range tail on ptReal and multiSync."""
+        client = _make_client()
+        manager = _make_manager(client)
+        tail = [0x01, 0x06, 0x03, 0x50]
+
+        result = await manager.async_send_fan_oscillation(DEVICE_ID, SKU, True, tail)
+
+        assert result is True
+        ptreal_b64 = client.async_publish_ptreal.call_args[0][2]
+        ptreal = base64.b64decode(ptreal_b64)
+        assert ptreal[:7] == bytes([0x33, 0x1D, 0x01, 0x01, 0x06, 0x03, 0x50])
+        payload = client.async_publish_command.call_args[0][2]
+        twin = base64.b64decode(payload["command"][0])
+        assert twin[:7] == bytes([0x3A, 0x1D, 0x01, 0x01, 0x06, 0x03, 0x50])
+
+    @pytest.mark.asyncio
+    async def test_no_client_returns_false(self):
+        """Without an MQTT client nothing is sent and False lets REST run."""
+        manager = _make_manager(None)
+
+        assert await manager.async_send_fan_oscillation(DEVICE_ID, SKU, False) is False
+
+    @pytest.mark.asyncio
+    async def test_ptreal_result_propagates(self):
+        """The ptReal publish result is the return value."""
+        client = _make_client()
+        client.async_publish_ptreal.return_value = False
+        manager = _make_manager(client)
+
+        assert await manager.async_send_fan_oscillation(DEVICE_ID, SKU, True) is False
+
+    @pytest.mark.asyncio
+    async def test_multisync_failure_is_non_fatal(self):
+        """A failing multiSync twin does not mask a successful ptReal send."""
+        client = _make_client()
+        client.async_publish_command.side_effect = RuntimeError("twin failed")
+        manager = _make_manager(client)
+
+        result = await manager.async_send_fan_oscillation(DEVICE_ID, SKU, False)
+
+        assert result is True
+        client.async_publish_ptreal.assert_awaited_once()

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -292,6 +293,96 @@ class TestGoveeFanEntityControls:
         call_args = mock_coordinator.async_control_device.call_args
         assert isinstance(call_args[0][1], OscillationCommand)
         assert call_args[0][1].oscillating is False
+
+    # ------------------------------------------------------------------
+    # Tower Fan 2 family (H7105/H7107): oscillation over MQTT ptReal
+    # ------------------------------------------------------------------
+
+    @pytest.fixture
+    def tower_fan_entity(self, mock_coordinator, mock_fan_device):
+        """Create an H7107 entity whose oscillation routes over MQTT."""
+        device = replace(mock_fan_device, sku="H7107")
+        mock_coordinator.devices = {device.device_id: device}
+        mock_coordinator.mqtt_connected = True
+        mock_coordinator.async_send_fan_oscillation = AsyncMock(return_value=True)
+        entity = GoveeFanEntity(mock_coordinator, device)
+        entity.async_write_ha_state = MagicMock()
+        return entity
+
+    @pytest.mark.asyncio
+    async def test_tower_fan_oscillate_uses_mqtt(
+        self, tower_fan_entity, mock_coordinator, mock_fan_device_state
+    ):
+        """H7107 sends the MQTT frame, skips REST, and updates optimistically."""
+        await tower_fan_entity.async_oscillate(False)
+
+        mock_coordinator.async_send_fan_oscillation.assert_awaited_once_with(
+            tower_fan_entity._device_id, False
+        )
+        mock_coordinator.async_control_device.assert_not_called()
+        assert mock_fan_device_state.oscillating is False
+        tower_fan_entity.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tower_fan_oscillate_falls_back_when_mqtt_down(
+        self, tower_fan_entity, mock_coordinator
+    ):
+        """No MQTT session -> the pre-existing REST OscillationCommand path."""
+        mock_coordinator.mqtt_connected = False
+
+        await tower_fan_entity.async_oscillate(True)
+
+        mock_coordinator.async_send_fan_oscillation.assert_not_awaited()
+        mock_coordinator.async_control_device.assert_called_once()
+        call_args = mock_coordinator.async_control_device.call_args
+        assert isinstance(call_args[0][1], OscillationCommand)
+        assert call_args[0][1].oscillating is True
+
+    @pytest.mark.asyncio
+    async def test_tower_fan_oscillate_falls_back_when_send_declined(
+        self, tower_fan_entity, mock_coordinator, mock_fan_device_state
+    ):
+        """A False from the MQTT path (no client/topic) falls back to REST."""
+        mock_coordinator.async_send_fan_oscillation.return_value = False
+
+        await tower_fan_entity.async_oscillate(False)
+
+        mock_coordinator.async_control_device.assert_called_once()
+        assert isinstance(
+            mock_coordinator.async_control_device.call_args[0][1],
+            OscillationCommand,
+        )
+        # No optimistic write when the MQTT frame did not go out.
+        assert mock_fan_device_state.oscillating is True
+        tower_fan_entity.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tower_fan_oscillate_falls_back_when_send_raises(
+        self, tower_fan_entity, mock_coordinator
+    ):
+        """An exception on the MQTT path is logged and REST still runs."""
+        mock_coordinator.async_send_fan_oscillation.side_effect = RuntimeError(
+            "publish failed"
+        )
+
+        await tower_fan_entity.async_oscillate(False)
+
+        mock_coordinator.async_control_device.assert_called_once()
+        assert isinstance(
+            mock_coordinator.async_control_device.call_args[0][1],
+            OscillationCommand,
+        )
+
+    @pytest.mark.asyncio
+    async def test_other_fans_keep_rest_oscillation(self, fan_entity, mock_coordinator):
+        """A non-Tower-Fan-2 SKU (H7101) never touches the MQTT path."""
+        mock_coordinator.mqtt_connected = True
+        mock_coordinator.async_send_fan_oscillation = AsyncMock(return_value=True)
+
+        await fan_entity.async_oscillate(True)
+
+        mock_coordinator.async_send_fan_oscillation.assert_not_awaited()
+        mock_coordinator.async_control_device.assert_called_once()
 
 
 # ==============================================================================

--- a/tests/test_mqtt_fan_tail.py
+++ b/tests/test_mqtt_fan_tail.py
@@ -1,0 +1,123 @@
+"""Tests for Tower Fan swing-range tail capture in the AWS IoT MQTT client.
+
+Tower Fan 2 units (H7105/H7107) report their configured sweep arc in an
+inbound ``aa 1d`` BLE-format frame. The client keeps the last 4 range bytes
+per device so an oscillation-ON frame can replay the fan's own arc
+(homebridge-govee ``fan-H7107.js``).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.govee.api.auth import GoveeIotCredentials
+from custom_components.govee.api.mqtt import GoveeAwsIotClient
+
+FAN_ID = "AA:BB:CC:DD:EE:FF:00:44"
+
+
+def _make_client() -> GoveeAwsIotClient:
+    """Build a client with throwaway credentials and a no-op callback."""
+    creds = GoveeIotCredentials(
+        token="t",
+        refresh_token="r",
+        account_topic="GA/account",
+        iot_cert="cert",
+        iot_key="key",
+        iot_ca=None,
+        client_id="cid",
+        endpoint="endpoint",
+    )
+    client = GoveeAwsIotClient(creds, on_state_update=MagicMock())
+    # The multiSync branch is exercised elsewhere; keep this test on the tail.
+    client._handle_multisync = MagicMock()
+    return client
+
+
+def _message(frames: list[str | bytes]) -> MagicMock:
+    """Wrap raw frames in an inbound multiSync message from the fan."""
+    encoded = [
+        f if isinstance(f, str) else base64.b64encode(f).decode() for f in frames
+    ]
+    payload = {
+        "device": FAN_ID,
+        "sku": "H7107",
+        "cmd": "multiSync",
+        "op": {"command": encoded},
+    }
+    message = MagicMock()
+    message.topic = "GA/account"
+    message.payload = json.dumps(payload).encode()
+    return message
+
+
+def _aa1d(tail: list[int]) -> bytes:
+    """Build a 20-byte aa 1d status frame carrying the given 4 range bytes."""
+    body = [0xAA, 0x1D, 0x01, *tail]
+    return bytes(body + [0] * (20 - len(body)))
+
+
+class TestFanSwingTailCapture:
+    """The client remembers the latest aa1d swing-range tail per device."""
+
+    def test_none_before_any_frame(self):
+        """No frame seen yet -> None (caller sends a bare ON)."""
+        assert _make_client().fan_swing_tail(FAN_ID) is None
+
+    @pytest.mark.asyncio
+    async def test_captures_tail_from_aa1d_frame(self):
+        """Bytes 3-6 of an aa 1d frame are retained for the device."""
+        client = _make_client()
+
+        await client._handle_message(_message([_aa1d([0x01, 0x06, 0x03, 0x50])]))
+
+        assert client.fan_swing_tail(FAN_ID) == [0x01, 0x06, 0x03, 0x50]
+
+    @pytest.mark.asyncio
+    async def test_latest_frame_wins(self):
+        """A newer aa 1d frame replaces the stored tail."""
+        client = _make_client()
+
+        await client._handle_message(_message([_aa1d([1, 2, 3, 4])]))
+        await client._handle_message(_message([_aa1d([5, 6, 7, 8])]))
+
+        assert client.fan_swing_tail(FAN_ID) == [5, 6, 7, 8]
+
+    @pytest.mark.asyncio
+    async def test_ignores_other_frames(self):
+        """Frames that are not aa 1d (or are too short) are not harvested."""
+        client = _make_client()
+        other = bytes([0xAA, 0x05, 0x01, 0x06, 0x03, 0x50, 0x03]) + bytes(13)
+        short = bytes([0xAA, 0x1D, 0x01, 0x02])
+
+        await client._handle_message(_message([other, short]))
+
+        assert client.fan_swing_tail(FAN_ID) is None
+
+    @pytest.mark.asyncio
+    async def test_bad_base64_is_skipped(self):
+        """Undecodable entries are skipped without breaking the message."""
+        client = _make_client()
+
+        await client._handle_message(_message(["not-base64!!", _aa1d([9, 9, 9, 9])]))
+
+        assert client.fan_swing_tail(FAN_ID) == [9, 9, 9, 9]
+        client._handle_multisync.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tail_is_per_device(self):
+        """Another device's frame does not leak into this fan's tail."""
+        client = _make_client()
+        message = _message([_aa1d([1, 1, 1, 1])])
+        payload = json.loads(message.payload)
+        payload["device"] = "11:22:33:44:55:66:77:88"
+        message.payload = json.dumps(payload).encode()
+
+        await client._handle_message(message)
+
+        assert client.fan_swing_tail(FAN_ID) is None
+        assert client.fan_swing_tail("11:22:33:44:55:66:77:88") == [1, 1, 1, 1]


### PR DESCRIPTION
## Summary

Gives the Tower Fan 2 family real oscillation control by sending the raw frames the fan actually listens to, over the AWS IoT session the integration already holds.

The Platform API advertises `oscillationToggle` on these fans and returns HTTP 200 for it — but the sweep motor never moves. This is a documented, cross-project dead end (wez/govee2mqtt #438 and #709, disforw/goveelife #70), and it is why the H7107 in #121 reports "oscillation should already work" yet doesn't. The state *readback* is fine; only the write is a no-op.

homebridge-govee reverse-engineered the working path (`lib/device/fan-H7107.js`, v11.33.0; same fix for the H7105 in v11.34.0): a BLE-format frame published as **ptReal** — `33 1d <on>` zero-padded with the usual XOR checksum — plus a **multiSync** twin with a `3a` prefix. The fan ACKs each one with `state.result: 1` on its `GA/…` reporting topic.

## What changes

| File | Change |
|---|---|
| `api/ble_packet.py` | `build_fan_oscillation_packet(enabled, swing_tail, *, prefix)` + `FAN_OSC_*` constants |
| `api/mqtt.py` | Harvest the 4 swing-range bytes from inbound `aa 1d` frames (per device) so an ON frame can replay the fan's own configured arc; `fan_swing_tail(device_id)` getter |
| `ble_passthrough.py` | `async_send_fan_oscillation()` — publishes the ptReal frame and the multiSync twin (twin failure is non-fatal) |
| `coordinator.py` | `async_send_fan_oscillation(device_id, enabled)` — SKU + tail lookup → passthrough manager |
| `fan.py` | `GoveeFanEntity.async_oscillate` routes `MQTT_OSCILLATION_SKUS` through the frame path when the AWS IoT session is up, applies `apply_optimistic_oscillation`, and **falls back to the existing REST `OscillationCommand`** if MQTT is down, the send returns False, or anything raises |
| `docs/govee-protocol-reference.md` | Frame table + notes under the H7107 section |
| `tests/` | 23 new tests: packet builder (incl. byte-exact match to homebridge's OFF frame), entity routing + all three fallbacks + non-family SKU untouched, passthrough manager, `aa1d` tail capture |

Design notes:
- **Additive and gated.** Only `{"H7105", "H7107"}` take the new path — the two SKUs with a hardware-confirmed frame. H7106/H7108 are the same family and probably want this too, but I left them on REST until someone with the hardware confirms (one-line change).
- **Never worse than before.** Every failure mode on the MQTT path lands on the pre-existing REST command, so users without IoT credentials or with MQTT down see exactly today's behaviour.
- **Optimistic state** is applied only after the ptReal publish succeeds; the fan's normal state reports keep it honest afterwards.
- **No angle/aim control** — the protocol only offers a sweep on/off boolean; the 4 tail bytes echo the fan's own arc and are not a settable range. Documented as such.

## Hardware verification

Verified on an H7107 (2026-08-26) from Home Assistant with this exact code:
- Oscillate **OFF** → the sweep stops in under a second
- Oscillate **ON** (bare `33 1d 01`, no tail captured yet) → the sweep resumes
- Both frames ACK'd by the fan with `state.result: 1`
- OFF is byte-exact to homebridge's hardware-confirmed frame (`Mx0AAAAAAAAAAAAAAAAAAAAAAC4=`)

## Checks

- `pytest`: 1908 passed (full suite), 23 new
- `mypy custom_components/govee`: clean
- `flake8`: clean
- `black`: my hunks are clean; `fan.py`/`coordinator.py` on `main` already have a handful of pre-existing lines black 26.x would rewrap — I deliberately did **not** touch those to keep this diff reviewable

## References

- homebridge-govee `lib/device/fan-H7107.js` (v11.33.0) — frame source; issue homebridge-plugins/homebridge-govee#1334
- wez/govee2mqtt #438, #709 — `oscillationToggle` no-op on H7107
- disforw/goveelife #70 — same finding
- #121 — H7107 diagnostics in this repo (the fan's only three capabilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)