### PR TITLE
fix(dreamview): send the video opcode instead of Scene(Sunset)

### DIFF
--- a/custom_components/govee/api/ble_packet.py
+++ b/custom_components/govee/api/ble_packet.py
@@ -25,9 +25,12 @@ MUSIC_PACKET_PREFIX = 0x33
 MUSIC_MODE_COMMAND = 0x05
 MUSIC_MODE_INDICATOR = 0x01
 
-# DreamView (Movie Mode) packet constants
+# DreamView (Video/Movie Mode) packet constants
 DREAMVIEW_COMMAND = 0x05  # Same as music mode command byte
-DREAMVIEW_INDICATOR = 0x04  # Scene mode indicator (vs 0x01 for music)
+DREAMVIEW_INDICATOR = 0x00  # Video mode indicator (0x04 is a scene preset!)
+DREAMVIEW_SEGMENTS_ALL = 0x01  # 0x00 = partial, 0x01 = all segments
+DREAMVIEW_STYLE_MOVIE = 0x00  # 0x00 = movie, 0x01 = game
+DREAMVIEW_SATURATION_MAX = 0x64  # Saturation, 0x00-0x64
 DIY_MODE_INDICATOR = 0x0A  # DIY mode indicator
 
 # DIY style name to value mapping for select entity
@@ -107,24 +110,33 @@ def build_music_mode_packet(enabled: bool, sensitivity: int = 50) -> bytes:
     return build_packet(data)
 
 
-def build_dreamview_packet(enabled: bool) -> bytes:
-    """Build DreamView (Movie Mode) control packet.
+def build_dreamview_packet() -> bytes:
+    """Build the DreamView (video/camera sync) activation packet.
 
-    Uses the scene mode indicator (0x04) with on/off value.
-    Follows same pattern as music mode but with different indicator.
+    Byte 2 of a ``0x33 0x05`` frame selects the colour operation mode, and
+    video mode is ``0x00`` — see ``docs/govee-protocol-reference.md`` 6.4,
+    which already documents ``0x00 = Video/DreamView mode``.
 
-    Args:
-        enabled: True to enable DreamView, False to disable.
+    This previously used ``0x04``, which is the *scene preset* sub-command:
+    ``33 05 04 01`` is byte-for-byte the documented ``Scene(Sunset)`` frame,
+    so "DreamView ON" put the device into a static orange scene instead of
+    video sync.
+
+    There is deliberately no "disable" counterpart: the protocol has no
+    video-off opcode. A device leaves video mode by being given another
+    mode, which the integration already does over the REST colour path.
 
     Returns:
-        20-byte BLE packet for DreamView command.
+        20-byte BLE packet that enables video mode.
     """
-    # Packet: 33 05 04 [enabled] 00...00 [XOR]
+    # Packet: 33 05 00 [segments] [style] [saturation] 00...00 [XOR]
     data = [
         MUSIC_PACKET_PREFIX,  # 0x33 - Standard command prefix
         DREAMVIEW_COMMAND,  # 0x05 - Color/mode command
-        DREAMVIEW_INDICATOR,  # 0x04 - Scene mode indicator
-        0x01 if enabled else 0x00,  # Enabled state
+        DREAMVIEW_INDICATOR,  # 0x00 - Video mode indicator
+        DREAMVIEW_SEGMENTS_ALL,
+        DREAMVIEW_STYLE_MOVIE,
+        DREAMVIEW_SATURATION_MAX,
     ]
     return build_packet(data)
 

--- a/custom_components/govee/ble_passthrough.py
+++ b/custom_components/govee/ble_passthrough.py
@@ -109,19 +109,20 @@ class BlePassthroughManager:
         self,
         device_id: str,
         sku: str,
-        enabled: bool,
     ) -> bool:
-        """Send DreamView command via BLE passthrough.
+        """Enable DreamView (video/camera sync) via BLE passthrough.
+
+        There is no disable counterpart — the protocol has no video-off
+        opcode; the device leaves video mode when given another mode.
 
         Args:
             device_id: Device identifier.
             sku: Device SKU.
-            enabled: True to enable, False to disable.
 
         Returns:
             True if command was sent successfully.
         """
