### PR TITLE
feat(sensor): H7152 pump state and hose-connection Mode sensor

### DIFF
--- a/custom_components/govee/binary_sensor.py
+++ b/custom_components/govee/binary_sensor.py
@@ -72,6 +72,11 @@ async def async_setup_entry(
             continue
         if device.supports_water_full_event:
             entities.append(GoveeWaterFullBinarySensor(coordinator, device))
+        # Pump-fault sensor for pump-model dehumidifiers (H7152 "Max") — a
+        # separate alert from water-tank-full, reached via a decoded AWS IoT
+        # status frame rather than a capability (see GoveePumpStateBinarySensor).
+        if device.supports_pump_state:
+            entities.append(GoveePumpStateBinarySensor(coordinator, device))
         # Standalone water-leak detectors (H5054) that surface in the developer
         # device list with a bodyAppearedEvent capability — issue #62. Presence
         # sensors (H5127) share that instance but are excluded here (they get an
@@ -193,6 +198,38 @@ class GoveeWaterFullBinarySensor(GoveeEntity, BinarySensorEntity, RestoreEntity)
         if changed is not None:
             attrs["changed_at"] = changed.isoformat()
         return attrs
+
+
+class GoveePumpStateBinarySensor(GoveeEntity, BinarySensorEntity):
+    """Pump-fault sensor for pump-model dehumidifiers (H7152 "Max"), issue #114 follow-up.
+
+    Separate from :class:`GoveeWaterFullBinarySensor` — the app treats a
+    pump fault (e.g. a clogged drain hose) and "Water Tank Full" as distinct
+    alerts, and this one is reachable through a completely different channel:
+    it has no capability entry, no OpenAPI event, and no flat MQTT ``state``
+    key (all three confirmed empty during a live fault) — only a bit in the
+    AWS IoT status push's BLE-format ``op.command`` frames, decoded in
+    :meth:`GoveeDeviceState.update_pump_state_from_frames`.
+
+    Unlike ``waterFullEvent``, this is a live/level flag: it clears on its own
+    once the device reports the fault gone, so no clear-alert button/latch is
+    needed here.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "govee_pump_state"
+    _attr_icon = "mdi:pump"
+
+    def __init__(self, coordinator: GoveeCoordinator, device: Any) -> None:
+        """Initialize the pump-abnormal binary sensor."""
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.device_id}_pump_state"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True while the pump-fault flag is set."""
+        state = self.device_state
+        return state.pump_state if state else None
 
 
 class GoveeWaterLeakBinarySensor(GoveeEntity, BinarySensorEntity):

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -3283,6 +3283,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             state.update_ceiling_fan_from_frames(
                 self._op_frames_from(state_data)
             )
+        if device is not None and device.supports_pump_state:
+            frames = self._op_frames_from(state_data)
+            state.update_pump_state_from_frames(frames)
+            state.update_dehumidifier_mode_from_frames(frames)
         if device is not None and device.mqtt_outlet_count:
             self._apply_outlet_mask(device, state, state_data.get("onOff"))
 
@@ -3620,6 +3624,16 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                     state.battery = existing_state.battery
                 if existing_state.water_full is not None and state.water_full is None:
                     state.water_full = existing_state.water_full
+                # Pump-abnormal and hose-connection mode (H7152) are decoded
+                # only from AWS IoT push frames — the Developer poll has no
+                # field for either, so the fresh state has them as None.
+                # Preserve the push-derived values across the poll or the
+                # sensors flicker to "unknown" every poll cycle (same class
+                # of bug as #118/#124).
+                if existing_state.pump_state is not None and state.pump_state is None:
+                    state.pump_state = existing_state.pump_state
+                if existing_state.dehumidifier_mode is not None and state.dehumidifier_mode is None:
+                    state.dehumidifier_mode = existing_state.dehumidifier_mode
                 # Occupancy (H5127) is a momentary push event; the developer
                 # /device/state poll returns only `online` for it (never the
                 # bodyAppearedEvent value), so the fresh state has presence=None.

--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -24,5 +24,5 @@
     "bleak-retry-connector>=3.0.0",
     "cryptography>=41.0.0"
   ],
-  "version": "2026.9.3"
+  "version": "2026.9.4"
 }

--- a/custom_components/govee/models/device.py
+++ b/custom_components/govee/models/device.py
@@ -28,6 +28,13 @@ LEAK_HUB_SKUS = frozenset({"H5043", "H5044"})
 # SKU-locked here, consistent with LEAK_SENSOR_SKUS. Add new presence SKUs here.
 PRESENCE_SENSOR_SKUS = frozenset({"H5127"})
 
