### PR TITLE
Add support for probe (cooking) thermometers — H5192

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Govee in Home Assistant has several integrations, and it's easy to pick one that
 | **Aroma diffusers** | H7161 | Power switch + light/mist scene selector |
 | **Space heaters** | H7130, H7131, H713B, H721C | Power switch, target‑temperature number, auto‑stop switch; temperature unit follows what the device itself reports |
 | **Thermometers / hygrometers** | H5103, H5107, H5109, H5111, H5112, H5179, H5301, H5310 | Temperature & humidity sensors, **Battery** (account login) + a "Last Changed" timestamp; gateway‑bridged models (H5301/H5310 via an H5044) nest under the hub |
+| **Probe (cooking) thermometers** | H5192 | Core and ambient temperature per probe, plus the four alarm limits as editable numbers. These are **pull** devices — they answer a read and otherwise stay silent — so a **Live polling** switch (off by default, to spare the battery) controls whether readings update |
 | **Air‑quality & CO₂ monitors** | H5106, H5140 | CO₂ (ppm), air‑quality (AQI), temperature & humidity sensors |
 | **Presence sensors** | H5127 | Occupancy binary sensor, updated in real time over MQTT |
 | **Leak sensors** | H5054, H5055, H5058, H5059 (via an H5040/H5043/H5044 hub) | Moisture binary sensor, battery, sensor/gateway connectivity, last‑wet timestamp, button‑press event |

--- a/custom_components/govee/api/auth.py
+++ b/custom_components/govee/api/auth.py
@@ -39,6 +39,7 @@ from .exceptions import (
 from ..models.device import (
     LEAK_HUB_SKUS,
     LEAK_SENSOR_SKUS,
+    PROBE_THERMOMETER_BFF_SKUS,
     THERMO_HYGRO_BFF_READ_SKUS,
     THERMO_HYGRO_BFF_SKUS,
 )
@@ -880,6 +881,7 @@ class GoveeAuthClient:
                     if (
                         sku not in THERMO_HYGRO_BFF_SKUS
                         and sku not in THERMO_HYGRO_BFF_READ_SKUS
+                        and sku not in PROBE_THERMOMETER_BFF_SKUS
                     ):
                         continue
 
@@ -1447,6 +1449,9 @@ class GoveeAuthClient:
                     "in_leak_sensor_skus": sku in LEAK_SENSOR_SKUS,
                     "in_leak_hub_skus": sku in LEAK_HUB_SKUS,
                     "in_thermo_hygro_skus": sku in THERMO_HYGRO_BFF_SKUS,
+                    "in_probe_thermometer_skus": (
+                        sku in PROBE_THERMOMETER_BFF_SKUS
+                    ),
                     "has_sno": sno is not None,
                     # The slot number itself is a small int (0-7), not PII —
                     # surfacing it lets us confirm slot<->sno alignment against

--- a/custom_components/govee/api/mqtt.py
+++ b/custom_components/govee/api/mqtt.py
@@ -27,6 +27,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from ..models.device import PROBE_THERMOMETER_BFF_SKUS
+from .probe_thermometer import (
+    concat_command_blocks,
+    decode_limits,
+    decode_probe_reading,
+    decode_status_frame,
+)
+
 # Import aiomqtt at module level to avoid blocking in event loop
 try:
     import aiomqtt
@@ -231,6 +239,11 @@ class GoveeAwsIotClient:
         # undecoded hub packets (e.g. the H5059's 0xEE 0x35 wet alarm in #87)
         # without asking end users to enable verbose logging.
         self._recent_multisync: deque[dict[str, Any]] = deque(maxlen=64)
+        # Same idea for probe-thermometer frames: keeping the raw hex means
+        # the next probe SKU can be decoded from a diagnostics download
+        # alone, without asking the owner to run verbose logging while
+        # cooking.
+        self._recent_probe_frames: deque[dict[str, Any]] = deque(maxlen=64)
         # Latest Tower-Fan swing-range tail bytes per device_id, harvested from
         # inbound aa1d status frames. Used to rebuild the oscillation-ON packet
         # so the fan resumes its own physically-configured sweep arc.
@@ -249,6 +262,11 @@ class GoveeAwsIotClient:
     def recent_multisync(self) -> list[dict[str, Any]]:
         """Recent multiSync packets (hex + decode) for leak-sensor diagnostics."""
         return list(self._recent_multisync)
+
+    @property
+    def recent_probe_frames(self) -> list[dict[str, Any]]:
+        """Recent probe-thermometer frames (hex) for diagnostics."""
+        return list(self._recent_probe_frames)
 
     @property
     def last_message_ts(self) -> datetime | None:
@@ -566,8 +584,20 @@ class GoveeAwsIotClient:
                 ):
                     self._fan_swing_tail[device_id] = list(_fb[3:7])
 
-            # Handle multiSync messages (leak sensor events)
             cmd = data.get("cmd")
+
+            # Probe thermometers (H5192) answer reads over ptReal and
+            # volunteer a status frame on power-on. Gated on the SKU because
+            # light strips push their own 0xAA 0x05/0x13/0xA5 packets
+            # through op.command, which must never reach this decoder.
+            if data.get("sku", "") in PROBE_THERMOMETER_BFF_SKUS and cmd in (
+                "status",
+                "ptReal",
+            ):
+                self._handle_probe_frame(device_id, data)
+                return
+
+            # Handle multiSync messages (leak sensor events)
             if cmd == "multiSync":
                 self._handle_multisync(device_id, data)
                 return
@@ -627,6 +657,72 @@ class GoveeAwsIotClient:
                 "hex": safe.hex(),
             }
         )