-        packet = build_dreamview_packet(enabled)
+        packet = build_dreamview_packet()
         encoded = encode_packet_base64(packet)
         return await self.async_send_ble_packet(device_id, sku, encoded)
 

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -4195,7 +4195,20 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         except Exception as err:
             _LOGGER.debug("REST DreamView failed for %s: %s", device.name, err)
 
-        # Fall back to BLE passthrough for devices that need it
+        # Fall back to BLE passthrough for devices that need it.
+        #
+        # Only for enabling: the protocol has no video-off opcode, so there is
+        # nothing meaningful to pass through when turning DreamView off. The
+        # device leaves video mode as soon as it is given another mode, which
+        # the REST colour path above already does.
+        if not enabled:
+            _LOGGER.debug(
+                "DreamView OFF not sent for %s: no BLE opcode exists for "
+                "leaving video mode; set a colour or scene instead",
+                device.name,
+            )
+            return False
+
         if not self._ble_manager.available:
             _LOGGER.warning(
                 "Cannot send DreamView for %s: MQTT not connected",
@@ -4203,9 +4216,7 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             )
             return False
 
-        success = await self._ble_manager.async_send_dreamview(
-            device_id, device.sku, enabled
-        )
+        success = await self._ble_manager.async_send_dreamview(device_id, device.sku)
 
         if success:
             state = self._states.get(device_id)