+# Pump-model dehumidifiers (H7152 "Max") — the only variant with a drain
+# pump/hose, distinct from the H7150/H7151 tank-only models. Neither the
+# pump-fault flag nor the hose-connection mode is a capability or event; both
+# are decoded from AWS IoT push frames (see GoveeDeviceState). Detection is
+# therefore SKU-locked, issue #114 follow-up.
+PUMP_DEHUMIDIFIER_SKUS = frozenset({"H7152"})
+
 # Thermo-hygrometer SKUs that the Govee *Developer* API (/user/devices) does
 # NOT return, so they never reach capability-based discovery and "don't show
 # up" (issue #86). These battery WiFi sensors are present in the account-login
@@ -615,6 +622,18 @@ class GoveeDevice:
             cap.type == CAPABILITY_EVENT and cap.instance == INSTANCE_WATER_FULL_EVENT
             for cap in self.capabilities
         )
+
+    @property
+    def supports_pump_state(self) -> bool:
+        """Check if device can report a pump-fault flag (H7152 "Max").
+
+        Not a capability (absent from the discovered capabilities list even
+        while the fault is active), not on the OpenAPI event channel, and not
+        in the flat MQTT ``state`` keys — confirmed empty across live fault
+        captures. Detection is SKU-locked (``PUMP_DEHUMIDIFIER_SKUS``) rather
+        than capability-based, since the flag never surfaces there at all.
+        """
+        return self.sku.upper() in PUMP_DEHUMIDIFIER_SKUS
 
     @property
     def supports_presence_event(self) -> bool:

--- a/custom_components/govee/models/state.py
+++ b/custom_components/govee/models/state.py
@@ -264,6 +264,26 @@ class GoveeDeviceState:
     # H7150 — see GoveeDevice.auto_mode_value_is_setpoint.
     configured_humidity: int | None = None
 
+    # Pump-fault status for pump-model dehumidifiers (H7152 "Max"). Not
+    # advertised as a capability by the Developer API and never carried in the
+    # flat MQTT ``state`` keys or the OpenAPI event-push channel (confirmed by
+    # a live capture during an actual clogged-drain fault, with zero footprint
+    # on either channel) — only in the AWS IoT status push's ``op.command``
+    # BLE-format frames, decoded in :meth:`update_pump_state_from_frames`.
+    # Live/level flag, not edge-latched like water_full: it clears on its own
+    # once the app's pump-fault alert clears.
+    pump_state: bool | None = None
+
+    # Hose-connection mode for pump-model dehumidifiers (H7152 "Max"),
+    # decoded from byte offset 9 of the AWS IoT ``aa 19`` status frame.
+    # "pump" = drain hose physically connected (app's "Pump Mode"); "tank" =
+    # hose disconnected, draining into the bucket instead (app's "Water Tank
+    # Mode"). Confirmed directly against the app: repeatedly pressing and
+    # holding the device's physical hose-connection button (~5s per hold)
+    # toggled the app's own Mode label in exact lockstep with this byte on
+    # every single transition. See update_dehumidifier_mode_from_frames.
+    dehumidifier_mode: str | None = None  # "pump" | "tank"
+
     # Standalone water-leak detector trip (H5054, issue #62). True when water
     # is detected. Arrives via the bodyAppearedEvent event capability — the
     # developer-API device-state poll only returns `online`, so the trip
@@ -938,6 +958,55 @@ class GoveeDeviceState:
             self.active_scene = None
             self.active_scene_name = None
             self.active_diy_scene = None