+
+    def _handle_probe_frame(self, device_id: str, data: dict[str, Any]) -> None:
+        """Handle a probe-thermometer frame (H5192) from status or ptReal.
+
+        Three frame kinds arrive on this path, all identified by byte 1 of the
+        reassembled 20-byte packet (byte 0 varies between 0x40 and 0x47 and
+        carries no meaning here):
+
+        - 0x0F: the full status frame the device volunteers on power-on, both
+          probes with readings and limits in one packet
+        - 0x24: the answer to a live read, one probe's core and ambient
+        - 0x12: the answer to a limits read, one probe's alarm corridor
+
+        Anything else is left to the diagnostics ring buffer, which is written
+        before decoding so an unknown frame from the next probe SKU survives
+        into a download.
+        """
+        raw = concat_command_blocks(data.get("op", {}).get("command", []))
+        if raw is None:
+            return
+
+        self._recent_probe_frames.append(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "device_id": device_id,
+                "sku": data.get("sku", ""),
+                "cmd": data.get("cmd", ""),
+                "header": raw[:2].hex(),
+                "length": len(raw),
+                "hex": raw.hex(),
+            }
+        )
+
+        probes: dict[int, dict[str, float | None]] = {}
+
+        status = decode_status_frame(raw)
+        if status is not None:
+            probes = status
+        else:
+            reading = decode_probe_reading(raw)
+            if reading is not None:
+                probe, core, ambient = reading
+                probes = {probe: {"core": core, "ambient": ambient}}
+            else:
+                decoded_limits = decode_limits(raw)
+                if decoded_limits is not None:
+                    probe, limits = decoded_limits
+                    probes = {
+                        probe: {
+                            "core_max": limits.core_max,
+                            "core_min": limits.core_min,
+                            "ambient_max": limits.ambient_max,
+                            "ambient_min": limits.ambient_min,
+                        }
+                    }
+
+        if not probes:
+            _LOGGER.debug(
+                "Unhandled probe frame from %s: %s", device_id, raw[:2].hex()
+            )
+            return
+
+        try:
+            self._on_state_update(device_id, {"_probe_frame": True, "probes": probes})
+        except Exception as err:
+            _LOGGER.error("probe callback failed for %s: %s", device_id, err)
 
     def _handle_multisync(self, hub_device_id: str, data: dict[str, Any]) -> None:
         """Handle multiSync messages from hub devices (e.g., H5043 leak hub).

--- a/custom_components/govee/api/probe_thermometer.py
+++ b/custom_components/govee/api/probe_thermometer.py
@@ -1,0 +1,251 @@
+"""Decoding and encoding for Govee probe thermometers (H5192).
+
+These are two-probe cooking thermometers. Unlike every other device in this
+integration they are **pull devices**: they never volunteer readings, they only
+answer requests. Frames arrive while the Govee app is open because the app
+polls them on open — not because the device pushes. A 10 K core-temperature
+change with the app closed produces zero frames, while other devices on the
+same MQTT connection keep reporting, so it is not change-triggered either.
+
+The payload travels as base64 blocks in ``op.command`` of a ``ptReal`` message.
+Packets are 20 bytes with an XOR checksum over bytes 0-18 (see
+:mod:`.ble_packet`). Byte 0 selects read or write, byte 1 the register, byte 2
+the probe number.
+
+Register map, established by scanning and correlating against values set in the
+Govee app (33/88 degC for the core corridor, 70/-10 degC for the ambient one):
+
+===========  ==========================================  =========================
+Register     Contents                                    Evidence
+===========  ==========================================  =========================
+``0x08``     current probe values (core, ambient)        ``0D48 0A28`` = 34.00/26.00
+``0x09``     core corridor (max, min)                    ``2260 0CE4`` = 88/33
+``0x0C``     early-warning offset                        ``01F4`` = 5.00 (app value)
+``0x0D``     hardware version                            ASCII ``1.02.00``
+``0x0E``     wifi version                                ASCII ``2.10.03``
+``0x0F``     MAC address                                 matched the app's info screen
+``0x11``     ambient corridor (max, min)                 ``1B58 FC18`` = 70/-10
+``0x12``     all four limits at once                     ``26AC 02BC 1B58 FC18``
+``0x24``     probe data + history buffer                 see :func:`decode_probe_reading`
+``0x26``     likely battery voltage                      ``0DA6`` = 3494 (mV)
+===========  ==========================================  =========================
+
+``0x12`` is the register this module uses for limits: one read returns all four
+values for a probe, one write sets them. The device has no partial update, so a
+caller changing one value must supply the other three; a limit that is not set
+is carried as the sentinel, which the device both reports and accepts.
+
+Byte 11 of a ``0x12`` frame is a flag for whether the probe has any limit at
+all: ``0xFF`` when all four are unset, ``0xEE`` as soon as one is set. It does
+not encode which limit or how many — captured across all four states on an
+H5192 with firmware 1.00.81. Bytes 12-13 stayed ``FF FF`` throughout.
+
+All temperatures are signed int16, big-endian, in hundredths of a degree
+Celsius. ``0xFFFF`` is the "not present" sentinel, returned both by an unplugged
+probe and by an unset limit — it is checked **unsigned before** the signed
+conversion, otherwise it would decode to -0.01 degC.
+
+Two inbound frame shapes carry readings:
+
+* ``cmd: "status"``, byte 1 ``0x0F`` — both probes, six values each. The device
+  sends this unprompted on power-on and when an app session opens; no request
+  was found that triggers it.
+* ``cmd: "ptReal"``, byte 1 ``0x24`` — one probe's core and ambient temperature
+  plus a history buffer, newest first. Byte 0 is ``0x33`` when the device
+  volunteers it and ``0xAA`` when it answers a read.
+
+Byte 0 of the status frame varies (``0x40``, ``0x42``, ``0x44``, ``0x45`` and
+``0x47`` all observed on one device), so **only byte 1 identifies a frame**.
+
+The byte that looks like a battery percentage is a counter of buffered history
+points: it dropped from ``0x29`` to ``0x01`` on a probe swap while the battery
+was unchanged. The BFF device entry carries no battery field for this SKU
+either, so battery level is only available as the raw voltage in ``0x26``.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import struct
+from dataclasses import dataclass
+
+from .ble_packet import build_packet, encode_packet_base64
+
+READ_PREFIX = 0xAA
+WRITE_PREFIX = 0x33
+
+REGISTER_PROBE_DATA = 0x24
+REGISTER_LIMITS = 0x12
+REGISTER_STATUS = 0x0F
+
+SENTINEL = 0xFFFF
+SCALE = 100.0
+
+PROBES = (1, 2)
+
+# Status frame (byte 1 == 0x0F): six int16 per probe, 16 bytes apart.
+_STATUS_PROBE_OFFSETS = {1: 10, 2: 26}
+_STATUS_FIELDS = (
+    "core",
+    "core_max",
+    "core_min",
+    "ambient",
+    "ambient_max",
+    "ambient_min",
+)
+
+# ptReal frame (byte 1 == 0x24): newest (core, ambient) pair at offset 22.
+_PROBE_NUMBER_OFFSET = 2
+_PROBE_FIRST_PAIR = 22
+
+# Limits frame (byte 1 == 0x12): four int16 from offset 3.
+_LIMITS_FIRST = 3
+_LIMITS_FIELDS = ("core_max", "core_min", "ambient_max", "ambient_min")
+# Byte 11 says whether the probe has any limit set at all; bytes 12-13 were
+# FF FF in every capture. See the module docstring for the evidence.
+_LIMITS_ANY_SET = 0xEE
+_LIMITS_NONE_SET = 0xFF
+_LIMITS_TAIL_REST = (0xFF, 0xFF)
+
+
+@dataclass(frozen=True)
+class ProbeLimits:
+    """The four alarm limits of a single probe, in degrees Celsius."""
+
+    core_max: float | None
+    core_min: float | None
+    ambient_max: float | None
+    ambient_min: float | None
+
+
+def _read_temperature(raw: bytes, offset: int) -> float | None:
+    """Read one int16 as degrees Celsius, or None for the sentinel.
+
+    The unsigned word is compared against the sentinel *before* the signed
+    conversion — ``0xFFFF`` interpreted as a signed value would decode to
+    -0.01 degC and look like a plausible reading.
+    """
+    if offset + 2 > len(raw):
+        return None
+    if struct.unpack_from(">H", raw, offset)[0] == SENTINEL:
+        return None
+    return struct.unpack_from(">h", raw, offset)[0] / SCALE
+
+
+def concat_command_blocks(commands: list[str]) -> bytes | None:
+    """Join the base64 blocks of an ``op.command`` list into one frame."""
+    if not commands:
+        return None
+    try:
+        return b"".join(base64.b64decode(block) for block in commands)
+    except (binascii.Error, TypeError, ValueError):
+        return None
+
+
+def verify_checksum(raw: bytes) -> bool:
+    """Return True if the first 20 bytes carry a valid XOR checksum."""
+    if len(raw) < 20:
+        return False
+    checksum = 0
+    for byte in raw[:19]:
+        checksum ^= byte
+    return checksum == raw[19]
+
+
+def decode_status_frame(raw: bytes) -> dict[int, dict[str, float | None]] | None:
+    """Decode a ``cmd: "status"`` frame into per-probe readings and limits.
+
+    Returns a mapping of probe number to its six values, or None if the frame
+    is too short or byte 1 does not identify a status frame.
+    """
+    if len(raw) < 40 or raw[1] != REGISTER_STATUS:
+        return None
+
+    result: dict[int, dict[str, float | None]] = {}
+    for probe, base in _STATUS_PROBE_OFFSETS.items():
+        result[probe] = {
+            field: _read_temperature(raw, base + 2 * index)
+            for index, field in enumerate(_STATUS_FIELDS)
+        }
+    return result
+
+
+def decode_probe_reading(raw: bytes) -> tuple[int, float | None, float | None] | None:
+    """Decode a ``0x24`` frame into ``(probe, core, ambient)``.
+
+    Accepts both the device-volunteered form (byte 0 ``0x33``) and the reply to
+    a read (byte 0 ``0xAA``); only byte 1 is checked.
+    """
+    if len(raw) < _PROBE_FIRST_PAIR + 4 or raw[1] != REGISTER_PROBE_DATA:
+        return None
+
+    probe = raw[_PROBE_NUMBER_OFFSET]
+    if probe not in PROBES:
+        return None
+
+    return (
+        probe,
+        _read_temperature(raw, _PROBE_FIRST_PAIR),
+        _read_temperature(raw, _PROBE_FIRST_PAIR + 2),
+    )
+
+
+def decode_limits(raw: bytes) -> tuple[int, ProbeLimits] | None:
+    """Decode a ``0x12`` frame into ``(probe, ProbeLimits)``."""
+    if len(raw) < _LIMITS_FIRST + 8 or raw[1] != REGISTER_LIMITS:
+        return None
+
+    probe = raw[_PROBE_NUMBER_OFFSET]
+    if probe not in PROBES:
+        return None
+
+    values = {
+        field: _read_temperature(raw, _LIMITS_FIRST + 2 * index)
+        for index, field in enumerate(_LIMITS_FIELDS)
+    }
+    return probe, ProbeLimits(**values)
+
+
+def build_probe_read_packet(probe: int) -> str:
+    """Build the base64 read request for one probe's current values."""
+    return encode_packet_base64(build_packet([READ_PREFIX, REGISTER_PROBE_DATA, probe]))
+
+
+def build_limits_read_packet(probe: int) -> str:
+    """Build the base64 read request for one probe's four limits."""
+    return encode_packet_base64(build_packet([READ_PREFIX, REGISTER_LIMITS, probe]))
+
+
+def build_limits_write_packet(probe: int, limits: ProbeLimits) -> str:
+    """Build the base64 write packet setting all four limits of one probe.
+
+    A limit of None is written as the sentinel, which is how the device itself
+    represents "no limit": a factory-fresh probe reports all four as ``0xFFFF``,
+    and clearing an alarm in the Govee app puts them back to it. Refusing to
+    write while a value is unknown would therefore lock the common case — every
+    probe starts with all four unset, so the first limit could never be set.
+
+    The device has no partial update, so the caller supplies all four values;
+    :meth:`GoveeCoordinator.async_set_probe_limits` fills the ones that are not
+    being changed from state.
+    """
+    values = (
+        limits.core_max,
+        limits.core_min,
+        limits.ambient_max,
+        limits.ambient_min,
+    )
+
+    data = [WRITE_PREFIX, REGISTER_LIMITS, probe]
+    for value in values:
+        if value is None:
+            data.extend(SENTINEL.to_bytes(2, "big"))
+            continue
+        data.extend(struct.pack(">h", round(float(value) * SCALE)))
+
+    any_set = any(value is not None for value in values)
+    data.append(_LIMITS_ANY_SET if any_set else _LIMITS_NONE_SET)
+    data.extend(_LIMITS_TAIL_REST)
+
+    return encode_packet_base64(build_packet(data))

--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_LAN_TARGETS,
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
+    CONF_PROBE_POLL_INTERVAL,
     CONF_WATER_DETECTOR_POLL_INTERVAL,
     CONFIG_VERSION,
     DEFAULT_API_TEMPERATURE_UNIT,
@@ -54,12 +55,15 @@ from .const import (
     DEFAULT_EXPOSE_TRANSPORT_ENTITIES,
     DEFAULT_LAN_TARGETS,
     DEFAULT_POLL_INTERVAL,
+    DEFAULT_PROBE_POLL_INTERVAL,
     DEFAULT_SEGMENT_MODE,
     DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DOMAIN,
     KEY_IOT_CREDENTIALS,
     KEY_IOT_LOGIN_FAILED,
+    MAX_PROBE_POLL_INTERVAL,
     MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_PROBE_POLL_INTERVAL,
     MIN_WATER_DETECTOR_POLL_INTERVAL,
     SEGMENT_MODE_BOTH,
     SEGMENT_MODE_DISABLED,
@@ -451,6 +455,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_WATER_DETECTOR_POLL_INTERVAL: (
                     DEFAULT_WATER_DETECTOR_POLL_INTERVAL
                 ),
+                CONF_PROBE_POLL_INTERVAL: DEFAULT_PROBE_POLL_INTERVAL,
             },
         )
 
