### PR TITLE
fix(sensor): decode H5310 temperature carry bit

### DIFF
--- a/custom_components/govee/api/mqtt.py
+++ b/custom_components/govee/api/mqtt.py
@@ -64,7 +64,7 @@ MULTISYNC_SUBTYPE_THERMO = 0x08
 
 # Thermo frame temperature encoding (issue #151).
 #
-#   T[°C] = (byte13 + THERMO_TEMP_OFFSET) / 10
+#   T[°C] = (byte13 + 256 * (byte14 & 0x01) + THERMO_TEMP_OFFSET) / 10
 #
 # Established by @Araknus13 against 30 on-the-hour frames paired with the
 # cloud reading they produced, spanning 24.4-29.5 °C over 31 hours: least
@@ -74,10 +74,11 @@ MULTISYNC_SUBTYPE_THERMO = 0x08
 # been indistinguishable only because they intersect at 31.25 °C, right where
 # that lone reading sat.
 #
-# The byte is unsigned, so the representable span is 11.2-36.7 °C, and the
-# capture only spans 24-30 °C. Both endpoints are treated as sentinels rather
-# than readings (see _decode_thermo_frame) since the rest of the frame uses
-# 0x00/0xFF the same way.
+# A later H5310 capture spanning the rollover showed byte 13 changing from
+# 0xFF to 0x00 while byte 14 changed from 0x82 to 0x83. The low bit of byte 14
+# is therefore the ninth (carry) bit of the temperature value; the other seven
+# bits are device-specific and must be ignored. This also proves 0x00 and 0xFF
+# are valid temperature bytes, not no-data sentinels.
 THERMO_TEMP_OFFSET = 112
 THERMO_TEMP_SCALE = 10.0
 
@@ -133,26 +134,22 @@ def _decode_thermo_frame(raw: bytes) -> dict[str, Any] | None:
 
     Returns:
         ``{"sensor_slot", "temperature_c", "battery", "frame_ts"}``, or None if
-        the frame is too short or byte 13 reads as a sentinel rather than a
-        temperature.
+        the frame is too short.
     """
-    if len(raw) < 14:
+    if len(raw) < 15:
         return None
 
     temp_byte = raw[13]
-    # 0x00 / 0xFF are the frame's own no-data markers (byte 16 sits at 0xFF
-    # permanently on the temperature-only H5310, and BFF reports its absent
-    # humidity as 0xFFFF). Decoding them would surface a confident 11.2 °C or
-    # 36.7 °C, which is worse than reporting nothing.
-    if temp_byte in (0x00, 0xFF):
-        return None
+    temp_carry = raw[14] & 0x01
 
     battery = raw[5] if raw[5] <= 100 else None
     frame_ts = int.from_bytes(raw[9:13], "big") if len(raw) >= 13 else None
 
     return {
         "sensor_slot": raw[2],
-        "temperature_c": (temp_byte + THERMO_TEMP_OFFSET) / THERMO_TEMP_SCALE,
+        "temperature_c": (
+            temp_byte + (temp_carry << 8) + THERMO_TEMP_OFFSET
+        ) / THERMO_TEMP_SCALE,
         "battery": battery,
         "frame_ts": frame_ts,
     }

--- a/tests/test_mqtt_multisync.py
+++ b/tests/test_mqtt_multisync.py
@@ -271,7 +271,8 @@ class TestThermoFrameDecode:
     stablemate leak sensors use. Byte 3 is the only discriminator: 0x02 for a
     leak sub-device, 0x08 for a thermometer.
 
-    The temperature encoding is ``T[°C] = (byte13 + 112) / 10``, established
+    The temperature encoding is
+    ``T[°C] = (byte13 + 256 * (byte14 & 1) + 112) / 10``, established
     in #151 against 30 on-the-hour frames paired with the cloud reading each
     produced. All frames below are verbatim from that capture, with the label
     the reporter's own cloud history recorded for them.
@@ -288,6 +289,14 @@ class TestThermoFrameDecode:
     # H5310 via H5044 from a DIFFERENT account (#157) — one labelled reading
     # of 88.34 °F at the end of that window, where byte 13 read 201.
     H5310_OTHER_ACCOUNT = "ee34000800642514a86a7ab5bec982ccff200060"
+
+    # Same H5310 immediately around the 36.7/36.8 °C rollover. Byte 13 wraps
+    # FF -> 00 and the low bit of byte 14 carries into 82 -> 83.
+    ROLLOVER = [
+        ("ee34000800642915b86a9374dfff82ccff20000e", 36.7),
+        ("ee34000800642915b76a9374070083ccff200027", 36.8),
+        ("ee34000800642915bb6a9340271683ccff200029", 39.0),
+    ]
 
     def _decode_one(self, packet: bytes) -> dict:
         """Run one packet through the handler; return the emitted event_data."""
@@ -323,6 +332,12 @@ class TestThermoFrameDecode:
         assert event["frame_ts"] == 0x6A7ECA3C
         assert 1786000000 < event["frame_ts"] < 1790000000
 
+    def test_temperature_carry_bit_across_rollover(self):
+        """Byte 14 bit 0 extends the temperature to nine bits."""
+        for hex_frame, label in self.ROLLOVER:
+            event = self._decode_one(bytes.fromhex(hex_frame))
+            assert abs(event["temperature_c"] - label) <= 0.1, hex_frame
+
     def test_battery_and_slot_decoded(self):
         event = self._decode_one(bytes.fromhex(self.LABELLED[0][0]))
         assert event["battery"] == 100
@@ -352,18 +367,6 @@ class TestThermoFrameDecode:
         event = self._decode_one(bytes.fromhex(self.LABELLED[0][0]))
         assert event.get("_leak_event") is None
         assert "is_wet" not in event
-
-    def test_sentinel_temperature_byte_is_dropped(self):
-        """0x00 / 0xFF at byte 13 are no-data markers, not 11.2/36.7 °C."""
-        cb = MagicMock()
-        client = _make_client()
-        client._on_state_update = cb
-        for sentinel in ("00", "ff"):
-            frame = bytes.fromhex(
-                "ee34000800642915c26a7eca3c" + sentinel + "baccff80002a"
-            )
-            client._handle_multisync(HUB_ID, _multisync([frame]))
-        assert cb.call_count == 0
 
     def test_short_thermo_frame_ignored(self):
         """A truncated frame has no byte 13 to read."""


### PR DESCRIPTION
## Summary

Fix H5310 gateway MQTT temperature decoding above 36.7°C.

The temperature uses byte 13 plus the low bit of byte 14 as a
9-bit value:

T°C = (byte13 + 256 × (byte14 & 1) + 112) / 10

The previous decoder used only byte 13, causing temperatures above
36.7°C to wrap by 25.6°C. For example, 39.0°C was decoded as 13.4°C.

## Evidence

Diagnostics captured the rollover:

- 36.7°C: byte13=FF, byte14=82
- 36.8°C: byte13=00, byte14=83
- 39.0°C: byte13=16, byte14=83

A live Home Assistant test now reports correctly through the previous
98°F rollover point, whereas before it reported incorrectly.

## Testing

Added regression cases using captured H5310 MQTT frames for 36.7°C,
36.8°C, and 39.0°C.


This is my first git pull request for anything ever, so hopefully I did it right.    Thanks.