+
+    def update_pump_state_from_frames(self, frames: Iterable[bytes]) -> bool:
+        """Apply the pump-fault flag an H7152 carries in its AWS IoT push.
+
+        Reverse-engineered from a live clogged-drain capture: the app's
+        pump-fault alert corresponds to byte offset 12 of an ``aa 17``
+        status frame in the push's ``op.command`` list — ``0x00`` normally,
+        ``0x01`` while the fault is active, back to ``0x00`` once it clears.
+        Confirmed against three captures (before / during / after an actual
+        fault) with the checksum consistent across all three, and stable at
+        ``0x00`` across unrelated mode changes in between. Also confirmed
+        live against two independent real-world faults caught by the shipped
+        sensor, one of which lined up with Home Assistant's own recorded
+        state-transition timestamp to the second.
+
+        Args:
+            frames: Decoded (not base64) frames from ``op.command``.
+
+        Returns:
+            True if the frame was recognised.
+        """
+        for raw in frames:
+            if len(raw) >= 13 and raw[0] == 0xAA and raw[1] == 0x17:
+                self.pump_state = raw[12] == 0x01
+                return True
+        return False
+
+    def update_dehumidifier_mode_from_frames(self, frames: Iterable[bytes]) -> bool:
+        """Apply hose-connection mode from an H7152's AWS IoT ``aa 19``
+        status frame.
+
+        Reverse-engineered from a live test pressing and holding the
+        device's own hose-connection button repeatedly (~5s per hold):
+        byte offset 9 toggled in exact lockstep with the app's Mode label on
+        every single press, in both directions — ``0x01`` while the drain
+        hose reads as connected ("Pump Mode"), ``0x00`` once it doesn't
+        ("Water Tank Mode").
+
+        Args:
+            frames: Decoded (not base64) frames from ``op.command``.
+
+        Returns:
+            True if the frame was recognised.
+        """
+        for raw in frames:
+            if len(raw) >= 10 and raw[0] == 0xAA and raw[1] == 0x19:
+                self.dehumidifier_mode = "pump" if raw[9] == 0x01 else "tank"
+                return True
+        return False
 
     @classmethod
     def create_empty(cls, device_id: str) -> GoveeDeviceState:

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -119,6 +119,11 @@ async def async_setup_entry(
 
         if device.supports_temperature_sensor:
             entities.append(GoveeTemperatureSensor(coordinator, device))
+        # Hose-connection mode for pump-model dehumidifiers (H7152 "Max") —
+        # same SKU gate as the pump-fault sensor, since both are decoded
+        # from the same AWS IoT push (issue #114 follow-up).
+        if device.supports_pump_state:
+            entities.append(GoveeDehumidifierModeSensor(coordinator, device))
         # Second probe on dual-probe SKUs (#150). Gated on a reading actually
         # being present rather than on the SKU: the same model ships with one
         # or two probes connected, and a device with nothing on probe 2 must
@@ -411,6 +416,35 @@ class GoveeTemperatureSensor(_BffThermometerAvailabilityMixin, SensorEntity):
             return (value - 32.0) * (5.0 / 9.0)
 
         return value
+
+
+class GoveeDehumidifierModeSensor(GoveeEntity, SensorEntity):
+    """Hose-connection mode for pump-model dehumidifiers (H7152 "Max").
+
+    "Pump" while the drain hose reads as connected (the app's "Pump Mode");
+    "Water Tank" once it doesn't (draining into the bucket instead). Decoded
+    from byte offset 9 of the AWS IoT push's ``aa 19`` status frame — see
+    :meth:`GoveeDeviceState.update_dehumidifier_mode_from_frames` for how
+    this was confirmed (a live test toggling the device's own hose-detection
+    button, watched against the app's own Mode label).
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "govee_dehumidifier_mode"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["pump", "tank"]
+    _attr_icon = "mdi:pump"
+
+    def __init__(self, coordinator: GoveeCoordinator, device: GoveeDevice) -> None:
+        """Initialize the dehumidifier-mode sensor."""
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.device_id}_dehumidifier_mode"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return "pump" or "tank", or None until a push has landed."""
+        state = self.device_state
+        return state.dehumidifier_mode if state else None
 
 
 class GoveeSecondProbeTemperatureSensor(GoveeTemperatureSensor):

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -242,6 +242,13 @@
       "sensor_temperature": {
         "name": "Temperature"
       },
+      "govee_dehumidifier_mode": {
+        "name": "Mode",
+        "state": {
+          "pump": "Pump",
+          "tank": "Water Tank"
+        }
+      },
       "sensor_temperature_2": {
         "name": "Probe 2 temperature"
       },
@@ -310,6 +317,9 @@
       },
       "govee_water_full": {
         "name": "Water Tank Full"
+      },
+      "govee_pump_state": {
+        "name": "Pump State"
       },
       "govee_water_leak": {
         "name": "Water Leak"

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -242,6 +242,13 @@
       "sensor_temperature": {
         "name": "Temperature"
       },
+      "govee_dehumidifier_mode": {
+        "name": "Mode",
+        "state": {
+          "pump": "Pump",
+          "tank": "Water Tank"
+        }
+      },
       "sensor_temperature_2": {
         "name": "Probe 2 temperature"
       },
@@ -310,6 +317,9 @@
       },
       "govee_water_full": {
         "name": "Water Tank Full"
+      },
+      "govee_pump_state": {
+        "name": "Pump State"
       },
       "govee_water_leak": {
         "name": "Water Leak"

--- a/tests/test_pump_state.py
+++ b/tests/test_pump_state.py
@@ -1,0 +1,471 @@
+"""Pump state and hose-connection mode for pump-model dehumidifiers (H7152
+"Max") — issue #114 follow-up.
+
+Reverse-engineered from a live device:
+
+- Pump-fault flag: a clogged-drain capture showed neither the OpenAPI
+  event-push channel nor the flat MQTT ``state`` keys carried any trace of
+  the fault (confirmed empty across two captures, two minutes apart, while
+  the app showed the fault active). The only signal is byte offset 12 of an
+  ``aa 17`` status frame riding in the AWS IoT push's ``op.command`` list —
+  ``0x00`` normally, ``0x01`` while the fault is active.
+- Hose-connection mode: repeatedly pressing and holding the device's own
+  hose-connection button (~5s per hold) toggled the app's Mode label in
+  exact lockstep with byte offset 9 of an ``aa 19`` status frame on every
+  single transition — ``0x01`` = "Pump Mode", ``0x00`` = "Water Tank Mode".
+
+The frames below are taken verbatim from real diagnostics downloads and
+live debug-log captures.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.govee.coordinator import GoveeCoordinator
+from custom_components.govee.models import GoveeCapability, GoveeDevice, GoveeDeviceState
+from custom_components.govee.models.device import CAPABILITY_ON_OFF, INSTANCE_POWER
+from custom_components.govee.transport_health import TransportHealthTracker
+
+DEVICE_ID = "11:66:C0:EB:1D:75:5C:E7"
+
+# Verbatim ``aa 17`` frames from real diagnostics captures.
+FRAME_PUMP_OK = bytes.fromhex("aa170000000000000000000000000000000000bd")
+FRAME_PUMP_FAULT = bytes.fromhex("aa170000000000000000000001000000000000bc")
+FRAME_PUMP_RECOVERED = bytes.fromhex("aa170000000000000000000000000000000000bd")
+
+# An unrelated frame from the same push, to prove the scan doesn't false-match.
+FRAME_UNRELATED = bytes.fromhex("aa050003000000000000000000000000000000ac")
+
+# Verbatim ``aa 19`` frames from a live hose-button test on 2026-09-11 — byte
+# offset 9 confirmed against the app's own Mode label toggling in lockstep
+# across five press-and-hold cycles.
+FRAME_MODE_PUMP = bytes.fromhex("aa190000000000010101000000000000000000b2")
+FRAME_MODE_TANK = bytes.fromhex("aa190000000000010100000000000000000000b3")
+
+
+def _h7152() -> GoveeDevice:
+    return GoveeDevice(
+        device_id=DEVICE_ID,
+        sku="H7152",
+        name="Smart Dehumidifier Max",
+        device_type="devices.types.dehumidifier",
+        capabilities=(GoveeCapability(type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}),),
+    )
+
+
+def _h7150() -> GoveeDevice:
+    """Non-pump variant — must NOT be treated as pump-capable."""
+    return GoveeDevice(
+        device_id="11:66:C0:EB:1D:75:5C:E8",
+        sku="H7150",
+        name="Smart Dehumidifier",
+        device_type="devices.types.dehumidifier",
+        capabilities=(GoveeCapability(type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}),),
+    )
+
+
+class TestSupportsPumpState:
+    def test_h7152_supports_pump_state(self):
+        assert _h7152().supports_pump_state is True
+
+    def test_h7150_does_not_support_pump_state(self):
+        """H7150 is a non-pump variant — no confirmed frame layout for it yet."""
+        assert _h7150().supports_pump_state is False
+
+
+class TestUpdatePumpStateFromFrames:
+    def test_normal_frame_clears_flag(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        assert state.update_pump_state_from_frames([FRAME_PUMP_OK]) is True
+        assert state.pump_state is False
+
+    def test_fault_frame_sets_flag(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        assert state.update_pump_state_from_frames([FRAME_PUMP_FAULT]) is True
+        assert state.pump_state is True
+
+    def test_flag_clears_again_on_recovery(self):
+        """Live/level flag, not edge-latched like water_full — it tracks live."""
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.update_pump_state_from_frames([FRAME_PUMP_FAULT])
+        assert state.pump_state is True
+
+        state.update_pump_state_from_frames([FRAME_PUMP_RECOVERED])
+        assert state.pump_state is False
+
+    def test_unrelated_frame_is_not_recognised(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        assert state.update_pump_state_from_frames([FRAME_UNRELATED]) is False
+        assert state.pump_state is None
+
+    def test_short_frame_is_ignored(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        short = bytes([0xAA, 0x17, 0x00])
+        assert state.update_pump_state_from_frames([short]) is False
+        assert state.pump_state is None
+
+    def test_picks_the_right_frame_out_of_a_full_push(self):
+        """A real push carries ~15 frames; the scan must find the aa 17 one."""
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        frames = [FRAME_UNRELATED, FRAME_PUMP_FAULT]
+        assert state.update_pump_state_from_frames(frames) is True
+        assert state.pump_state is True
+
+
+class TestUpdateDehumidifierModeFromFrames:
+    def test_pump_frame_reports_pump(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        assert state.update_dehumidifier_mode_from_frames([FRAME_MODE_PUMP]) is True
+        assert state.dehumidifier_mode == "pump"
+
+    def test_tank_frame_reports_tank(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        assert state.update_dehumidifier_mode_from_frames([FRAME_MODE_TANK]) is True
+        assert state.dehumidifier_mode == "tank"
+
+    def test_toggles_both_ways(self):
+        """Live/level flag, not edge-latched — tracks the current mode."""
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.update_dehumidifier_mode_from_frames([FRAME_MODE_TANK])
+        assert state.dehumidifier_mode == "tank"
+
+        state.update_dehumidifier_mode_from_frames([FRAME_MODE_PUMP])
+        assert state.dehumidifier_mode == "pump"
+
+    def test_unrelated_frame_is_not_recognised(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        assert state.update_dehumidifier_mode_from_frames([FRAME_UNRELATED]) is False
+        assert state.dehumidifier_mode is None
+
+    def test_short_frame_is_ignored(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        short = bytes([0xAA, 0x19, 0x00])
+        assert state.update_dehumidifier_mode_from_frames([short]) is False
+        assert state.dehumidifier_mode is None
+
+    def test_picks_the_right_frame_out_of_a_full_push(self):
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        frames = [FRAME_UNRELATED, FRAME_PUMP_OK, FRAME_MODE_TANK]
+        assert state.update_dehumidifier_mode_from_frames(frames) is True
+        assert state.dehumidifier_mode == "tank"
+
+
+def _coordinator_for_mqtt_push() -> GoveeCoordinator:
+    """A minimal coordinator, bypassing __init__, for driving
+    _on_mqtt_state_update directly — mirrors
+    test_ceiling_fan_state.py's _coordinator() helper.
+    """
+    coordinator = GoveeCoordinator.__new__(GoveeCoordinator)
+    coordinator._devices = {DEVICE_ID: _h7152()}
+    coordinator._states = {DEVICE_ID: GoveeDeviceState.create_empty(DEVICE_ID)}
+    coordinator._transport = TransportHealthTracker()
+    coordinator.async_set_updated_data = MagicMock()
+    return coordinator
+
+
+class TestCoordinatorAppliesBothFieldsFromAnMqttPush:
+    """_on_mqtt_state_update must actually call both decoders for an H7152
+    push — the decoders themselves are covered above, this exercises the
+    wiring in the coordinator that calls them.
+    """
+
+    def test_pump_fault_and_tank_mode_applied_together(self):
+        coordinator = _coordinator_for_mqtt_push()
+
+        coordinator._on_mqtt_state_update(
+            DEVICE_ID,
+            {
+                "onOff": 1,
+                "_op_frames": [FRAME_PUMP_FAULT.hex(), FRAME_MODE_TANK.hex()],
+            },
+        )
+
+        state = coordinator._states[DEVICE_ID]
+        assert state.pump_state is True
+        assert state.dehumidifier_mode == "tank"
+        coordinator.async_set_updated_data.assert_called_once()
+
+    def test_pump_ok_and_pump_mode_applied_together(self):
+        coordinator = _coordinator_for_mqtt_push()
+
+        coordinator._on_mqtt_state_update(
+            DEVICE_ID,
+            {
+                "onOff": 1,
+                "_op_frames": [FRAME_PUMP_OK.hex(), FRAME_MODE_PUMP.hex()],
+            },
+        )
+
+        state = coordinator._states[DEVICE_ID]
+        assert state.pump_state is False
+        assert state.dehumidifier_mode == "pump"
+
+    def test_non_pump_device_is_left_untouched(self):
+        """A non-H7152 device must never reach either decoder, even if it
+        somehow carried a matching frame shape."""
+        coordinator = GoveeCoordinator.__new__(GoveeCoordinator)
+        other_id = _h7150().device_id
+        coordinator._devices = {other_id: _h7150()}
+        coordinator._states = {other_id: GoveeDeviceState.create_empty(other_id)}
+        coordinator._transport = TransportHealthTracker()
+        coordinator.async_set_updated_data = MagicMock()
+
+        coordinator._on_mqtt_state_update(
+            other_id,
+            {"onOff": 1, "_op_frames": [FRAME_PUMP_FAULT.hex(), FRAME_MODE_TANK.hex()]},
+        )
+
+        state = coordinator._states[other_id]
+        assert state.pump_state is None
+        assert state.dehumidifier_mode is None
+
+
+class TestPreservedAcrossDeveloperPoll:
+    """The Developer /device/state poll has no field for either value at
+    all — they only ever come from AWS IoT push frames — so a naive poll
+    would flicker the sensors to "unknown" every ~60s (same bug class as
+    water_full/presence, issues #118/#124).
+    """
+
+    def _coord(self):
+        import custom_components.govee.coordinator as coord_mod
+
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        config_entry.async_create_background_task = MagicMock()
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=None,
+            poll_interval=60,
+        )
+        coord._devices[DEVICE_ID] = _h7152()
+        return coord
+
+    @pytest.mark.asyncio
+    async def test_pump_state_survives_a_poll_that_knows_nothing_about_it(self):
+        coord = self._coord()
+        existing = GoveeDeviceState.create_empty(DEVICE_ID)
+        existing.pump_state = True
+        coord._states[DEVICE_ID] = existing
+
+        # What the Developer poll actually returns: no pump_state field at
+        # all, so the fresh state has it as None.
+        fresh = GoveeDeviceState.create_empty(DEVICE_ID)
+        coord._api_client.get_device_state = AsyncMock(return_value=fresh)
+
+        result = await coord._fetch_device_state(DEVICE_ID, coord._devices[DEVICE_ID])
+
+        assert result.pump_state is True
+
+    @pytest.mark.asyncio
+    async def test_dehumidifier_mode_survives_a_poll_that_knows_nothing_about_it(self):
+        coord = self._coord()
+        existing = GoveeDeviceState.create_empty(DEVICE_ID)
+        existing.dehumidifier_mode = "tank"
+        coord._states[DEVICE_ID] = existing
+
+        fresh = GoveeDeviceState.create_empty(DEVICE_ID)
+        coord._api_client.get_device_state = AsyncMock(return_value=fresh)
+
+        result = await coord._fetch_device_state(DEVICE_ID, coord._devices[DEVICE_ID])
+
+        assert result.dehumidifier_mode == "tank"
+
+    @pytest.mark.asyncio
+    async def test_recovery_is_not_masked_by_a_stale_preserved_value(self):
+        """Preservation only fills a None gap — it must never overwrite a
+        push-derived value the poll legitimately doesn't touch."""
+        coord = self._coord()
+        existing = GoveeDeviceState.create_empty(DEVICE_ID)
+        existing.pump_state = True
+        coord._states[DEVICE_ID] = existing
+
+        fresh = GoveeDeviceState.create_empty(DEVICE_ID)
+        fresh.pump_state = False  # e.g. a push landed between poll start and finish
+        coord._api_client.get_device_state = AsyncMock(return_value=fresh)
+
+        result = await coord._fetch_device_state(DEVICE_ID, coord._devices[DEVICE_ID])
+
+        assert result.pump_state is False
+
+
+class TestPumpStateBinarySensor:
+    def _coord(self):
+        import custom_components.govee.coordinator as coord_mod
+
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=None,
+            poll_interval=60,
+        )
+        coord._devices[DEVICE_ID] = _h7152()
+        return coord
+
+    def test_is_on_reflects_state(self):
+        from custom_components.govee.binary_sensor import GoveePumpStateBinarySensor
+
+        coord = self._coord()
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.pump_state = True
+        coord._states[DEVICE_ID] = state
+
+        sensor = GoveePumpStateBinarySensor(coord, coord._devices[DEVICE_ID])
+        assert sensor.is_on is True
+
+    def test_is_on_none_before_any_push(self):
+        from custom_components.govee.binary_sensor import GoveePumpStateBinarySensor
+
+        coord = self._coord()
+        sensor = GoveePumpStateBinarySensor(coord, coord._devices[DEVICE_ID])
+        assert sensor.is_on is None
+
+
+class TestDehumidifierModeSensor:
+    def _coord(self):
+        import custom_components.govee.coordinator as coord_mod
+
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=None,
+            poll_interval=60,
+        )
+        coord._devices[DEVICE_ID] = _h7152()
+        return coord
+
+    def test_native_value_reflects_state(self):
+        from custom_components.govee.sensor import GoveeDehumidifierModeSensor
+
+        coord = self._coord()
+        state = GoveeDeviceState.create_empty(DEVICE_ID)
+        state.dehumidifier_mode = "tank"
+        coord._states[DEVICE_ID] = state
+
+        sensor = GoveeDehumidifierModeSensor(coord, coord._devices[DEVICE_ID])
+        assert sensor.native_value == "tank"
+
+    def test_native_value_none_before_any_push(self):
+        from custom_components.govee.sensor import GoveeDehumidifierModeSensor
+
+        coord = self._coord()
+        sensor = GoveeDehumidifierModeSensor(coord, coord._devices[DEVICE_ID])
+        assert sensor.native_value is None
+
+
+class TestBinarySensorSetupRegistersPumpState:
+    """async_setup_entry must actually create the entity for an H7152 —
+    the entity class itself is covered above, this exercises the
+    conditional registration in the platform's setup function."""
+
+    @pytest.mark.asyncio
+    async def test_h7152_gets_a_pump_state_entity(self):
+        from custom_components.govee.binary_sensor import (
+            GoveePumpStateBinarySensor,
+            async_setup_entry,
+        )
+
+        coordinator = MagicMock()
+        coordinator.devices = {DEVICE_ID: _h7152()}
+        coordinator.is_bff_leak_sensor.return_value = False
+        coordinator.leak_sensors = {}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.options.get.return_value = False  # CONF_EXPOSE_TRANSPORT_ENTITIES off
+
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, added.extend)
+
+        pump_state_entities = [e for e in added if isinstance(e, GoveePumpStateBinarySensor)]
+        assert len(pump_state_entities) == 1
+
+    @pytest.mark.asyncio
+    async def test_h7150_gets_no_pump_state_entity(self):
+        from custom_components.govee.binary_sensor import (
+            GoveePumpStateBinarySensor,
+            async_setup_entry,
+        )
+
+        coordinator = MagicMock()
+        coordinator.devices = {_h7150().device_id: _h7150()}
+        coordinator.is_bff_leak_sensor.return_value = False
+        coordinator.leak_sensors = {}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.options.get.return_value = False
+
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, added.extend)
+
+        assert not any(isinstance(e, GoveePumpStateBinarySensor) for e in added)
+
+
+class TestSensorSetupRegistersDehumidifierMode:
+    """async_setup_entry must actually create the Mode entity for an
+    H7152 — the entity class itself is covered above, this exercises the
+    conditional registration in the platform's setup function."""
+
+    @pytest.mark.asyncio
+    async def test_h7152_gets_a_mode_entity(self):
+        from custom_components.govee.sensor import (
+            GoveeDehumidifierModeSensor,
+            async_setup_entry,
+        )
+
+        device = _h7152()
+        coordinator = MagicMock()
+        coordinator.devices = {DEVICE_ID: device}
+        coordinator.mqtt_client = None
+        coordinator.get_state.return_value = None
+        coordinator.is_bff_leak_sensor.return_value = False
+        coordinator.leak_sensors = {}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.entry_id = "test_entry"
+
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, added.extend)
+
+        mode_entities = [e for e in added if isinstance(e, GoveeDehumidifierModeSensor)]
+        assert len(mode_entities) == 1
+
+    @pytest.mark.asyncio
+    async def test_h7150_gets_no_mode_entity(self):
+        from custom_components.govee.sensor import (
+            GoveeDehumidifierModeSensor,
+            async_setup_entry,
+        )
+
+        device = _h7150()
+        coordinator = MagicMock()
+        coordinator.devices = {device.device_id: device}
+        coordinator.mqtt_client = None
+        coordinator.get_state.return_value = None
+        coordinator.is_bff_leak_sensor.return_value = False
+        coordinator.leak_sensors = {}
+
+        entry = MagicMock()
+        entry.runtime_data = coordinator
+        entry.entry_id = "test_entry"
+
+        added: list = []
+        await async_setup_entry(MagicMock(), entry, added.extend)
+
+        assert not any(isinstance(e, GoveeDehumidifierModeSensor) for e in added)