@@ -773,6 +778,19 @@ class GoveeOptionsFlow(OptionsFlow):
                         vol.Range(
                             min=MIN_WATER_DETECTOR_POLL_INTERVAL,
                             max=MAX_WATER_DETECTOR_POLL_INTERVAL,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_PROBE_POLL_INTERVAL,
+                        default=source.get(
+                            CONF_PROBE_POLL_INTERVAL,
+                            DEFAULT_PROBE_POLL_INTERVAL,
+                        ),
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(
+                            min=MIN_PROBE_POLL_INTERVAL,
+                            max=MAX_PROBE_POLL_INTERVAL,
                         ),
                     ),
                     vol.Optional(

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -23,6 +23,7 @@ CONF_ENABLE_MQTT_CONTROL: Final = "enable_mqtt_control"
 # account API's rate limit is unverified (homebridge issue #543) — users with
 # many detectors may want to back off, while a single detector can poll faster.
 CONF_WATER_DETECTOR_POLL_INTERVAL: Final = "water_detector_poll_interval"
+CONF_PROBE_POLL_INTERVAL: Final = "probe_poll_interval"
 
 # Extra LAN discovery targets for devices the local multicast scan can't reach —
 # e.g. Govee devices on a different VLAN/subnet than Home Assistant (issue #57).
@@ -168,12 +169,18 @@ DEFAULT_ENABLE_MQTT_CONTROL: Final = False
 DEFAULT_API_TEMPERATURE_UNIT: Final = "auto"
 DEFAULT_LAN_TARGETS: Final = ""
 DEFAULT_WATER_DETECTOR_POLL_INTERVAL: Final = 120  # seconds (2 minutes)
+# Probe thermometers are pull devices, so this interval is the entire
+# update rate while cooking. 30 s keeps a roast legible without hammering
+# the device; the poll only runs while its live-polling switch is on.
+DEFAULT_PROBE_POLL_INTERVAL: Final = 30  # seconds
 
 # Bounds for the configurable water-detector poll interval (seconds). The lower
 # bound keeps the unverified account-API rate limit at arm's length; the upper
 # bound (1 hour) is the slowest that still makes a leak alert useful.
 MIN_WATER_DETECTOR_POLL_INTERVAL: Final = 60
 MAX_WATER_DETECTOR_POLL_INTERVAL: Final = 3600
+MIN_PROBE_POLL_INTERVAL: Final = 10
+MAX_PROBE_POLL_INTERVAL: Final = 600
 
 # Optimistic state handling
 # Grace window (seconds) during which API polls do NOT overwrite optimistic

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -73,9 +73,11 @@ from .const import (
     CONF_ENABLE_MQTT_CONTROL,
     CONF_LAN_TARGETS,
     CONF_PASSWORD,
+    CONF_PROBE_POLL_INTERVAL,
     CONF_WATER_DETECTOR_POLL_INTERVAL,
     DEFAULT_API_TEMPERATURE_UNIT,
     DEFAULT_ENABLE_MQTT_CONTROL,
+    DEFAULT_PROBE_POLL_INTERVAL,
     DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DEVICE_REDISCOVERY_INTERVAL,
     DOMAIN,
@@ -88,7 +90,9 @@ from .const import (
     LAN_WRITE_CONFIRM_TIMEOUT,
     LAN_WRITE_SUPPRESS_SECONDS,
     LAN_WRITE_SUPPRESS_THRESHOLD,
+    MAX_PROBE_POLL_INTERVAL,
     MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_PROBE_POLL_INTERVAL,
     MIN_WATER_DETECTOR_POLL_INTERVAL,
     OPTIMISTIC_GRACE_CAP_SECONDS,
     resolve_fahrenheit_conversion,
@@ -96,6 +100,7 @@ from .const import (
 from .models import (
     GoveeDevice,
     GoveeDeviceState,
+    ProbeReading,
     RGBColor,
     TransportHealth,
     TransportKind,
@@ -120,6 +125,13 @@ from .models.commands import (
     WorkModeCommand,
     create_dreamview_command,
 )
+from .api.probe_thermometer import (
+    PROBES,
+    ProbeLimits,
+    build_limits_read_packet,
+    build_limits_write_packet,
+    build_probe_read_packet,
+)
 from .models.device import (
     INSTANCE_DREAMVIEW,
     INSTANCE_FAN_OSCILLATE,
@@ -131,6 +143,7 @@ from .models.device import (
     INSTANCE_THERMOSTAT_TOGGLE,
     MAINS_POWERED_BATTERY_SKUS,
     MAINS_POWERED_DEVICE_TYPES,
+    PROBE_THERMOMETER_BFF_SKUS,
 )
 from .models.device import GoveeLeakSensor, GoveeLeakSensorState
 from .scene_cache import SceneCacheManager
@@ -179,6 +192,12 @@ LAN_COLOR_TEMP_CONFIRM_TOLERANCE = 150
 
 # BFF polling interval for leak sensor state (seconds)
 BFF_POLL_INTERVAL = 300  # 5 minutes
+
+# Field names a probe frame may carry. Derived from the dataclass so a new
+# channel cannot be silently dropped by the merge.
+_PROBE_READING_FIELDS: Final = frozenset(
+    f.name for f in dataclasses.fields(ProbeReading)
+)
 
 
 def normalize_device_id(device_id: str) -> str:
@@ -425,6 +444,11 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         self._bff_poll_task: asyncio.Task[None] | None = None
         # Standalone water-detector (H5054) leak polling (issue #62).
         self._wd_poll_unsub: CALLBACK_TYPE | None = None
+        # Probe thermometers (H5192) are pull devices: nothing arrives
+        # unless we ask. The timer only runs while at least one device has
+        # its live-polling switch on, so an idle thermometer is left alone.
+        self._probe_poll_unsub: CALLBACK_TYPE | None = None
+        self._probe_polling_enabled: set[str] = set()
         # Last seen lastTime per detector — warnMessage is only called when the
         # device has freshly reported (or is currently wet), keeping the account
         # API request count low.
@@ -2340,6 +2364,25 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                         self._sensor_reading_changed_at[device_id] = dt_util.utcnow()
                     continue
 
+                if sensor["sku"] in PROBE_THERMOMETER_BFF_SKUS:
+                    self._devices[device_id] = (
+                        GoveeDevice.synthetic_probe_thermometer(
+                            device_id=device_id,
+                            sku=sensor["sku"],
+                            name=sensor["name"],
+                        )
+                    )
+                    # Membership here buys three things at once: the
+                    # Developer poll skips the device (it 404s on this SKU),
+                    # the availability mixin ignores the flapping online
+                    # flag, and readings count as already-Celsius.
+                    self._bff_thermometer_ids.add(device_id)
+                    state = GoveeDeviceState.create_empty(device_id)
+                    state.online = sensor.get("online", True)
+                    self._states[device_id] = state
+                    self._ensure_transport_health(device_id)
+                    continue
+
                 hub_device_id = sensor.get("hub_device_id", "")
                 device = GoveeDevice.synthetic_thermometer(
                     device_id=device_id,
@@ -2421,6 +2464,19 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 )
                 self._bff_thermo_pending.discard(device_id)
                 self._bff_thermometer_ids.add(device_id)
+
+            # Probe thermometers never take part in this refresh. It
+            # rebuilds state from create_empty() and copies only
+            # temp/humidity/battery, which would drop ``probes`` every five
+            # minutes — the readings only the MQTT frames carry. Their BFF
+            # entry has no reading to offer anyway.
+            #
+            # Gated on the SKU in the payload rather than on the device
+            # object: this runs before discovery has necessarily put the
+            # device in the registry, and the payload is the same source
+            # discovery itself reads.
+            if sensor.get("sku") in PROBE_THERMOMETER_BFF_SKUS:
+                continue
 
             existing = self._states.get(device_id)
             if existing is None:
@@ -2878,6 +2934,172 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         self._bff_poll_task = self.hass.async_create_task(self._poll_bff_leak_state())
 
     @callback
+    def _handle_probe_frame(self, device_id: str, state_data: dict[str, Any]) -> None:
+        """Merge a decoded probe-thermometer frame into device state.
+
+        Merges per probe and per field: a ``0x24`` reply carries only core and
+        ambient, a ``0x12`` reply only the four limits, and a status frame all
+        six. Replacing the entry instead of merging would blank whichever half
+        the current frame did not carry, so the values are folded into the
+        existing :class:`ProbeReading`.
+        """
+        device = self._devices.get(device_id)
+        if device is None:
+            return
+
+        state = self._states.get(device_id) or GoveeDeviceState.create_empty(device_id)
+        probes = dict(state.probes)
+        changed = False
+
+        for probe, fields in state_data.get("probes", {}).items():
+            current = probes.get(probe, ProbeReading())
+            merged = dataclasses.replace(
+                current,
+                **{k: v for k, v in fields.items() if k in _PROBE_READING_FIELDS},
+            )
+            if merged != current:
+                probes[probe] = merged
+                changed = True
+
+        state.probes = probes
+        # A frame is proof of life. The BFF ``online`` flag sits at false for
+        # this SKU permanently, so it must not be believed here.
+        state.online = True
+        self._states[device_id] = state
+
+        if changed or device_id not in self._sensor_reading_changed_at:
+            self._sensor_reading_changed_at[device_id] = dt_util.utcnow()
+
+        self._ensure_transport_health(device_id)
+        self._record_transport_success(device_id, "mqtt")
+        self.async_set_updated_data(self._states)
+
+    @property
+    def _probe_poll_interval(self) -> int:
+        """Configured probe-poll interval in seconds, clamped to sane bounds."""
+        raw = self._config_entry.options.get(
+            CONF_PROBE_POLL_INTERVAL, DEFAULT_PROBE_POLL_INTERVAL
+        )
+        try:
+            interval = int(raw)
+        except (TypeError, ValueError):
+            return DEFAULT_PROBE_POLL_INTERVAL
+        if not (MIN_PROBE_POLL_INTERVAL <= interval <= MAX_PROBE_POLL_INTERVAL):
+            return DEFAULT_PROBE_POLL_INTERVAL
+        return interval
+
+    def set_probe_polling(self, device_id: str, enabled: bool) -> None:
+        """Arm or disarm live polling for one probe thermometer.
+
+        Driven by the per-device switch entity. Enabling fires one immediate
+        read burst so the entities populate right away instead of staying
+        unknown until the first tick.
+        """
+        if enabled:
+            self._probe_polling_enabled.add(device_id)
+            self.hass.async_create_task(self._poll_probe_thermometers())
+            self._schedule_probe_poll()
+        else:
+            self._probe_polling_enabled.discard(device_id)
+            if not self._probe_polling_enabled and self._probe_poll_unsub:
+                self._probe_poll_unsub()
+                self._probe_poll_unsub = None
+
+    def is_probe_polling(self, device_id: str) -> bool:
+        """Return True while live polling is armed for this device."""
+        return device_id in self._probe_polling_enabled
+
+    def _schedule_probe_poll(self) -> None:
+        """Schedule the next probe read, replacing any pending timer."""
+        if self._probe_poll_unsub:
+            self._probe_poll_unsub()
+        self._probe_poll_unsub = async_call_later(
+            self.hass, self._probe_poll_interval, self._probe_poll_callback
+        )
+
+    async def _probe_poll_callback(self, _now: Any = None) -> None:
+        """Periodic callback: read every armed probe, then re-arm the timer."""
+        await self._poll_probe_thermometers()
+        if self._probe_polling_enabled:
+            self._schedule_probe_poll()
+
+    async def _poll_probe_thermometers(self) -> None:
+        """Read current values and limits from every armed probe thermometer.
+
+        One read per probe — the per-probe ``0x24`` reply is the only response
+        that could be provoked. The six-value status frame arrives unprompted
+        on power-on and when an app session opens; no request was found that
+        triggers it. Limits change rarely but are read on the same tick, which
+        costs two more small packets and keeps the number entities honest.
+        """
+        if not self._probe_polling_enabled:
+            return
+        client = self.mqtt_client
+        if client is None or not client.connected:
+            return
+
+        for device_id in list(self._probe_polling_enabled):
+            device = self._devices.get(device_id)
+            if device is None:
+                continue
+            for probe in PROBES:
+                await self._ble_manager.async_send_ble_packet(
+                    device_id, device.sku, build_probe_read_packet(probe)
+                )
+                await self._ble_manager.async_send_ble_packet(
+                    device_id, device.sku, build_limits_read_packet(probe)
+                )
+
+    async def async_set_probe_limits(
+        self,
+        device_id: str,
+        probe: int,
+        *,
+        core_max: float | None = None,
+        core_min: float | None = None,
+        ambient_max: float | None = None,
+        ambient_min: float | None = None,
+    ) -> bool:
+        """Write one or more alarm limits of a probe, carrying the rest over.
+
+        Register 0x12 has no partial update, so the three unchanged values come
+        from state. A value that is still unknown goes out as the sentinel,
+        which is how the device represents "no limit" — it reports all four
+        that way when nothing is set, and the Govee app clearing an alarm puts
+        them back to it. Passing None for a limit therefore clears it.
+        """
+        device = self._devices.get(device_id)
+        state = self._states.get(device_id)
+        if device is None or state is None:
+            return False
+
+        current = state.probes.get(probe, ProbeReading())
+        limits = ProbeLimits(
+            core_max=core_max if core_max is not None else current.core_max,
+            core_min=core_min if core_min is not None else current.core_min,
+            ambient_max=(
+                ambient_max if ambient_max is not None else current.ambient_max
+            ),
+            ambient_min=(
+                ambient_min if ambient_min is not None else current.ambient_min
+            ),
+        )
+
+        packet = build_limits_write_packet(probe, limits)
+        sent = await self._ble_manager.async_send_ble_packet(
+            device_id, device.sku, packet
+        )
+        if not sent:
+            return False
+
+        # Read back rather than trusting the write: the device acknowledges the
+        # packet, not the stored value.
+        await self._ble_manager.async_send_ble_packet(
+            device_id, device.sku, build_limits_read_packet(probe)
+        )
+        return True
+
+    @callback
     def _handle_thermo_frame(self, state_data: dict[str, Any]) -> None:
         """Apply a decoded gateway thermometer frame (issue #151).
 
@@ -3007,6 +3229,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             return
 
         # Handle gateway-bridged thermometer frames (issue #151)
+        if state_data.get("_probe_frame"):
+            self._handle_probe_frame(device_id, state_data)
+            return
+
         if state_data.get("_thermo_frame"):
             self._handle_thermo_frame(state_data)
             return
@@ -4581,6 +4807,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if self._wd_poll_unsub:
             self._wd_poll_unsub()
             self._wd_poll_unsub = None
+        # Cancel probe-thermometer polling
+        if self._probe_poll_unsub:
+            self._probe_poll_unsub()
+            self._probe_poll_unsub = None
 
         # Disconnect all BLE devices
         for ble_device in self._ble_devices.values():

--- a/custom_components/govee/diagnostics.py
+++ b/custom_components/govee/diagnostics.py
@@ -254,6 +254,7 @@ def _runtime_diag(coordinator: GoveeCoordinator) -> dict[str, Any]:
     mqtt_client = coordinator.mqtt_client
     mqtt_info: dict[str, Any] | None = None
     recent_multisync: list[dict[str, Any]] = []
+    recent_probe_frames: list[dict[str, Any]] = []
     if mqtt_client:
         mqtt_info = {
             "available": mqtt_client.available,
@@ -263,6 +264,9 @@ def _runtime_diag(coordinator: GoveeCoordinator) -> dict[str, Any]:
         # Recent hub multiSync packets (hex) — lets undecoded leak-sensor
         # packet subtypes be reverse-engineered from a download alone (#87).
         recent_multisync = mqtt_client.recent_multisync
+        # Raw probe-thermometer frames (hex). Same purpose as the multiSync
+        # buffer: the next probe SKU should be decodable from a download.
+        recent_probe_frames = mqtt_client.recent_probe_frames
     openapi_client = coordinator.openapi_events_client
     openapi_info: dict[str, Any] | None = None
     if openapi_client:
@@ -279,6 +283,7 @@ def _runtime_diag(coordinator: GoveeCoordinator) -> dict[str, Any]:
         "mqtt": mqtt_info,
         "openapi_events": openapi_info,
         "recent_multisync": recent_multisync,
+        "recent_probe_frames": recent_probe_frames,
         # Recent /device/control sends with the exact capability payload and
         # Govee's HTTP status + response body — lets "command accepted but
         # device does nothing" reports (#127) be debugged from a download

--- a/custom_components/govee/models/__init__.py
+++ b/custom_components/govee/models/__init__.py
@@ -29,7 +29,7 @@ from .device import (
     GoveeDevice,
     SegmentCapability,
 )
-from .state import GoveeDeviceState, RGBColor, SegmentState
+from .state import GoveeDeviceState, ProbeReading, RGBColor, SegmentState
 from .transport import TRANSPORT_KINDS, TransportHealth, TransportKind
 
 __all__ = [
@@ -40,6 +40,7 @@ __all__ = [
     "SegmentCapability",
     # State
     "GoveeDeviceState",
+    "ProbeReading",
     "RGBColor",
     "SegmentState",
     # Commands

--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -55,6 +55,14 @@ THERMO_HYGRO_BFF_READ_SKUS = frozenset({"H5179", "H5112"})
 # the humidity capability for these so no humidity entity is created.
 TEMP_ONLY_BFF_SKUS = frozenset({"H5310"})
 
+# Probe (cooking) thermometers reached through the BFF list. Unlike every
+# other device here these are PULL devices: they never volunteer readings,
+# they only answer read requests over ptReal (see
+# api/probe_thermometer.py). Their BFF ``lastDeviceData`` stays
+# ``{"online": false}`` permanently, so the BFF read path has nothing to
+# offer them either — the coordinator polls them instead.
+PROBE_THERMOMETER_BFF_SKUS = frozenset({"H5192"})
+
 # Capability type constants (from Govee API v2.0)
 CAPABILITY_ON_OFF = "devices.capabilities.on_off"
 CAPABILITY_RANGE = "devices.capabilities.range"
@@ -687,6 +695,11 @@ class GoveeDevice:
         """Check if device is a stand-alone thermometer/hygrometer."""
         return self.device_type == DEVICE_TYPE_THERMOMETER
 
+    @property
+    def is_probe_thermometer(self) -> bool:
+        """Check if device is a probe (cooking) thermometer, e.g. H5192."""
+        return self.sku in PROBE_THERMOMETER_BFF_SKUS
+
     def get_humidity_range(self) -> tuple[int, int]:
         """Extract target humidity range from the range.humidity capability.
 
@@ -1294,6 +1307,29 @@ class GoveeDevice:
         if hub_device_id:
             device = replace(device, hub_device_id=hub_device_id)
         return device
+
+    @classmethod
+    def synthetic_probe_thermometer(
+        cls, device_id: str, sku: str, name: str
+    ) -> GoveeDevice:
+        """Build a GoveeDevice for a BFF-discovered probe thermometer.
+
+        Deliberately carries NO ``sensorTemperature`` capability, unlike
+        :meth:`synthetic_thermometer`. A probe thermometer has one reading
+        per probe and channel, which a single capability cannot express;
+        granting it would create a generic temperature entity that sits at
+        unknown forever. The per-probe entities in ``sensor.py`` attach on
+        :attr:`is_probe_thermometer` instead.
+        """
+        return cls.from_api_response(
+            {
+                "device": device_id,
+                "sku": sku,
+                "deviceName": name,
+                "type": DEVICE_TYPE_THERMOMETER,
+                "capabilities": [],
+            }
+        )
 
 
 @dataclass(frozen=True)

--- a/custom_components/govee/models/state.py
+++ b/custom_components/govee/models/state.py
@@ -163,6 +163,24 @@ class LanDevStatusLike(Protocol):
     color_temp_kelvin: int | None
 
 
+@dataclass(frozen=True)
+class ProbeReading:
+    """One probe of a probe thermometer (H5192).
+
+    ``core`` and ``ambient`` are the live temperatures; the four limits are the
+    alarm corridor stored in the device. Every field is None when the device
+    reports the 0xFFFF sentinel — an unplugged probe for the readings, an unset
+    corridor for the limits. All values are degrees Celsius.
+    """
+
+    core: float | None = None
+    ambient: float | None = None
+    core_max: float | None = None
+    core_min: float | None = None
+    ambient_max: float | None = None
+    ambient_min: float | None = None
+
+
 @dataclass
 class GoveeDeviceState:
     """Mutable device state updated from API or MQTT.
@@ -206,6 +224,12 @@ class GoveeDeviceState:
     # Appliance nightlight scene (H5089/H7124, issue #114): integer id of the
     # active named nightlightScene mode option.
     nightlight_scene: int | None = None
+
+    # Probe thermometer readings, keyed by probe number (H5192). Frozen
+    # values, so a merge replaces the entry rather than mutating it.
+    # Diagnostics dumps state with dataclasses.asdict, so these appear in
+    # downloads without extra plumbing.
+    probes: dict[int, ProbeReading] = field(default_factory=dict)
 
     # DreamView (Movie Mode) state
     dreamview_enabled: bool | None = None  # DreamView on/off

--- a/custom_components/govee/number.py
+++ b/custom_components/govee/number.py
@@ -8,16 +8,23 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberMode,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api.probe_thermometer import PROBES
 from .const import DOMAIN, SUFFIX_HEATER_TEMPERATURE, SUFFIX_MUSIC_SENSITIVITY
 from .coordinator import GoveeCoordinator
+from .entity import GoveeEntity
 from .models import GoveeDevice, MusicModeCommand, TemperatureSettingCommand
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,6 +43,20 @@ async def async_setup_entry(
     entities: list[NumberEntity] = []
 
     for device in coordinator.devices.values():
+        # Probe thermometer alarm limits: four per probe.
+        if device.is_probe_thermometer:
+            for probe in PROBES:
+                for limit in (
+                    "core_max",
+                    "core_min",
+                    "ambient_max",
+                    "ambient_min",
+                ):
+                    entities.append(
+                        GoveeProbeLimitNumber(coordinator, device, probe, limit)
+                    )
+            continue
+
         # Music sensitivity control for devices with STRUCT-based music mode
         # Note: This doesn't require MQTT - it uses REST API
         if device.has_struct_music_mode:
@@ -73,6 +94,67 @@ async def async_setup_entry(
 
     async_add_entities(entities)
     _LOGGER.debug("Set up %d Govee number entities", len(entities))
+
+
+class GoveeProbeLimitNumber(GoveeEntity, NumberEntity):
+    """One alarm limit of one probe on a probe thermometer (H5192).
+
+    Four per probe: the core corridor and the ambient corridor, each with an
+    upper and a lower bound. Register 0x12 has no partial update, so writing
+    one value carries the other three over from state — see
+    :meth:`GoveeCoordinator.async_set_probe_limits`, which refuses the write
+    rather than guessing when one of them is still unknown.
+
+    Availability deliberately ignores ``state.online``: this SKU reports it
+    as false permanently, the same way the BFF thermo-hygrometers do.
+    """
+
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_native_min_value = -20.0
+    _attr_native_max_value = 300.0
+    _attr_native_step = 1.0
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GoveeCoordinator,
+        device: GoveeDevice,
+        probe: int,
+        limit: str,
+    ) -> None:
+        """Initialize the probe limit number."""
+        super().__init__(coordinator, device)
+        self._probe = probe
+        self._limit = limit
+        self._attr_unique_id = f"{device.device_id}_probe{probe}_{limit}"
+        self._attr_translation_key = f"probe_{limit}"
+        self._attr_translation_placeholders = {"probe": str(probe)}
+
+    @property
+    def available(self) -> bool:
+        """Available as soon as the coordinator holds state for the device."""
+        return self.coordinator.last_update_success and (
+            self.device_state is not None
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the limit currently stored in the device."""
+        state = self.device_state
+        if state is None:
+            return None
+        reading = state.probes.get(self._probe)
+        if reading is None:
+            return None
+        return getattr(reading, self._limit)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Write the limit to the device."""
+        await self.coordinator.async_set_probe_limits(
+            self._device_id, self._probe, **{self._limit: value}
+        )
 
 
 class GoveeMusicSensitivityNumber(

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api.probe_thermometer import PROBES
 from .const import (
     CONF_API_TEMPERATURE_UNIT,
     DEFAULT_API_TEMPERATURE_UNIT,
@@ -103,6 +104,19 @@ async def async_setup_entry(
         # last data received and last command sent (directional freshness).
         entities.append(GoveeAllDataLastUpdatedSensor(coordinator, device))
         entities.append(GoveeLastCommandSentSensor(coordinator, device))
+        # Probe thermometers get dedicated per-probe entities instead of the
+        # generic temperature sensor: one reading per probe and channel
+        # cannot be expressed by a single sensorTemperature value.
+        if device.is_probe_thermometer:
+            for probe in PROBES:
+                for channel in ("core", "ambient"):
+                    entities.append(
+                        GoveeProbeTemperatureSensor(
+                            coordinator, device, probe, channel
+                        )
+                    )
+            continue
+
         if device.supports_temperature_sensor:
             entities.append(GoveeTemperatureSensor(coordinator, device))
         # Second probe on dual-probe SKUs (#150). Gated on a reading actually
@@ -432,6 +446,47 @@ class GoveeSecondProbeTemperatureSensor(GoveeTemperatureSensor):
     def _raw_reading(self) -> float | None:
         state = self.device_state
         return state.sensor_temperature_2 if state else None
+
+
+class GoveeProbeTemperatureSensor(_BffThermometerAvailabilityMixin, SensorEntity):
+    """One channel of one probe on a probe thermometer (H5192).
+
+    Four per device — core and ambient for each of the two probes — created
+    unconditionally. The H5112 gates its second-probe entity on a reading being
+    present at setup, but a pull device has nothing at setup by definition, so
+    that gate would produce zero entities here. An unplugged probe reports the
+    0xFFFF sentinel, which decodes to None and shows as unknown.
+    """
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: GoveeCoordinator,
+        device: GoveeDevice,
+        probe: int,
+        channel: str,
+    ) -> None:
+        """Initialize the probe temperature sensor."""
+        super().__init__(coordinator, device)
+        self._probe = probe
+        self._channel = channel
+        self._attr_unique_id = f"{device.device_id}_probe{probe}_{channel}"
+        self._attr_translation_key = f"probe_{channel}"
+        self._attr_translation_placeholders = {"probe": str(probe)}
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current reading in degrees Celsius."""
+        state = self.device_state
+        if state is None:
+            return None
+        reading = state.probes.get(self._probe)
+        if reading is None:
+            return None
+        return getattr(reading, self._channel)
 
 
 class GoveeAirQualitySensor(GoveeEntity, SensorEntity):

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -135,6 +135,18 @@
       }
     },
     "number": {
+      "probe_core_max": {
+        "name": "Probe {probe} core max"
+      },
+      "probe_core_min": {
+        "name": "Probe {probe} core min"
+      },
+      "probe_ambient_max": {
+        "name": "Probe {probe} ambient max"
+      },
+      "probe_ambient_min": {
+        "name": "Probe {probe} ambient min"
+      },
       "govee_music_sensitivity": {
         "name": "Music Sensitivity"
       }
@@ -166,6 +178,9 @@
       }
     },
     "switch": {
+      "probe_live_polling": {
+        "name": "Live polling"
+      },
       "govee_plug": {
         "name": "{device_name}"
       },
@@ -207,6 +222,12 @@
       }
     },
     "sensor": {
+      "probe_core": {
+        "name": "Probe {probe} core"
+      },
+      "probe_ambient": {
+        "name": "Probe {probe} ambient"
+      },
       "rate_limit_remaining": {
         "name": "API Rate Limit Remaining"
       },

--- a/custom_components/govee/switch.py
+++ b/custom_components/govee/switch.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -94,6 +95,12 @@ async def async_setup_entry(
     entities: list[SwitchEntity] = []
 
     for device in coordinator.devices.values():
+        # Probe thermometers only report when polled, so the poll needs an
+        # explicit, restorable on/off that the owner controls.
+        if device.is_probe_thermometer:
+            entities.append(GoveeProbeLivePollingSwitch(coordinator, device))
+            continue
+
         # Create switch for smart plugs (power on/off)
         if device.is_plug and device.supports_power:
             entities.append(GoveePlugSwitchEntity(coordinator, device))
@@ -221,6 +228,54 @@ async def async_setup_entry(
 
     async_add_entities(entities)
     _LOGGER.debug("Set up %d Govee switch entities", len(entities))
+
+
+class GoveeProbeLivePollingSwitch(GoveeEntity, SwitchEntity, RestoreEntity):
+    """Arms live polling for a probe thermometer (H5192).
+
+    Probe thermometers answer only when asked, so this switch is what makes the
+    entities update at all. It is off by default and restores across restarts:
+    polling every 30 seconds around the clock would drain a battery device that
+    is only interesting while something is cooking.
+
+    Turning it on fires one immediate read so the entities populate without
+    waiting for the first tick.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "probe_live_polling"
+
+    def __init__(self, coordinator: GoveeCoordinator, device: GoveeDevice) -> None:
+        """Initialize the live polling switch."""
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.device_id}_probe_live_polling"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previous polling state and re-arm the timer if needed."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state == STATE_ON:
+            self.coordinator.set_probe_polling(self._device_id, True)
+
+    @property
+    def is_on(self) -> bool:
+        """Return True while polling is armed."""
+        return self.coordinator.is_probe_polling(self._device_id)
+
+    @property
+    def available(self) -> bool:
+        """Always available: this is a local toggle, not a device capability."""
+        return True
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Arm polling and read once immediately."""
+        self.coordinator.set_probe_polling(self._device_id, True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disarm polling."""
+        self.coordinator.set_probe_polling(self._device_id, False)
+        self.async_write_ha_state()
 
 
 class GoveePlugSwitchEntity(GoveeEntity, SwitchEntity):

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -135,6 +135,18 @@
       }
     },
     "number": {
+      "probe_core_max": {
+        "name": "Probe {probe} core max"
+      },
+      "probe_core_min": {
+        "name": "Probe {probe} core min"
+      },
+      "probe_ambient_max": {
+        "name": "Probe {probe} ambient max"
+      },
+      "probe_ambient_min": {
+        "name": "Probe {probe} ambient min"
+      },
       "govee_music_sensitivity": {
         "name": "Music Sensitivity"
       }
@@ -166,6 +178,9 @@
       }
     },
     "switch": {
+      "probe_live_polling": {
+        "name": "Live polling"
+      },
       "govee_plug": {
         "name": "{device_name}"
       },
@@ -207,6 +222,12 @@
       }
     },
     "sensor": {
+      "probe_core": {
+        "name": "Probe {probe} core"
+      },
+      "probe_ambient": {
+        "name": "Probe {probe} ambient"
+      },
       "rate_limit_remaining": {
         "name": "API Rate Limit Remaining"
       },

--- a/docs/govee-protocol-reference.md
+++ b/docs/govee-protocol-reference.md
@@ -1660,6 +1660,113 @@ The BLE 20-byte packet format is the canonical low-level protocol. MQTT and LAN 
 
 `ptReal` commands wrap base64-encoded BLE packets, making BLE the universal escape hatch for features not supported by the high-level JSON commands.
 
+### 6.8 Probe Thermometers (H5192)
+
+Two-probe cooking thermometers use the same 20-byte packet format as the light
+strips, but with their own registers and — unlike every other device in this
+document — a **pull model**: the H5192 never volunteers a reading. It answers
+a read request and otherwise stays silent, which is why the Govee app shows
+"not connected" for a second when a device page opens, and why its history
+graph takes a moment to populate. The app is asking, not listening.
+
+Everything below was captured from an H5192 on AWS IoT and cross-checked
+against what the app displayed at the same moment.
+
+#### Frame identification
+
+Packets arrive base64-encoded in `op.command[]` of a `status` or `ptReal`
+message, split across one or two blocks that must be concatenated before
+decoding. **Only byte 1 identifies the frame.** Byte 0 was observed as `0x40`,
+`0x42`, `0x44`, `0x45` and `0x47` on frames that were otherwise identical, so
+matching on it drops readings at random.
+
+| byte 1 | Direction | Meaning |
+|--------|-----------|---------|
+| `0x0F` | device to app | Full status: both probes, readings and limits |
+| `0x24` | both | Live reading for one probe (`0xAA` read, `0x33` push) |
+| `0x12` | both | Alarm limits for one probe |
+
+The `0xAA` / `0x33` prefix in byte 0 of a *request* follows the usual
+convention: `0xAA` reads, `0x33` writes. Byte 2 is the probe number (1 or 2).
+
+#### Temperature encoding
+
+Every temperature is a **signed 16-bit big-endian value in hundredths of a
+degree Celsius**: `0x0BB8` = 30.00 °C, `0xFF38` = -2.00 °C.
+
+`0xFFFF` is a sentinel, not a temperature. It means "probe not plugged in" for
+a reading and "limit not set" for a corridor bound. It has to be checked
+**against the unsigned word, before the signed conversion** — as a signed value
+it is -1, which is a perfectly plausible temperature for a fridge probe and
+would be shown as -0.01 °C.
+
+#### Status frame (`0x0F`)
+
+Volunteered on power-on and when an app session opens. No request was found
+that provokes it. Six values per probe, probe 1 at offset 10, probe 2 at
+offset 26 of the concatenated 40-byte payload:
+
+| Offset (probe 1) | Field |
+|---|---|
+| 10 | core temperature |
+| 12 | core max (alarm high) |
+| 14 | core min (alarm low) |
+| 16 | ambient temperature |
+| 18 | ambient max |
+| 20 | ambient min |
+
+Probe 2 repeats the same order 16 bytes later.
+
+#### Live reading (`0x24`)
+
+Read request: `AA 24 <probe> 00 …` padded to 19 bytes plus checksum.
+The reply carries the core temperature at offset 22 and the ambient
+temperature at offset 24 of the concatenated payload.
+
+The device also pushes this frame unprompted with prefix `0x33` while an app
+session is open, which is where the two-block split is most visible.
+
+#### Alarm limits (`0x12`)
+
+Read request: `AA 12 <probe>` padded to 19 bytes plus checksum. The reply
+carries four values starting at offset 3, in the order core max, core min,
+ambient max, ambient min.
+
+**Byte 11 is a flag, not padding.** It reads `0xFF` while the probe has no
+limit set at all and `0xEE` as soon as at least one is set. It does not encode
+which limit or how many — captured across all four states on an H5192 running
+firmware 1.00.81. Bytes 12-13 were `FF FF` in every capture.
+
+Writing uses the same layout with the `0x33` prefix. **There is no partial
+update** — a write carries all four values, so the three that are not being
+changed have to be supplied from the last read.
+
+`0xFFFF` is valid on a write and means "no limit". This is not a guess: a probe
+with no alarms configured reports all four as `0xFFFF`, and clearing an alarm in
+the Govee app puts them back to it. Setting a single limit out of that state —
+the normal first-use case — therefore means writing the sentinel for the other
+three, and the device accepts it and keeps them unset. An implementation that
+refuses to write while a value is unknown makes the first limit unsettable,
+because every probe starts with all four unset.
+
+#### Checksum
+
+Same as the rest of the BLE protocol: byte 19 is the XOR of bytes 0 through 18.
+
+#### Consequences for an integration
+
+- The device's BFF `lastDeviceData` stays `{"online": false}` permanently.
+  Availability must not be gated on it.
+- Nothing arrives without a request, so the poll interval *is* the update rate.
+  Polling a battery device around the clock is wasteful, so this integration
+  puts the poll behind an explicit per-device switch that is off by default.
+- The generic BFF thermometer refresh must skip these devices. It rebuilds
+  state from `create_empty()` and copies only temperature, humidity and
+  battery, which would drop the probe readings on every pass.
+- Light strips push their own `0xAA 0x05`, `0xAA 0x13` and `0xAA 0xA5` packets
+  through the same `op.command` field. Frame dispatch has to be gated on the
+  SKU, or a segment-color packet gets decoded as a probe reading.
+
 ---
 
 ## 8. State Management

--- a/tests/test_probe_thermometer.py
+++ b/tests/test_probe_thermometer.py
@@ -1,0 +1,283 @@
+"""Tests for the H5192 probe thermometer decoder.
+
+Every fixture is a real frame captured from an H5192 and verified against what
+the Govee app displayed at the same moment. The values in the docstrings are
+what the app showed, so a failure here means the decoder drifted away from the
+device, not away from an invented expectation.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from custom_components.govee.api.probe_thermometer import (
+    ProbeLimits,
+    REGISTER_LIMITS,
+    SENTINEL,
+    WRITE_PREFIX,
+    build_limits_read_packet,
+    build_limits_write_packet,
+    build_probe_read_packet,
+    concat_command_blocks,
+    decode_limits,
+    decode_probe_reading,
+    decode_status_frame,
+    verify_checksum,
+)
+
+# --- Captures -------------------------------------------------------------
+
+# Status frame, app showed: probe 1 core 46 degC, ambient 29 degC, target
+# 19/50 degC, ambient corridor -10/70 degC; probe 2 unplugged with its
+# 17/60 degC corridor still stored.
+STATUS_PROBE2_UNPLUGGED = [
+    "Rw8AAQH0AQIBABH4E4gHbAtUG1g=",
+    "/Bhe7v////8XcAak////////Zu4=",
+]
+
+# Status frame with both probes plugged in, before any ambient corridor was set.
+STATUS_BOTH_PROBES = [
+    "Rw8AAQH0AQIDAA1IE4gHbAu4//8=",
+    "//9f7v//DUgXcAakCoz/////XO4=",
+]
+
+# Same shape, but byte 0 is 0x44 instead of 0x47 — app showed 36/31 degC.
+STATUS_BYTE0_0X44 = [
+    "RA8AAQH0AQIDAA4QE4gHbAwcG1g=",
+    "/Bhb7v//DawXcAakDBz/////X+4=",
+]
+
+# Device-volunteered probe frame (byte 0 0x33), app showed 45 degC / 29 degC.
+PROBE_VOLUNTEERED = [
+    "MyQBAAYAAO2mjGoAAgAAAAAAAAA=",
+    "AAYRlAtUETALVBDMC1QQzArw//8=",
+]
+
+# Reply to our read request (byte 0 0xAA), app showed 36 degC / 26 degC.
+PROBE_READ_REPLY = [
+    "qiQBAAAAAAAAAAAAAQAAAAAAAAA=",
+    "AAAOEAoo//////////////////8=",
+]
+
+# Reply to a read of register 0x12 after we had written 99/7 degC.
+LIMITS_REPLY = ["qhIBJqwCvBtY/Bju//8AAAAAAMQ="]
+# Same probe after clearing every alarm in the Govee app: all four values are
+# the sentinel and the byte-11 flag reads FF.
+LIMITS_EMPTY = ["qhIB//////////////8AAAAAAEY="]
+# ... and after setting three of the four from Home Assistant, leaving
+# ambient_min unset. Byte 11 reads EE.
+LIMITS_PARTIAL = ["qhIBHUwB9GGo///u//8AAAAAADo="]
+
+# A light strip's status packet — must never reach the probe decoder.
+LIGHT_STRIP_PACKET = ["qgUBAAAAAAAAAAAAAAAAAAAAAK4="]
+
+
+def _frame(blocks: list[str]) -> bytes:
+    raw = concat_command_blocks(blocks)
+    assert raw is not None
+    return raw
+
+
+# --- Status frames --------------------------------------------------------
+
+
+def test_status_frame_matches_app_display() -> None:
+    """Probe 1 at 46/29 degC with both corridors, probe 2 unplugged."""
+    probes = decode_status_frame(_frame(STATUS_PROBE2_UNPLUGGED))
+    assert probes is not None
+
+    assert probes[1] == {
+        "core": 46.0,
+        "core_max": 50.0,
+        "core_min": 19.0,
+        "ambient": 29.0,
+        "ambient_max": 70.0,
+        "ambient_min": -10.0,
+    }
+    # The corridor of an unplugged probe stays stored, exactly as the app shows it.
+    assert probes[2]["core"] is None
+    assert probes[2]["ambient"] is None
+    assert probes[2]["core_max"] == 60.0
+    assert probes[2]["core_min"] == 17.0
+
+
+def test_status_frame_unset_ambient_corridor_is_none() -> None:
+    """Before a corridor is set, its two words are the sentinel, not 0."""
+    probes = decode_status_frame(_frame(STATUS_BOTH_PROBES))
+    assert probes is not None
+    assert probes[1]["core"] == 34.0
+    assert probes[1]["ambient"] == 30.0
+    assert probes[1]["ambient_max"] is None
+    assert probes[1]["ambient_min"] is None
+    assert probes[2]["core"] == 34.0
+    assert probes[2]["ambient"] == 27.0
+
+
+def test_status_frame_ignores_byte_zero() -> None:
+    """0x44 and 0x47 are the same frame; only byte 1 identifies it."""
+    probes = decode_status_frame(_frame(STATUS_BYTE0_0X44))
+    assert probes is not None
+    assert probes[1]["core"] == 36.0
+    assert probes[1]["ambient"] == 31.0
+    assert probes[2]["core"] == 35.0
+
+
+def test_negative_ambient_minimum_is_signed() -> None:
+    """FC18 is -10.00 degC, which is what proves the values are signed."""
+    probes = decode_status_frame(_frame(STATUS_PROBE2_UNPLUGGED))
+    assert probes is not None
+    assert probes[1]["ambient_min"] == -10.0
+
+
+def test_status_frame_rejects_short_input() -> None:
+    assert decode_status_frame(b"\x47\x0f\x00") is None
+
+
+def test_status_frame_rejects_other_register() -> None:
+    assert decode_status_frame(bytes([0x47, 0x24]) + bytes(40)) is None
+
+
+# --- Probe readings -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("blocks", "expected"),
+    [
+        (PROBE_VOLUNTEERED, (1, 45.0, 29.0)),
+        (PROBE_READ_REPLY, (1, 36.0, 26.0)),
+    ],
+)
+def test_probe_reading_decodes_both_byte_zero_variants(
+    blocks: list[str], expected: tuple[int, float, float]
+) -> None:
+    """0x33 (device speaks) and 0xAA (device answers) carry the same payload."""
+    assert decode_probe_reading(_frame(blocks)) == expected
+
+
+def test_probe_reading_rejects_unknown_probe_number() -> None:
+    raw = bytearray(_frame(PROBE_READ_REPLY))
+    raw[2] = 7
+    assert decode_probe_reading(bytes(raw)) is None
+
+
+def test_probe_reading_rejects_light_strip_packet() -> None:
+    """Light strips push 0xAA 0x05 packets; those must not decode as probes."""
+    assert decode_probe_reading(_frame(LIGHT_STRIP_PACKET)) is None
+    assert decode_limits(_frame(LIGHT_STRIP_PACKET)) is None
+    assert decode_status_frame(_frame(LIGHT_STRIP_PACKET)) is None
+
+
+# --- Limits ---------------------------------------------------------------
+
+
+def test_limits_reply_matches_written_values() -> None:
+    """We had written 99/7 degC; the ambient corridor was 70/-10 degC."""
+    decoded = decode_limits(_frame(LIMITS_REPLY))
+    assert decoded is not None
+    probe, limits = decoded
+    assert probe == 1
+    assert limits == ProbeLimits(
+        core_max=99.0, core_min=7.0, ambient_max=70.0, ambient_min=-10.0
+    )
+
+
+def test_sentinel_decodes_to_none_not_minus_hundredth() -> None:
+    """0xFFFF must be caught unsigned; as int16 it would be -0.01 degC."""
+    raw = bytes([0xAA, REGISTER_LIMITS, 0x01]) + b"\xff\xff" * 4 + bytes(9)
+    decoded = decode_limits(raw)
+    assert decoded is not None
+    _, limits = decoded
+    assert limits == ProbeLimits(None, None, None, None)
+
+
+# --- Packet building ------------------------------------------------------
+
+
+def test_read_packets_carry_valid_checksum() -> None:
+    for packet in (build_probe_read_packet(1), build_limits_read_packet(2)):
+        raw = base64.b64decode(packet)
+        assert len(raw) == 20
+        assert verify_checksum(raw)
+
+
+def test_write_packet_layout_round_trips_through_the_decoder() -> None:
+    """A written frame differs from the read reply only in byte 0."""
+    limits = ProbeLimits(
+        core_max=99.0, core_min=7.0, ambient_max=70.0, ambient_min=-10.0
+    )
+    raw = base64.b64decode(build_limits_write_packet(1, limits))
+
+    assert raw[0] == WRITE_PREFIX
+    assert raw[1] == REGISTER_LIMITS
+    assert raw[2] == 1
+    assert verify_checksum(raw)
+
+    reply = _frame(LIMITS_REPLY)
+    assert raw[1:19] == reply[1:19]
+
+
+def test_write_packet_matches_what_the_device_stored() -> None:
+    """The packet we build equals the frame the device reported back.
+
+    LIMITS_PARTIAL was captured after setting exactly these three values on a
+    live H5192, leaving the fourth alone. Rebuilding it here pins the layout,
+    the sentinel for the unset value and the byte-11 flag against hardware
+    rather than against an expectation invented in this file.
+    """
+    limits = ProbeLimits(
+        core_max=75.0, core_min=5.0, ambient_max=250.0, ambient_min=None
+    )
+    raw = base64.b64decode(build_limits_write_packet(1, limits))
+    stored = _frame(LIMITS_PARTIAL)
+
+    assert raw[0] == WRITE_PREFIX
+    assert raw[1:19] == stored[1:19]
+
+
+def test_write_packet_clears_a_limit_with_the_sentinel() -> None:
+    """None means "no limit" — the device reports and accepts 0xFFFF for it."""
+    limits = ProbeLimits(
+        core_max=75.0, core_min=None, ambient_max=None, ambient_min=None
+    )
+    raw = base64.b64decode(build_limits_write_packet(1, limits))
+
+    assert raw[5:11] == bytes([SENTINEL >> 8, SENTINEL & 0xFF]) * 3
+    # At least one limit is set, so the byte-11 flag says so.
+    assert raw[11] == 0xEE
+
+
+def test_write_packet_marks_a_fully_empty_corridor() -> None:
+    """All four cleared: every value is the sentinel and byte 11 flips to FF.
+
+    LIMITS_EMPTY is the factory/cleared state, captured from a probe whose
+    alarms had all been switched off in the Govee app.
+    """
+    raw = base64.b64decode(
+        build_limits_write_packet(1, ProbeLimits(None, None, None, None))
+    )
+    assert raw[1:19] == _frame(LIMITS_EMPTY)[1:19]
+    assert raw[11] == 0xFF
+
+
+def test_write_packet_encodes_negative_values() -> None:
+    limits = ProbeLimits(
+        core_max=99.0, core_min=7.0, ambient_max=70.0, ambient_min=-10.0
+    )
+    raw = base64.b64decode(build_limits_write_packet(1, limits))
+    assert raw[9:11] == b"\xfc\x18"
+
+
+# --- Frame helpers --------------------------------------------------------
+
+
+def test_bad_checksum_is_detected() -> None:
+    raw = bytearray(base64.b64decode(build_probe_read_packet(1)))
+    raw[19] ^= 0xFF
+    assert not verify_checksum(bytes(raw))
+
+
+def test_concat_returns_none_on_garbage() -> None:
+    assert concat_command_blocks([]) is None
+    assert concat_command_blocks(["not base64 !!"]) is None

--- a/tests/test_probe_thermometer_integration.py
+++ b/tests/test_probe_thermometer_integration.py
@@ -1,0 +1,360 @@
+"""Wiring tests for probe thermometers (H5192).
+
+The decoder itself is covered by ``test_probe_thermometer.py``. This file
+covers what happens around it: which MQTT envelopes reach the decoder, how a
+partial frame is merged into coordinator state, and the two places where a
+wrong answer would silently cost the owner a reading — the five-minute BFF
+refresh and the limits write.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+import custom_components.govee.coordinator as coord_mod
+from custom_components.govee import const
+from custom_components.govee.api.auth import GoveeIotCredentials
+from custom_components.govee.api.mqtt import GoveeAwsIotClient
+from custom_components.govee.coordinator import GoveeCoordinator
+from custom_components.govee.models import GoveeDevice, GoveeDeviceState, ProbeReading
+
+DEVICE_ID = "AA:BB:CC:DD:EE:FF:00:11"
+
+# Real captures, same frames the decoder tests use.
+STATUS_BOTH_PROBES = ["Rw8AAQH0AQIDAA1IE4gHbAu4//8=", "//9f7v//DUgXcAakCoz/////XO4="]
+PROBE_READ_REPLY = ["qiQBAAAAAAAAAAAAAQAAAAAAAAA=", "AAAOEAoo//////////////////8="]
+LIMITS_REPLY = ["qhIBJqwCvBtY/Bju//8AAAAAAMQ="]
+# A light strip's segment-color packet. Same op.command field, same 0xAA
+# prefix — it must never be routed to the probe decoder.
+LIGHT_STRIP_PACKET = ["qgUBAAAAAAAAAAAAAAAAAAAAAK4="]
+
+
+def _make_client() -> GoveeAwsIotClient:
+    """Build an MQTT client with throwaway credentials and a mock callback."""
+    creds = GoveeIotCredentials(
+        token="t",
+        refresh_token="r",
+        account_topic="GA/account",
+        iot_cert="cert",
+        iot_key="key",
+        iot_ca=None,
+        client_id="cid",
+        endpoint="endpoint",
+    )
+    return GoveeAwsIotClient(creds, on_state_update=MagicMock())
+
+
+def _message(sku: str, cmd: str, commands: list[str]) -> MagicMock:
+    """Wrap base64 command blocks in an AWS IoT message envelope."""
+    message = MagicMock()
+    message.payload = json.dumps(
+        {
+            "device": DEVICE_ID,
+            "sku": sku,
+            "cmd": cmd,
+            "op": {"command": commands},
+        }
+    ).encode()
+    return message
+
+
+class TestMqttDispatch:
+    """Only probe SKUs reach the probe decoder, and every frame is retained."""
+
+    async def test_status_frame_reaches_the_state_callback(self):
+        client = _make_client()
+
+        await client._handle_message(_message("H5192", "status", STATUS_BOTH_PROBES))
+
+        client._on_state_update.assert_called_once()
+        device_id, payload = client._on_state_update.call_args[0]
+        assert device_id == DEVICE_ID
+        assert payload["_probe_frame"] is True
+        # Status frames carry both probes with all six values each.
+        assert set(payload["probes"]) == {1, 2}
+        assert payload["probes"][1]["core"] == pytest.approx(34.0)
+
+    async def test_ptreal_reply_reaches_the_state_callback(self):
+        client = _make_client()
+
+        await client._handle_message(_message("H5192", "ptReal", PROBE_READ_REPLY))
+
+        _, payload = client._on_state_update.call_args[0]
+        assert set(payload["probes"]) == {1}
+        assert set(payload["probes"][1]) == {"core", "ambient"}
+
+    async def test_light_strip_packet_is_not_decoded_as_a_probe(self):
+        """0xAA 0x05 from a light strip must not become a temperature."""
+        client = _make_client()
+
+        await client._handle_message(_message("H6072", "status", LIGHT_STRIP_PACKET))
+
+        for call in client._on_state_update.call_args_list:
+            assert "_probe_frame" not in call[0][1]
+        assert client.recent_probe_frames == []
+
+    async def test_frames_are_retained_for_diagnostics(self):
+        client = _make_client()
+
+        await client._handle_message(_message("H5192", "status", STATUS_BOTH_PROBES))
+
+        (record,) = client.recent_probe_frames
+        assert record["header"] == "470f"
+        assert record["length"] == 40
+        assert record["device_id"] == DEVICE_ID
+
+    async def test_unknown_probe_frame_is_retained_but_not_dispatched(self):
+        """An undecodable frame still has to survive into a diagnostics dump."""
+        client = _make_client()
+        unknown = ["qn8AAAAAAAAAAAAAAAAAAAAAANU="]
+
+        await client._handle_message(_message("H5192", "ptReal", unknown))
+
+        assert len(client.recent_probe_frames) == 1
+        for call in client._on_state_update.call_args_list:
+            assert "_probe_frame" not in call[0][1]
+
+
+def _coordinator(state: GoveeDeviceState | None = None) -> GoveeCoordinator:
+    """Build a coordinator with only the attributes the probe path touches."""
+    coordinator = GoveeCoordinator.__new__(GoveeCoordinator)
+    device = GoveeDevice.synthetic_probe_thermometer(
+        device_id=DEVICE_ID, sku="H5192", name="Grill"
+    )
+    coordinator._devices = {DEVICE_ID: device}
+    coordinator._states = {DEVICE_ID: state or GoveeDeviceState.create_empty(DEVICE_ID)}
+    coordinator._sensor_reading_changed_at = {}
+    coordinator._probe_polling_enabled = set()
+    coordinator._probe_poll_unsub = None
+    coordinator._ble_manager = MagicMock()
+    coordinator.hass = MagicMock()
+    coordinator._ensure_transport_health = MagicMock()
+    coordinator._record_transport_success = MagicMock()
+    coordinator.async_set_updated_data = MagicMock()
+    return coordinator
+
+
+class TestFrameMerge:
+    """A partial frame must not blank the fields it does not carry."""
+
+    def test_limits_reply_keeps_the_live_readings(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.probes = {1: ProbeReading(core=34.0, ambient=99.0)}
+        coordinator = _coordinator(state)
+
+        coordinator._handle_probe_frame(
+            DEVICE_ID,
+            {"probes": {1: {"core_max": 75.0, "core_min": 5.0}}},
+        )
+
+        reading = coordinator._states[DEVICE_ID].probes[1]
+        assert reading.core == 34.0
+        assert reading.ambient == 99.0
+        assert reading.core_max == 75.0
+
+    def test_reading_reply_keeps_the_limits(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.probes = {1: ProbeReading(core_max=75.0, ambient_min=5.0)}
+        coordinator = _coordinator(state)
+
+        coordinator._handle_probe_frame(
+            DEVICE_ID, {"probes": {1: {"core": 40.0, "ambient": 120.0}}}
+        )
+
+        reading = coordinator._states[DEVICE_ID].probes[1]
+        assert reading.core_max == 75.0
+        assert reading.ambient_min == 5.0
+        assert reading.core == 40.0
+
+    def test_frame_marks_the_device_online(self):
+        """The BFF online flag is false for this SKU; a frame is proof of life."""
+        coordinator = _coordinator()
+        coordinator._states[DEVICE_ID].online = False
+
+        coordinator._handle_probe_frame(DEVICE_ID, {"probes": {1: {"core": 40.0}}})
+
+        assert coordinator._states[DEVICE_ID].online is True
+
+    def test_unknown_device_is_ignored(self):
+        coordinator = _coordinator()
+        coordinator._handle_probe_frame("nope", {"probes": {1: {"core": 40.0}}})
+        assert coordinator._states[DEVICE_ID].probes == {}
+
+
+class TestBffRefreshSkip:
+    """The five-minute BFF refresh must leave probe state alone."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_does_not_wipe_probe_readings(self, monkeypatch):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.probes = {1: ProbeReading(core=34.0)}
+        coordinator = _coordinator(state)
+        coordinator._iot_credentials = MagicMock(token="tok")
+        coordinator._bff_thermometer_ids = {DEVICE_ID}
+        coordinator._bff_thermo_pending = set()
+        coordinator._bff_thermo_hubs = {}
+        coordinator._display_fahrenheit = {}
+
+        async def _sensors(*args, **kwargs):
+            # What the BFF actually returns for an H5192: no reading at all.
+            return [
+                {
+                    "device_id": DEVICE_ID,
+                    "name": "Grill",
+                    "sku": "H5192",
+                    "temperature": None,
+                    "humidity": None,
+                    "online": False,
+                }
+            ]
+
+        monkeypatch.setattr(coordinator, "_async_bff_call", _sensors)
+
+        await coordinator._refresh_bff_thermometers()
+
+        assert coordinator._states[DEVICE_ID].probes[1].core == 34.0
+
+
+class TestProbePollInterval:
+    """The poll interval is an option, and a hand-edited bad value must not arm."""
+
+    def _coord_with_options(self, options):
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        config_entry.options = options
+        return coord_mod.GoveeCoordinator(
+            hass=MagicMock(),
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=MagicMock(token="tok"),
+            poll_interval=60,
+        )
+
+    def test_default_when_option_unset(self):
+        coord = self._coord_with_options({})
+        assert coord._probe_poll_interval == const.DEFAULT_PROBE_POLL_INTERVAL
+
+    def test_configured_value_is_used(self):
+        coord = self._coord_with_options({const.CONF_PROBE_POLL_INTERVAL: 120})
+        assert coord._probe_poll_interval == 120
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            const.MIN_PROBE_POLL_INTERVAL - 1,
+            const.MAX_PROBE_POLL_INTERVAL + 1,
+            "not-a-number",
+            None,
+        ],
+    )
+    def test_out_of_range_or_bad_value_falls_back(self, value):
+        coord = self._coord_with_options({const.CONF_PROBE_POLL_INTERVAL: value})
+        assert coord._probe_poll_interval == const.DEFAULT_PROBE_POLL_INTERVAL
+
+    def test_schedule_uses_configured_interval(self, monkeypatch):
+        coord = self._coord_with_options({const.CONF_PROBE_POLL_INTERVAL: 45})
+        seen = {}
+
+        def _capture(hass, delay, callback):
+            seen["delay"] = delay
+            return lambda: None
+
+        monkeypatch.setattr(coord_mod, "async_call_later", _capture)
+        coord._schedule_probe_poll()
+
+        assert seen["delay"] == 45
+
+
+class TestPollingSwitch:
+    """Polling is armed per device and the timer stops with the last one."""
+
+    def test_disarming_the_last_device_cancels_the_timer(self):
+        coordinator = _coordinator()
+        cancelled = []
+        coordinator._probe_polling_enabled = {DEVICE_ID}
+        coordinator._probe_poll_unsub = lambda: cancelled.append(True)
+
+        coordinator.set_probe_polling(DEVICE_ID, False)
+
+        assert cancelled == [True]
+        assert coordinator._probe_poll_unsub is None
+        assert not coordinator.is_probe_polling(DEVICE_ID)
+
+    @pytest.mark.asyncio
+    async def test_poll_is_a_noop_without_mqtt(self, monkeypatch):
+        coordinator = _coordinator()
+        coordinator._probe_polling_enabled = {DEVICE_ID}
+        monkeypatch.setattr(
+            type(coordinator), "mqtt_client", property(lambda self: None)
+        )
+
+        await coordinator._poll_probe_thermometers()
+
+        coordinator._ble_manager.async_send_ble_packet.assert_not_called()
+
+
+class TestLimitsWrite:
+    """Register 0x12 has no partial update, so the other three come from state."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_limits_go_out_as_the_sentinel(self):
+        """A fresh probe has all four unset; the first write must still land.
+
+        The device reports 0xFFFF for a limit that is not set and accepts it
+        back, so an unknown value is not a reason to refuse — refusing would
+        make the very first limit unsettable.
+        """
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.probes = {1: ProbeReading()}
+        coordinator = _coordinator(state)
+        sent = []
+
+        async def _send(device_id, sku, packet):
+            sent.append(packet)
+            return True
+
+        coordinator._ble_manager.async_send_ble_packet = MagicMock(side_effect=_send)
+
+        result = await coordinator.async_set_probe_limits(DEVICE_ID, 1, core_max=75.0)
+
+        assert result is True
+        raw = base64.b64decode(sent[0])
+        assert raw[3:5] == bytes([0x1D, 0x4C])  # 75.00 C
+        assert raw[5:11] == bytes([0xFF]) * 6  # the three untouched limits
+
+    @pytest.mark.asyncio
+    async def test_write_carries_the_other_three_values_over(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.probes = {
+            1: ProbeReading(
+                core_max=75.0, core_min=5.0, ambient_max=250.0, ambient_min=5.0
+            )
+        }
+        coordinator = _coordinator(state)
+
+        async def _send(*args, **kwargs):
+            return True
+
+        coordinator._ble_manager.async_send_ble_packet = MagicMock(side_effect=_send)
+
+        result = await coordinator.async_set_probe_limits(DEVICE_ID, 1, core_max=80.0)
+
+        assert result is True
+        # One write, then a read-back: the device acknowledges the packet, not
+        # the stored value.
+        assert coordinator._ble_manager.async_send_ble_packet.call_count == 2
+
+
+class TestSyntheticDevice:
+    """The synthetic device must not claim a capability it cannot serve."""
+
+    def test_has_no_sensor_temperature_capability(self):
+        device = GoveeDevice.synthetic_probe_thermometer(
+            device_id=DEVICE_ID, sku="H5192", name="Grill"
+        )
+        assert device.is_probe_thermometer
+        assert not device.supports_temperature_sensor


### PR DESCRIPTION
## Add support for probe (cooking) thermometers — H5192

Closes #174.

The H5192 is a two-probe cooking thermometer that reaches the cloud over the
same AWS IoT channel as the rest of the account, but it behaves unlike anything
else the integration talks to: **it never volunteers a reading.** It answers a
read request and is otherwise silent. That single fact drives most of the
design decisions below.

Everything here was reverse-engineered from live captures of an H5192 running
firmware 1.00.81 and cross-checked against what the Govee app displayed at the
same moment. The register map is written up in
`docs/govee-protocol-reference.md` §6.8.

### What the user gets

- 4 temperature sensors — core and ambient for each of the two probes
- 8 number entities — the four alarm limits per probe (core high/low,
  ambient high/low), writable
- 1 switch — **Live polling**, off by default
- A configurable poll interval (10–600 s, default 30 s)

### Design notes

**Polling is opt-in.** Since nothing arrives unprompted, the poll interval *is*
the update rate. Polling a battery device around the clock is wasteful, so the
poll sits behind an explicit per-device switch that restores across restarts
and is off by default. Turning it on fires one immediate read so the entities
populate straight away.

**Frames are identified by byte 1 only.** Byte 0 was observed as `0x40`,
`0x42`, `0x44`, `0x45` and `0x47` on frames that were otherwise identical, so
matching on it drops readings at random.

**The `0xFFFF` sentinel is checked unsigned, before the signed conversion.**
Temperatures are signed int16 in hundredths of a degree; as a signed value the
sentinel is -1, a perfectly plausible fridge-probe reading that would surface
as -0.01 °C instead of "probe not plugged in".

**`0xFFFF` is written, not refused.** This answers the question you raised on
the issue. A probe with no alarms configured reports all four limits as
`0xFFFF`, and clearing an alarm in the Govee app puts them back to it — the
sentinel is the device's own way of saying "no limit", in both directions. That
matters more than it sounds: register `0x12` has no partial update, so setting
one limit means writing all four. Every probe leaves the factory with all four
unset, so an implementation that refuses to write while a value is unknown
makes the *first* limit unsettable. An earlier revision of this PR did exactly
that; it was caught on hardware, and there is now a test that rebuilds the
write packet and compares it byte for byte against the frame the device
reported back after that write.

**Byte 11 of a `0x12` frame is a flag, not padding.** It reads `0xFF` while the
probe has no limit set at all and `0xEE` once at least one is set; it encodes
neither which limit nor how many. Captured across all four states. Writing a
fixed value here would tell the device "an alarm is active" on a probe whose
alarms were all cleared.

**MQTT dispatch is SKU-gated.** Light strips push their own `0xAA 0x05` /
`0x13` / `0xA5` packets through the same `op.command` field; without the gate a
segment-colour packet decodes as a temperature. There is a regression test for
exactly this.

**Probe SKUs skip `_refresh_bff_thermometers`.** That refresh rebuilds state
from `create_empty()` and copies only temperature, humidity and battery, so it
would drop the probe readings every five minutes. Their BFF entry has no
reading to offer anyway — `lastDeviceData` stays `{"online": false}`
permanently, which is also why availability is not gated on `online`. The skip
reads the SKU from the payload rather than the device object, because the
refresh can run before discovery has registered the device.

**The synthetic device carries no `sensorTemperature` capability**, unlike
`synthetic_thermometer`. One reading per probe and channel cannot be expressed
by a single capability, and granting it would create a generic temperature
entity stuck at unknown.

**Raw frames are retained for diagnostics**, hex only, the same way the
multiSync ring buffer works. The intent is that the next probe SKU can be
decoded from a diagnostics download alone, without asking someone to run
verbose logging while they cook.

### Known limitation

A limit can be *set* from Home Assistant but not *cleared*: a number entity has no
way to express "unset", so going back to no-alarm still means the Govee app.
The plumbing underneath handles it — passing None to ``async_set_probe_limits``
writes the sentinel — so exposing it would be a small service or a button, if
you would like that in this PR or a follow-up.

### Tests

`tests/test_probe_thermometer.py` covers the decoder. Every fixture is a real
captured frame and the expected values in the docstrings are what the app
showed at that moment, so a failure means the decoder drifted away from the
device rather than away from an invented expectation. Negative cases include a
light-strip packet and a truncated frame.

`tests/test_probe_thermometer_integration.py` covers the wiring: MQTT dispatch
and the SKU gate, the partial-frame merge, the BFF refresh skip, the poll
interval option, and the sentinel write.

### Verified on hardware

The whole integration was deployed to a live Home Assistant instance with an
H5192 attached, not just unit-tested: entities appear, the polling switch
defaults to off, turning it on populates all four sensors, the alarm limits
read back correctly including the unset one, and writing a limit while another
is unknown reaches the device and leaves the unknown one unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