--- a/tests/test_ble_packet.py
+++ b/tests/test_ble_packet.py
@@ -10,6 +10,9 @@ from custom_components.govee.api.ble_packet import (
     DIY_MODE_INDICATOR,
     DREAMVIEW_COMMAND,
     DREAMVIEW_INDICATOR,
+    DREAMVIEW_SATURATION_MAX,
+    DREAMVIEW_SEGMENTS_ALL,
+    DREAMVIEW_STYLE_MOVIE,
     FAN_OSC_COMMAND,
     FAN_OSC_MULTISYNC_PREFIX,
     FAN_OSC_PTREAL_PREFIX,
@@ -346,50 +349,51 @@ class TestMusicModePacketIntegration:
 
 
 class TestBuildDreamviewPacket:
-    """Test DreamView packet building."""
+    """Test DreamView (video/camera sync) packet building."""
 
     def test_packet_length(self):
         """Test DreamView packet is 20 bytes."""
-        packet = build_dreamview_packet(True)
+        packet = build_dreamview_packet()
         assert len(packet) == 20
 
     def test_packet_header(self):
-        """Test DreamView packet has correct header."""
-        packet = build_dreamview_packet(True)
+        """Test DreamView packet selects video mode, not a scene preset."""
+        packet = build_dreamview_packet()
 
         # Byte 0: Standard command prefix (0x33)
         assert packet[0] == MUSIC_PACKET_PREFIX
         assert packet[0] == 0x33
 
-        # Byte 1: DreamView command (0x05, same as music mode)
+        # Byte 1: Colour/mode command (0x05, same as music mode)
         assert packet[1] == DREAMVIEW_COMMAND
         assert packet[1] == 0x05
 
-        # Byte 2: DreamView indicator (0x04, scene mode)
+        # Byte 2: video mode. 0x04 here would be the *scene preset*
+        # sub-command — see docs/govee-protocol-reference.md 6.4.
         assert packet[2] == DREAMVIEW_INDICATOR
-        assert packet[2] == 0x04
+        assert packet[2] == 0x00
 
-    def test_enabled_byte_position(self):
-        """Test enabled value is at correct position (byte 3)."""
-        packet_on = build_dreamview_packet(True)
-        assert packet_on[3] == 0x01
+    def test_video_parameters(self):
+        """Test the video-mode parameter bytes."""
+        packet = build_dreamview_packet()
 
-        packet_off = build_dreamview_packet(False)
-        assert packet_off[3] == 0x00
+        assert packet[3] == DREAMVIEW_SEGMENTS_ALL  # all segments
+        assert packet[4] == DREAMVIEW_STYLE_MOVIE  # movie (not game)
+        assert packet[5] == DREAMVIEW_SATURATION_MAX  # 100% saturation
 
-    def test_enabled_on(self):
-        """Test DreamView enabled packet."""
-        packet = build_dreamview_packet(True)
-        assert packet[3] == 0x01
+    def test_is_not_scene_sunset(self):
+        """Regression: the old packet was byte-for-byte Scene(Sunset).
 
-    def test_enabled_off(self):
-        """Test DreamView disabled packet."""
-        packet = build_dreamview_packet(False)
-        assert packet[3] == 0x00
+        ``33 05 04 01 00...00 33`` is the documented Sunset scene frame, so
+        enabling DreamView used to leave the device on a static orange scene.
+        """
+        assert (
+            build_dreamview_packet().hex() != "3305040100000000000000000000000000000033"
+        )
 
     def test_valid_checksum(self):
         """Test packet has valid checksum."""
-        packet = build_dreamview_packet(True)
+        packet = build_dreamview_packet()
 
         # Recalculate checksum from first 19 bytes
         expected_checksum = calculate_checksum(list(packet[:19]))
@@ -397,11 +401,11 @@ class TestBuildDreamviewPacket:
 
     def test_different_from_music_mode(self):
         """Test DreamView packet differs from music mode packet."""
-        dreamview_packet = build_dreamview_packet(True)
+        dreamview_packet = build_dreamview_packet()
         music_packet = build_music_mode_packet(True, 50)
 
-        # Byte 2 should differ (0x04 vs 0x01)
-        assert dreamview_packet[2] == 0x04
+        # Byte 2 should differ (0x00 vs 0x01)
+        assert dreamview_packet[2] == 0x00
         assert music_packet[2] == 0x01
 
         # Overall packets should be different
@@ -417,9 +421,9 @@ class TestDreamviewPacketIntegration:
     """Integration tests for DreamView packet generation."""
 
     def test_full_workflow_on(self):
-        """Test complete DreamView ON packet generation workflow."""
+        """Test complete DreamView packet generation workflow."""
         # Build packet
-        packet = build_dreamview_packet(True)
+        packet = build_dreamview_packet()
         assert len(packet) == 20
 
         # Encode for transmission
@@ -429,24 +433,8 @@ class TestDreamviewPacketIntegration:
         # Verify can be decoded back
         decoded = base64.b64decode(encoded)
         assert decoded == packet
-        assert decoded[2] == 0x04  # DreamView indicator
-        assert decoded[3] == 0x01  # Enabled
-
-    def test_full_workflow_off(self):
-        """Test complete DreamView OFF packet generation workflow."""
-        # Build packet
-        packet = build_dreamview_packet(False)
-        assert len(packet) == 20
-
-        # Encode for transmission
-        encoded = encode_packet_base64(packet)
-        assert isinstance(encoded, str)
-
-        # Verify can be decoded back
-        decoded = base64.b64decode(encoded)
-        assert decoded == packet
-        assert decoded[2] == 0x04  # DreamView indicator
-        assert decoded[3] == 0x00  # Disabled
+        assert decoded[2] == 0x00  # Video mode indicator
+        assert decoded[3] == 0x01  # All segments
 
 
 # ==============================================================================
@@ -524,12 +512,12 @@ class TestBuildDiyScenePacket:
         """Test DIY scene packet differs from music and DreamView packets."""
         diy_packet = build_diy_scene_packet(1)
         music_packet = build_music_mode_packet(True, 50)
-        dreamview_packet = build_dreamview_packet(True)
+        dreamview_packet = build_dreamview_packet()
 
-        # Byte 2 should differ (0x0A vs 0x01 vs 0x04)
+        # Byte 2 should differ (0x0A vs 0x01 vs 0x00)
         assert diy_packet[2] == 0x0A
         assert music_packet[2] == 0x01
-        assert dreamview_packet[2] == 0x04
+        assert dreamview_packet[2] == 0x00
 
     @pytest.mark.parametrize("scene_id", [1, 100, 21104832, 0xFFFFFFFF])
     def test_various_scene_ids(self, scene_id: int):


### PR DESCRIPTION
## Summary

`build_dreamview_packet()` sets byte 2 of the `0x33 0x05` frame to `0x04`. That byte selects the colour operation sub-command, and `0x04` is the **scene preset**, not video mode — so the frame sent for "DreamView ON" is:

```
33 05 04 01 00…00 33
```

which is byte-for-byte the documented `Scene(Sunset)` frame. Enabling DreamView on the passthrough path puts the device into a static orange scene instead of video sync; OFF (`33 05 04 00`) is `Scene(Sunrise)`. The switch isn't a no-op — it takes the light out of whatever it was doing.

Video mode is `0x00`. This repository's own `docs/govee-protocol-reference.md` 6.4 already documents `0x00 | Video/DreamView mode` alongside `0x04 | Scene preset`, and homebridge-govee's `lib/utils/ble-protocol.js` says the same (`VIDEO: 0x00`, `SCENE_PRESET: 0x04`). The correct opcode was documented here all along; only the builder never used it.

Only devices that actually reach the passthrough are affected — `async_send_dreamview()` tries REST first and returns on success, so anything whose `dreamViewToggle` works over the Platform API is untouched.

## Changes

| File | Change |
|---|---|
| `api/ble_packet.py` | `DREAMVIEW_INDICATOR` `0x04` → `0x00`; builder emits `33 05 00 01 00 64` (all segments, movie style, full saturation) via named constants |
| `ble_passthrough.py` | `async_send_dreamview()` drops its `enabled` argument |
| `coordinator.py` | The passthrough fallback is entered only when enabling |
| `tests/test_ble_packet.py` | Assertions pinned `0x04`; updated, plus a regression test that the frame is no longer the Sunset packet |

The builder no longer takes `enabled` because the protocol has no video-off opcode. A device leaves video mode when given another mode, which the REST colour path already does — passing through a scene preset doesn't leave video mode, it replaces it with a static scene.

**Review note:** on the passthrough path `switch.turn_off` now returns `False` rather than sending `Scene(Sunrise)`, so the switch doesn't settle to off in the UI. If you'd prefer it did, the natural alternative is to have the disable branch restore the last known colour the way `async_clear_scene()` does — I left that out to keep the diff on the defect itself.

## Verification

Tested end to end on an **H605C** (RGBIC TV Backlight) over AWS IoT `ptReal`, with no local Bluetooth adapter on the host. The Platform API rejects the capability with `HTTP 400 – The device does not has DreamView` even though the device advertises `dreamViewToggle`, so the passthrough fallback is what runs.

Before the change the light went to a static orange and stayed there. After it, DreamView ON engages camera sync — the LEDs track the picture and go dark on a black screen — and a `light.turn_on` with a colour leaves the mode cleanly. Repeated on → colour → on without a stuck state.

- `pytest`: 1949 passed (full suite; `main` is 1951 — the four tests asserting the ON/OFF value byte are gone, since there is no OFF packet, and two replace them)
- `flake8`: clean
- `black --check`: clean on the three files it passes on `main`; `coordinator.py` already has 8 pre-existing hunks and my change adds none
- `mypy`: unchanged

## References

- #48 — reported for an H605C. The device does advertise `dreamViewToggle`, so the existing switch looked like the answer; what it sent was the scene frame above.
- `docs/govee-protocol-reference.md` 6.4
- homebridge-plugins/homebridge-govee `lib/utils/ble-protocol.js`
- Obi2000/Govee-H6199-Reverse-Engineering — video frame layout and the Sunset frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