### PR DESCRIPTION
## Summary

Adds two new entities for the H7152 "Smart Dehumidifier Max" (the pump/drain-hose variant, distinct from the tank-only H7150/H7151), follow-up on #114. Neither signal is exposed through any Developer-API capability, the OpenAPI event-push channel, or the flat MQTT `state` keys — both were reverse-engineered from the AWS IoT status push's BLE-format `op.command` frames, which this integration already decodes for other purposes (ceiling-fan combos, ptReal thermometer probes, etc.).

### Pump State (`binary_sensor`, `device_class: problem`)

Byte offset 12 of an `aa 17` status frame:

```
normal: aa 17 00 00 00 00 00 00 00 00 00 00 [00] 00 00 00 00 00 00 <checksum>
fault:  aa 17 00 00 00 00 00 00 00 00 00 00 [01] 00 00 00 00 00 00 <checksum>
```

Confirmed against 3 lab captures (before / during / after a real clogged-drain fault, checksum consistent with the single-bit flip each time) plus 2 independent real-world faults caught live by the shipped sensor — one of which lined up with Home Assistant's own recorded state-transition timestamp to the second. It's a live/level flag, not edge-latched: it clears on its own once the fault condition clears, unlike `waterFullEvent` which needs an explicit clear.

### Mode (`sensor`, enum: `pump` / `tank` → "Pump" / "Water Tank")

Byte offset 9 of an `aa 19` status frame — `0x01` while the drain hose reads as connected (app's "Pump Mode"), `0x00` once it doesn't (app's "Water Tank Mode", draining into the bucket instead).

Confirmed directly against the app's own UI: repeatedly pressed and held the device's physical hose-connection button (~5s per hold, 5 cycles) and watched the app's Mode label toggle in *exact* lockstep with this byte on every single transition — not just a plausible correlation, a byte-for-byte match against a live control.

(A second byte in the same frame, offset 7, also moves but is intentionally left undecoded — it was first suspected to be the pump-motor running state, since it matched a hose-unplug/replug test. But a direct frame-by-frame diff against a moment independently confirmed motor-on and two moments confirmed motor-off showed the *entire* `aa 19` frame, byte 7 included, identical across all three samples — the pump's running state isn't transmitted in this push at all. Rather than guess, its meaning is left unresolved.)

### Preserved across the Developer poll

Both fields are MQTT-push-only — the Developer `/device/state` poll has no field for either, so a naive implementation would flicker both entities to "unknown" every ~60s poll cycle. Fixed the same way `water_full` and `presence` already are (#118, #124): the poll only overwrites a field when it actually returns a value for it, so a push-derived value survives polls that don't touch it.

## Contributing guidelines checklist

- [x] `black .`, `flake8 .`, `mypy custom_components/govee` all clean
- [x] `pytest` — 2072/2072 passing. `tests/test_pump_state.py` covers: SKU gating, frame decoding (happy-path and malformed/unrelated-frame rejection), preserve-across-poll behavior, both entity classes directly, the coordinator's `_on_mqtt_state_update` wiring end-to-end (not just the decoders in isolation), and the `async_setup_entry` registration branches in both platforms. Every line this PR adds is exercised — the two platform files' overall percentages (80-82%) reflect pre-existing gaps in code this PR didn't touch, not new gaps.
- [x] Type hints on all new functions/methods
- [x] Google-style docstrings throughout, each citing the specific evidence (byte offsets, capture methodology) rather than just describing behavior
- [x] Architecture: decode logic in `models/state.py` (no I/O), SKU detection in `models/device.py`, entities in `binary_sensor.py`/`sensor.py`, orchestration (calling the decoders + preserve-across-poll) in `coordinator.py`
- [ ] CONTRIBUTING.md asks for 95%+ overall coverage; a full-suite run is 76.73%. That's the wider codebase's existing coverage baseline, not something this PR moved — chasing it here would mean adding tests for large amounts of unrelated pre-existing code, well outside this PR's scope. Flagging rather than silently claiming compliance.

## Test plan

```
black --check --line-length 119 .
flake8 --max-line-length 119 .
mypy custom_components/govee
pytest   # 2072 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti2pwAMMVhFyZGwoNXZ2Xh
