### PR TITLE
Poll loop: per-device deadlines, skip fully-disabled devices, and a daily request counter

### DIFF
--- a/custom_components/govee/api/client.py
+++ b/custom_components/govee/api/client.py
@@ -198,6 +198,13 @@ class GoveeApiClient:
 
         Counted for every response, including 429s and errors: a rejected
         request still consumed the allowance.
+
+        Called from response handling, so the totals are a FLOOR, not an exact
+        figure. A request that dies below the HTTP layer — connection timeout,
+        DNS failure, a retry chain exhausting itself — never reaches here but
+        may still have been counted on Govee's side. Undercounting is the safe
+        direction for the question these numbers exist to answer: if the floor
+        already exceeds the daily cap, the real spend certainly does.
         """
         now = time.time()
         hour = int(now // 3600)
@@ -238,16 +245,23 @@ class GoveeApiClient:
 
     @property
     def requests_per_hour(self) -> float:
-        """Mean requests/hour over the buckets held, 0.0 before the first hour.
+        """Mean requests/hour across the span of history held, 0.0 if none.
 
-        Only complete history is averaged, so this is a description of what has
-        happened, not a projection.
+        Divided by hours *elapsed*, not by buckets recorded. A bucket only
+        exists for an hour that saw traffic, so averaging over buckets would
+        drop idle hours out of the denominator — a restart or a reload would
+        make the rate read higher than it truly was, on an attribute people
+        will read as a plain average.
+
+        This describes what has happened over the window held; it is not a
+        projection of what the next 24 hours will cost.
         """
         cutoff = int(time.time() // 3600) - (REQUEST_HISTORY_HOURS - 1)
         buckets = [b for b in self._request_buckets if b[0] >= cutoff]
         if not buckets:
             return 0.0
-        return round(sum(count for _, count in buckets) / len(buckets), 1)
+        hours_elapsed = buckets[-1][0] - buckets[0][0] + 1
+        return round(sum(count for _, count in buckets) / hours_elapsed, 1)
 
     def _update_rate_limits(self, headers: Any) -> None:
         """Update rate limit tracking from response headers."""

--- a/custom_components/govee/api/client.py
+++ b/custom_components/govee/api/client.py
@@ -7,6 +7,7 @@ Implements IApiClient protocol.
 from __future__ import annotations
 
 import logging
+import time
 import uuid
 from collections import deque
 from datetime import datetime, timezone
@@ -31,6 +32,11 @@ if TYPE_CHECKING:
     from ..models.commands import DeviceCommand
 
 _LOGGER = logging.getLogger(__name__)
+
+# How many hourly buckets of request history to keep. Govee documents a
+# 10,000/day cap but returns no daily counter of its own, so the only way
+# to know what an install actually spends is to count locally.
+REQUEST_HISTORY_HOURS = 24
 
 # Govee API v2.0 endpoints
 API_BASE = "https://openapi.api.govee.com/router/api/v1"
@@ -97,6 +103,15 @@ class GoveeApiClient:
         self.rate_limit_remaining: int = 100
         self.rate_limit_total: int = 100
         self.rate_limit_reset: int = 0
+
+        # Local request accounting. The per-minute allowance comes back in
+        # response headers, but the daily one does not, so it is counted here.
+        # Hourly buckets rather than per-request timestamps: 24 small entries
+        # instead of tens of thousands, which is ample to answer "are we over
+        # the daily cap, and by how much".
+        self._request_buckets: deque[list[int]] = deque()
+        self._request_day: int = 0
+        self._requests_today: int = 0
 
         # Last raw API responses, retained for diagnostics (redacted at dump
         # time). Lets a diagnostics download include exactly what the device
@@ -178,6 +193,62 @@ class GoveeApiClient:
             "Accept": "application/json",
         }
 
+    def _note_request(self) -> None:
+        """Record that one request was spent against the Govee quota.
+
+        Counted for every response, including 429s and errors: a rejected
+        request still consumed the allowance.
+        """
+        now = time.time()
+        hour = int(now // 3600)
+        day = int(now // 86400)
+
+        if day != self._request_day:
+            self._request_day = day
+            self._requests_today = 0
+        self._requests_today += 1
+
+        if self._request_buckets and self._request_buckets[-1][0] == hour:
+            self._request_buckets[-1][1] += 1
+        else:
+            self._request_buckets.append([hour, 1])
+
+        cutoff = hour - (REQUEST_HISTORY_HOURS - 1)
+        while self._request_buckets and self._request_buckets[0][0] < cutoff:
+            self._request_buckets.popleft()
+
+    @property
+    def requests_last_24h(self) -> int:
+        """Requests spent in the trailing 24 hours, to hourly resolution."""
+        cutoff = int(time.time() // 3600) - (REQUEST_HISTORY_HOURS - 1)
+        return sum(count for hour, count in self._request_buckets if hour >= cutoff)
+
+    @property
+    def requests_today(self) -> int:
+        """Requests spent since UTC midnight.
+
+        Tracked alongside the rolling figure because a daily cap resets on a
+        clock boundary, and the two answer different questions: this one says
+        how much of today's allowance is gone, the rolling one says what a
+        steady state actually costs.
+        """
+        if int(time.time() // 86400) != self._request_day:
+            return 0
+        return self._requests_today
+
+    @property
+    def requests_per_hour(self) -> float:
+        """Mean requests/hour over the buckets held, 0.0 before the first hour.
+
+        Only complete history is averaged, so this is a description of what has
+        happened, not a projection.
+        """
+        cutoff = int(time.time() // 3600) - (REQUEST_HISTORY_HOURS - 1)
+        buckets = [b for b in self._request_buckets if b[0] >= cutoff]
+        if not buckets:
+            return 0.0
+        return round(sum(count for _, count in buckets) / len(buckets), 1)
+
     def _update_rate_limits(self, headers: Any) -> None:
         """Update rate limit tracking from response headers."""
         if "X-RateLimit-Remaining" in headers:
@@ -216,6 +287,7 @@ class GoveeApiClient:
             GoveeDeviceNotFoundError: 400 for missing device.
             GoveeApiError: Other API errors.
         """
+        self._note_request()
         self._update_rate_limits(response.headers)
 
         try:

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -193,6 +193,11 @@ MAX_WATER_DETECTOR_POLL_INTERVAL: Final = 3600
 MIN_PROBE_POLL_INTERVAL: Final = 10
 MAX_PROBE_POLL_INTERVAL: Final = 600
 
+# Govee's documented developer-API quotas. The per-minute figure comes back
+# in response headers; the daily one never does, so it is carried here so
+# the rate-limit sensor can say how much of it an install has spent.
+GOVEE_DAILY_REQUEST_LIMIT: Final = 10000
+
 # Optimistic state handling
 # Grace window (seconds) during which API polls do NOT overwrite optimistic
 # power/brightness. Masks out-of-range BLE devices and slow cloud responses

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -19,6 +19,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -3396,20 +3397,37 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # BLE-capable devices would stay cloud-only until a manual reload.
         self._ble_handler.enroll_from_cache()
 
+        # Devices the user has fully disabled cost a cloud request per poll and
+        # give nothing back. On an install where a batch of devices moved to
+        # another protocol, that is the largest slice of the daily API budget.
+        pollable = {
+            device_id: device
+            for device_id, device in self._devices.items()
+            if not self._entities_all_disabled(device_id)
+        }
+        skipped = len(self._devices) - len(pollable)
+        if skipped:
+            _LOGGER.debug(
+                "Skipping %d device(s) with all entities disabled", skipped
+            )
+
+        if not pollable:
+            return self._states
+
         # Create tasks for parallel fetching. Each fetch carries its own
         # deadline: a single timeout around the whole gather discarded every
         # device's result as soon as one device was slow, so one unreachable
         # bulb held the entire house's state hostage for that cycle.
         tasks = [
             self._fetch_device_state_bounded(device_id, device)
-            for device_id, device in self._devices.items()
+            for device_id, device in pollable.items()
         ]
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         # Process results
         successful_updates = 0
-        for device_id, result in zip(self._devices.keys(), results):
+        for device_id, result in zip(pollable.keys(), results):
             if isinstance(result, GoveeDeviceState):
                 self._states[device_id] = result
                 successful_updates += 1
@@ -3452,6 +3470,37 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             _LOGGER.debug("Govee LAN read refresh failed: %s", err)
 
         return self._states
+
+    def _entities_all_disabled(self, device_id: str) -> bool:
+        """True when this device has entities and every one of them is disabled.
+
+        Polling a device whose entities are all disabled buys nothing: no
+        entity will ever show the result. Each one still spends a request
+        against Govee's documented 10,000/day budget every cycle, so on an
+        install where a batch of devices has been migrated to another
+        protocol and switched off here, they can dominate the daily spend.
+
+        A device with no registry entries is deliberately NOT skipped — that
+        is the normal state during first setup, before platforms have added
+        their entities, and skipping then would stall discovery.
+        """
+        try:
+            registry = er.async_get(self.hass)
+            entries = er.async_entries_for_config_entry(
+                registry, self._config_entry.entry_id
+            )
+        except Exception as err:  # noqa: BLE001 - registry must never fail a poll
+            _LOGGER.debug("Entity registry unavailable, polling %s: %s", device_id, err)
+            return False
+
+        found = False
+        for entry in entries:
+            if not entry.unique_id.startswith(device_id):
+                continue
+            found = True
+            if entry.disabled_by is None:
+                return False
+        return found
 
     async def _fetch_device_state_bounded(
         self,

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -3415,10 +3415,11 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # Devices the user has fully disabled cost a cloud request per poll and
         # give nothing back. On an install where a batch of devices moved to
         # another protocol, that is the largest slice of the daily API budget.
+        fully_disabled = self._devices_with_all_entities_disabled()
         pollable = {
             device_id: device
             for device_id, device in self._devices.items()
-            if not self._entities_all_disabled(device_id)
+            if device_id not in fully_disabled
         }
         skipped = len(self._devices) - len(pollable)
         if skipped:
@@ -3486,24 +3487,52 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
 
         return self._states
 
-    def _entities_all_disabled(self, device_id: str) -> bool:
-        """True when this device has entities and every one of them is disabled.
+    def _owning_device_id(self, unique_id: str) -> str | None:
+        """Map an entity registry unique_id back to the device it belongs to.
 
-        Polling a device whose entities are all disabled buys nothing: no
-        entity will ever show the result. Each one still spends a request
-        against Govee's documented 10,000/day budget every cycle.
+        Entity unique_ids are either the bare device id (entity.py) or the
+        device id followed by an underscore-prefixed suffix (every SUFFIX_* in
+        const.py starts with "_"). Testing a bare prefix instead would let one
+        device claim another's entities whenever one id is a prefix of the
+        other, which is not hypothetical: group devices carry purely numeric
+        ids, where prefix collisions are easy.
+        """
+        if unique_id in self._devices:
+            return unique_id
+        head = unique_id.split("_", 1)[0]
+        if head in self._devices:
+            return head
+        # Device ids are MAC-shaped or numeric, so the split above resolves
+        # them all; this is the safety net if that ever stops being true.
+        for device_id in self._devices:
+            if unique_id.startswith(f"{device_id}_"):
+                return device_id
+        return None
 
-        The common cause is a device that a better transport took over —
-        moved to Matter, or controlled locally by another integration — whose
-        cloud twin was then disabled here rather than removed. Those twins
-        stay in the account device list forever, so on a mature install they
-        can outnumber the devices still in use and dominate the daily spend.
-        The cause does not matter to this check: any device the user has
-        fully switched off is one the cloud need not be asked about.
+    def _devices_with_all_entities_disabled(self) -> set[str]:
+        """Device ids that have registry entities and every one is disabled.
 
-        A device with no registry entries is deliberately NOT skipped — that
-        is the normal state during first setup, before platforms have added
-        their entities, and skipping then would stall discovery.
+        Polling such a device buys nothing: no entity will ever show the
+        result. Each one still spends a request against Govee's documented
+        10,000/day budget every cycle.
+
+        The common cause is a device that a better transport took over — moved
+        to Matter, or controlled locally by another integration — whose cloud
+        twin was disabled here rather than removed. Those twins stay in the
+        account device list forever, so on a mature install they can outnumber
+        the devices still in use and dominate the daily spend. The cause does
+        not matter to this check: any device the user has fully switched off is
+        one the cloud need not be asked about.
+
+        Built in a single pass over the registry. Asking per device would walk
+        the whole entity list once per device on every poll, which is
+        quadratic for no gain.
+
+        A device with no registry entries is deliberately absent from the
+        result — that is the normal state during first setup, before platforms
+        have added their entities, and skipping then would stall discovery.
+        A registry failure returns an empty set, so nothing is ever skipped
+        because the lookup broke.
         """
         try:
             registry = er.async_get(self.hass)
@@ -3511,17 +3540,23 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                 registry, self._config_entry.entry_id
             )
         except Exception as err:  # noqa: BLE001 - registry must never fail a poll
-            _LOGGER.debug("Entity registry unavailable, polling %s: %s", device_id, err)
-            return False
+            _LOGGER.debug("Entity registry unavailable, polling every device: %s", err)
+            return set()
 
-        found = False
+        has_entities: set[str] = set()
+        has_enabled: set[str] = set()
         for entry in entries:
-            if not entry.unique_id.startswith(device_id):
+            device_id = self._owning_device_id(entry.unique_id)
+            if device_id is None:
                 continue
-            found = True
+            has_entities.add(device_id)
             if entry.disabled_by is None:
-                return False
-        return found
+                has_enabled.add(device_id)
+        return has_entities - has_enabled
+
+    def _entities_all_disabled(self, device_id: str) -> bool:
+        """True when this one device has entities and all of them are disabled."""
+        return device_id in self._devices_with_all_entities_disabled()
 
     async def _fetch_device_state_bounded(
         self,

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -3396,22 +3396,16 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # BLE-capable devices would stay cloud-only until a manual reload.
         self._ble_handler.enroll_from_cache()
 
-        # Create tasks for parallel fetching
+        # Create tasks for parallel fetching. Each fetch carries its own
+        # deadline: a single timeout around the whole gather discarded every
+        # device's result as soon as one device was slow, so one unreachable
+        # bulb held the entire house's state hostage for that cycle.
         tasks = [
-            self._fetch_device_state(device_id, device)
+            self._fetch_device_state_bounded(device_id, device)
             for device_id, device in self._devices.items()
         ]
 
-        # Scale timeout based on device count (2s per device, min 30s, max 120s)
-        timeout = min(max(STATE_FETCH_TIMEOUT, len(self._devices) * 2), 120)
-
-        # Wait for all with timeout
-        try:
-            async with asyncio.timeout(timeout):
-                results = await asyncio.gather(*tasks, return_exceptions=True)
-        except TimeoutError:
-            _LOGGER.warning("State fetch timed out after %ds", timeout)
-            return self._states
+        results = await asyncio.gather(*tasks, return_exceptions=True)
 
         # Process results
         successful_updates = 0
@@ -3458,6 +3452,41 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             _LOGGER.debug("Govee LAN read refresh failed: %s", err)
 
         return self._states
+
+    async def _fetch_device_state_bounded(
+        self,
+        device_id: str,
+        device: GoveeDevice,
+    ) -> GoveeDeviceState | Exception:
+        """Fetch one device's state under its own deadline.
+
+        Returns the exception rather than raising so ``asyncio.gather`` keeps
+        every other device's result. ``_fetch_device_state`` already converts
+        most failures into a returned exception; this bounds the call in time
+        and catches anything that escapes, so a device that never answers
+        costs only its own slot in the poll.
+
+        Args:
+            device_id: Device identifier.
+            device: Device instance.
+
+        Returns:
+            GoveeDeviceState, or the Exception that stopped the fetch.
+        """
+        try:
+            async with asyncio.timeout(STATE_FETCH_TIMEOUT):
+                return await self._fetch_device_state(device_id, device)
+        except TimeoutError as err:
+            _LOGGER.debug(
+                "State fetch for %s timed out after %ds",
+                device_id,
+                STATE_FETCH_TIMEOUT,
+            )
+            self._record_transport_failure(device_id, "cloud_api", "poll_timeout")
+            return err
+        except Exception as err:  # noqa: BLE001 - isolate one device's failure
+            self._record_transport_failure(device_id, "cloud_api", str(err))
+            return err
 
     async def _fetch_device_state(
         self,

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -3491,9 +3491,15 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
 
         Polling a device whose entities are all disabled buys nothing: no
         entity will ever show the result. Each one still spends a request
-        against Govee's documented 10,000/day budget every cycle, so on an
-        install where a batch of devices has been migrated to another
-        protocol and switched off here, they can dominate the daily spend.
+        against Govee's documented 10,000/day budget every cycle.
+
+        The common cause is a device that a better transport took over —
+        moved to Matter, or controlled locally by another integration — whose
+        cloud twin was then disabled here rather than removed. Those twins
+        stay in the account device list forever, so on a mature install they
+        can outnumber the devices still in use and dominate the daily spend.
+        The cause does not matter to this check: any device the user has
+        fully switched off is one the cloud need not be asked about.
 
         A device with no registry entries is deliberately NOT skipped — that
         is the normal state during first setup, before platforms have added

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -521,6 +521,21 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         return self._api_client.rate_limit_reset
 
     @property
+    def api_requests_last_24h(self) -> int:
+        """Requests spent in the trailing 24 hours (hourly resolution)."""
+        return self._api_client.requests_last_24h
+
+    @property
+    def api_requests_today(self) -> int:
+        """Requests spent since UTC midnight."""
+        return self._api_client.requests_today
+
+    @property
+    def api_requests_per_hour(self) -> float:
+        """Mean requests/hour over the history held."""
+        return self._api_client.requests_per_hour
+
+    @property
     def mqtt_client(self) -> GoveeAwsIotClient | None:
         """Return MQTT client instance."""
         return self._mqtt_client

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_API_TEMPERATURE_UNIT,
     DEFAULT_API_TEMPERATURE_UNIT,
     DOMAIN,
+    GOVEE_DAILY_REQUEST_LIMIT,
     resolve_fahrenheit_conversion,
 )
 from .coordinator import GoveeCoordinator
@@ -223,11 +224,21 @@ class GoveeRateLimitSensor(CoordinatorEntity["GoveeCoordinator"], SensorEntity):
         return self.coordinator.api_rate_limit_remaining
 
     @property
-    def extra_state_attributes(self) -> dict[str, int]:
-        """Return additional rate limit info."""
+    def extra_state_attributes(self) -> dict[str, float]:
+        """Return additional rate limit info.
+
+        The sensor's own value is the per-minute allowance Govee reports in
+        response headers. The daily cap is not reported by the API at all, so
+        the request counts here are measured locally — without them an install
+        has no way to tell whether it is inside the documented 10,000/day.
+        """
         return {
             "total_limit": self.coordinator.api_rate_limit_total,
             "reset_time": self.coordinator.api_rate_limit_reset,
+            "requests_today": self.coordinator.api_requests_today,
+            "requests_last_24h": self.coordinator.api_requests_last_24h,
+            "requests_per_hour": self.coordinator.api_requests_per_hour,
+            "daily_limit": GOVEE_DAILY_REQUEST_LIMIT,
         }
 
 

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -231,6 +231,13 @@ class GoveeRateLimitSensor(CoordinatorEntity["GoveeCoordinator"], SensorEntity):
         response headers. The daily cap is not reported by the API at all, so
         the request counts here are measured locally — without them an install
         has no way to tell whether it is inside the documented 10,000/day.
+
+        What the counts include: every REST call the integration makes, which
+        is the state poll plus periodic device rediscovery and scene fetches —
+        not the state poll alone. They will therefore read somewhat above what
+        "devices x polls per day" predicts. That gap is the point, not a
+        defect: the daily cap applies to all of it, so a figure that counted
+        only the poll would understate the spend.
         """
         return {
             "total_limit": self.coordinator.api_rate_limit_total,

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -238,6 +238,10 @@ class GoveeRateLimitSensor(CoordinatorEntity["GoveeCoordinator"], SensorEntity):
         "devices x polls per day" predicts. That gap is the point, not a
         defect: the daily cap applies to all of it, so a figure that counted
         only the poll would understate the spend.
+
+        They are nonetheless a lower bound. Counting happens when a response
+        is handled, so a request that fails below the HTTP layer is missed.
+        Read these as "at least this many".
         """
         return {
             "total_limit": self.coordinator.api_rate_limit_total,

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -674,6 +674,33 @@ class TestRequestAccounting:
         # Two hourly buckets holding 30 requests.
         assert client.requests_per_hour == 15.0
 
+    def test_idle_hours_count_against_the_average(self, monkeypatch):
+        """An hour with no traffic still happened.
+
+        Buckets only exist for hours that saw requests, so dividing by buckets
+        held would drop a restart or a quiet spell out of the denominator and
+        report a rate higher than the install actually ran at.
+        """
+        client, clock = self._client(monkeypatch, 1_000_000.0)
+
+        for _ in range(10):
+            client._note_request()
+        # Three silent hours - a restart, say - then traffic again.
+        clock["now"] += 4 * self.HOUR
+        for _ in range(10):
+            client._note_request()
+
+        # 20 requests across a 5-hour span, not across the 2 hours recorded.
+        assert client.requests_per_hour == 4.0
+
+    def test_single_hour_of_traffic_averages_to_itself(self, monkeypatch):
+        client, _ = self._client(monkeypatch, 1_000_000.0)
+
+        for _ in range(7):
+            client._note_request()
+
+        assert client.requests_per_hour == 7.0
+
     @pytest.mark.asyncio
     async def test_handle_response_counts_the_request(self, monkeypatch):
         """Every answered request is counted, whatever the status."""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -559,3 +559,146 @@ class TestRecordLocalCommand:
             "colorRgb",
             "brightness",
         ]
+
+
+# ==============================================================================
+# Daily request accounting
+# ==============================================================================
+
+
+class TestRequestAccounting:
+    """Local counting of requests against Govee's undocumented-in-headers cap.
+
+    Govee reports the per-minute allowance in response headers but never the
+    daily one, so an install has no way to know what it spends per day unless
+    it counts locally. These counters are the measurement that has to exist
+    before any polling behaviour is tuned.
+    """
+
+    HOUR = 3600
+    DAY = 86400
+
+    def _client(self, monkeypatch, now: float):
+        """A client whose clock is fixed at ``now`` and movable."""
+        import custom_components.govee.api.client as client_mod
+
+        clock = {"now": now}
+        monkeypatch.setattr(client_mod.time, "time", lambda: clock["now"])
+        return GoveeApiClient("test_key", session=MagicMock()), clock
+
+    def test_starts_at_zero(self, monkeypatch):
+        client, _ = self._client(monkeypatch, 1_000_000.0)
+
+        assert client.requests_today == 0
+        assert client.requests_last_24h == 0
+        assert client.requests_per_hour == 0.0
+
+    def test_counts_each_request(self, monkeypatch):
+        client, _ = self._client(monkeypatch, 1_000_000.0)
+
+        for _ in range(5):
+            client._note_request()
+
+        assert client.requests_today == 5
+        assert client.requests_last_24h == 5
+
+    def test_buckets_by_hour(self, monkeypatch):
+        client, clock = self._client(monkeypatch, 1_000_000.0)
+
+        client._note_request()
+        clock["now"] += self.HOUR
+        client._note_request()
+        client._note_request()
+
+        assert client.requests_last_24h == 3
+        assert len(client._request_buckets) == 2
+
+    def test_drops_history_older_than_24h(self, monkeypatch):
+        client, clock = self._client(monkeypatch, 1_000_000.0)
+
+        client._note_request()
+        # Walk forward a full day; the first hour must fall out of the window.
+        clock["now"] += 24 * self.HOUR
+        client._note_request()
+
+        assert client.requests_last_24h == 1
+        assert len(client._request_buckets) == 1
+
+    def test_history_is_bounded(self, monkeypatch):
+        """A week of traffic must not grow the history without limit."""
+        client, clock = self._client(monkeypatch, 1_000_000.0)
+
+        for _ in range(24 * 7):
+            client._note_request()
+            clock["now"] += self.HOUR
+
+        assert len(client._request_buckets) <= 24
+
+    def test_requests_today_resets_at_utc_midnight(self, monkeypatch):
+        # Start mid-day so the rollover is unambiguous.
+        start = 1_000_000.0
+        client, clock = self._client(monkeypatch, start)
+
+        client._note_request()
+        client._note_request()
+        assert client.requests_today == 2
+
+        # Cross into the next UTC day.
+        clock["now"] = (int(start // self.DAY) + 1) * self.DAY + 10
+        assert client.requests_today == 0
+
+        client._note_request()
+        assert client.requests_today == 1
+
+    def test_rolling_window_survives_the_day_rollover(self, monkeypatch):
+        """The trailing-24h figure is independent of the calendar reset."""
+        start = 1_000_000.0
+        client, clock = self._client(monkeypatch, start)
+
+        client._note_request()
+        clock["now"] = (int(start // self.DAY) + 1) * self.DAY + 10
+        client._note_request()
+
+        assert client.requests_today == 1
+        assert client.requests_last_24h == 2
+
+    def test_requests_per_hour_averages_held_history(self, monkeypatch):
+        client, clock = self._client(monkeypatch, 1_000_000.0)
+
+        for _ in range(10):
+            client._note_request()
+        clock["now"] += self.HOUR
+        for _ in range(20):
+            client._note_request()
+
+        # Two hourly buckets holding 30 requests.
+        assert client.requests_per_hour == 15.0
+
+    @pytest.mark.asyncio
+    async def test_handle_response_counts_the_request(self, monkeypatch):
+        """Every answered request is counted, whatever the status."""
+        client, _ = self._client(monkeypatch, 1_000_000.0)
+
+        response = MagicMock()
+        response.headers = {}
+        response.status = 200
+        response.json = AsyncMock(return_value={"code": 200, "data": {}})
+
+        await client._handle_response(response)
+
+        assert client.requests_today == 1
+
+    @pytest.mark.asyncio
+    async def test_rejected_request_still_counts(self, monkeypatch):
+        """A 429 consumed the allowance too — not counting it hides the spend."""
+        client, _ = self._client(monkeypatch, 1_000_000.0)
+
+        response = MagicMock()
+        response.headers = {}
+        response.status = 429
+        response.json = AsyncMock(return_value={"message": "rate limited"})
+
+        with pytest.raises(GoveeRateLimitError):
+            await client._handle_response(response)
+
+        assert client.requests_today == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4212,3 +4212,142 @@ class TestHumidityVerificationPoll:
         await self._scheduled_coro(coord)
 
         assert record["verification_poll"] == {"error": "boom"}
+
+
+class TestPerDeviceFetchIsolation:
+    """One slow device must not void the whole poll batch.
+
+    Before the per-device deadline, a single ``asyncio.timeout`` wrapped the
+    entire ``asyncio.gather``: one unreachable device meant `_async_update_data`
+    returned the previous states wholesale, so every other device's fresh
+    reading was thrown away. On a cloud-only house that is how a bulb stayed
+    stale for hours after a power cut.
+    """
+
+    DEVICE_A = "AA:BB:CC:DD:EE:FF:00:11"
+    DEVICE_B = "AA:BB:CC:DD:EE:FF:00:22"
+
+    def _coord(self, device_ids):
+        import custom_components.govee.coordinator as coord_mod
+
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        config_entry.options = {}
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=None,
+            poll_interval=60,
+        )
+        caps = (
+            GoveeCapability(
+                type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}
+            ),
+        )
+        for dev_id in device_ids:
+            coord._devices[dev_id] = GoveeDevice(
+                device_id=dev_id,
+                sku="H6008",
+                name=f"Bulb {dev_id[-2:]}",
+                device_type="devices.types.light",
+                capabilities=caps,
+                is_group=False,
+            )
+            coord._states[dev_id] = GoveeDeviceState.create_empty(dev_id)
+        coord.async_set_updated_data = MagicMock()
+        return coord, coord_mod
+
+    def _quieten(self, coord, monkeypatch):
+        """Stub the side paths _async_update_data runs around the fetch."""
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(coord, "_async_maybe_rediscover_devices", _noop)
+        monkeypatch.setattr(coord, "_async_maybe_rescan_lan", _noop)
+        monkeypatch.setattr(coord, "_refresh_lan_reads", _noop)
+        monkeypatch.setattr(coord._ble_handler, "enroll_from_cache", lambda: None)
+
+    @pytest.mark.asyncio
+    async def test_bounded_fetch_returns_timeout_instead_of_raising(
+        self, monkeypatch
+    ):
+        """A device that never answers yields a TimeoutError as a value."""
+        coord, coord_mod = self._coord([self.DEVICE_A])
+        monkeypatch.setattr(coord_mod, "STATE_FETCH_TIMEOUT", 0.01)
+
+        async def _hang(device_id, device):
+            await asyncio.sleep(5)
+
+        monkeypatch.setattr(coord, "_fetch_device_state", _hang)
+
+        result = await coord._fetch_device_state_bounded(
+            self.DEVICE_A, coord._devices[self.DEVICE_A]
+        )
+
+        assert isinstance(result, TimeoutError)
+
+    @pytest.mark.asyncio
+    async def test_bounded_fetch_passes_through_a_good_state(self, monkeypatch):
+        """The wrapper is transparent when the fetch answers in time."""
+        coord, _ = self._coord([self.DEVICE_A])
+        fresh = GoveeDeviceState.create_empty(self.DEVICE_A)
+        fresh.power_state = True
+
+        async def _ok(device_id, device):
+            return fresh
+
+        monkeypatch.setattr(coord, "_fetch_device_state", _ok)
+
+        result = await coord._fetch_device_state_bounded(
+            self.DEVICE_A, coord._devices[self.DEVICE_A]
+        )
+
+        assert result is fresh
+
+    @pytest.mark.asyncio
+    async def test_hanging_device_does_not_discard_the_others(self, monkeypatch):
+        """Device B's fresh reading survives Device A hanging past the deadline."""
+        coord, coord_mod = self._coord([self.DEVICE_A, self.DEVICE_B])
+        monkeypatch.setattr(coord_mod, "STATE_FETCH_TIMEOUT", 0.01)
+        self._quieten(coord, monkeypatch)
+
+        async def _fetch(device_id, device):
+            if device_id == self.DEVICE_A:
+                await asyncio.sleep(5)
+            fresh = GoveeDeviceState.create_empty(device_id)
+            fresh.power_state = True
+            fresh.source = "api"
+            return fresh
+
+        monkeypatch.setattr(coord, "_fetch_device_state", _fetch)
+
+        result = await coord._async_update_data()
+
+        # B landed despite A hanging.
+        assert result[self.DEVICE_B].power_state is True
+        assert result[self.DEVICE_B].source == "api"
+        # A kept its previous state rather than taking B's down with it.
+        assert result[self.DEVICE_A].power_state is not True
+
+    @pytest.mark.asyncio
+    async def test_batch_is_not_bounded_by_device_count(self, monkeypatch):
+        """Every device still gets its full deadline, in parallel."""
+        coord, coord_mod = self._coord([self.DEVICE_A, self.DEVICE_B])
+        monkeypatch.setattr(coord_mod, "STATE_FETCH_TIMEOUT", 0.5)
+        self._quieten(coord, monkeypatch)
+
+        async def _fetch(device_id, device):
+            await asyncio.sleep(0.05)
+            fresh = GoveeDeviceState.create_empty(device_id)
+            fresh.source = "api"
+            return fresh
+
+        monkeypatch.setattr(coord, "_fetch_device_state", _fetch)
+
+        result = await coord._async_update_data()
+
+        assert result[self.DEVICE_A].source == "api"
+        assert result[self.DEVICE_B].source == "api"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4529,3 +4529,115 @@ class TestSkipFullyDisabledDevices:
 
         assert called is False
         assert result is coord._states
+
+
+class TestDeviceIdPrefixCollisions:
+    """One device must never claim another's entities.
+
+    Entity unique_ids are the device id, optionally plus an underscore-led
+    suffix. A bare `startswith` test lets a device whose id is a strict prefix
+    of another's absorb that other device's entities. Group devices carry
+    purely numeric ids, so prefixes genuinely collide in a real install.
+
+    The failure is quiet: the short device sees the long device's enabled
+    entities, concludes it is still in use, and gets polled forever. Nothing
+    breaks, the saving just silently does not happen.
+    """
+
+    SHORT = "118259"
+    LONG = "11825917"
+
+    def _coord(self, device_ids):
+        import custom_components.govee.coordinator as coord_mod
+
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        config_entry.options = {}
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=None,
+            poll_interval=60,
+        )
+        caps = (
+            GoveeCapability(
+                type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}
+            ),
+        )
+        for dev_id in device_ids:
+            coord._devices[dev_id] = GoveeDevice(
+                device_id=dev_id,
+                sku="GROUP",
+                name=f"Group {dev_id}",
+                device_type="devices.types.group",
+                capabilities=caps,
+                is_group=True,
+            )
+            coord._states[dev_id] = GoveeDeviceState.create_empty(dev_id)
+        coord.async_set_updated_data = MagicMock()
+        return coord, coord_mod
+
+    def _with_registry(self, coord_mod, monkeypatch, entries):
+        monkeypatch.setattr(coord_mod.er, "async_get", lambda hass: MagicMock())
+        monkeypatch.setattr(
+            coord_mod.er,
+            "async_entries_for_config_entry",
+            lambda registry, entry_id: entries,
+        )
+
+    def test_entities_are_attributed_to_the_right_device(self, monkeypatch):
+        coord, coord_mod = self._coord([self.SHORT, self.LONG])
+        self._with_registry(coord_mod, monkeypatch, [])
+
+        assert coord._owning_device_id(self.SHORT) == self.SHORT
+        assert coord._owning_device_id(self.LONG) == self.LONG
+        assert coord._owning_device_id(f"{self.LONG}_scene_select") == self.LONG
+        assert coord._owning_device_id(f"{self.SHORT}_music_mode") == self.SHORT
+
+    def test_unrelated_unique_id_belongs_to_no_device(self, monkeypatch):
+        """Hub-level entities are keyed on the config entry, not a device."""
+        coord, coord_mod = self._coord([self.SHORT])
+        self._with_registry(coord_mod, monkeypatch, [])
+
+        assert coord._owning_device_id("test_entry_rate_limit") is None
+
+    def test_longer_devices_entities_do_not_rescue_the_shorter_one(
+        self, monkeypatch
+    ):
+        """The regression: SHORT is disabled, LONG is live, SHORT must skip."""
+        coord, coord_mod = self._coord([self.SHORT, self.LONG])
+        self._with_registry(
+            coord_mod,
+            monkeypatch,
+            [
+                _FakeRegistryEntry(self.SHORT, disabled_by="user"),
+                _FakeRegistryEntry(f"{self.SHORT}_scene_select", disabled_by="user"),
+                _FakeRegistryEntry(self.LONG, disabled_by=None),
+                _FakeRegistryEntry(f"{self.LONG}_scene_select", disabled_by=None),
+            ],
+        )
+
+        fully_disabled = coord._devices_with_all_entities_disabled()
+
+        assert self.SHORT in fully_disabled
+        assert self.LONG not in fully_disabled
+
+    def test_registry_is_walked_once_per_poll_not_once_per_device(
+        self, monkeypatch
+    ):
+        """Asking per device makes the poll quadratic in entity count."""
+        coord, coord_mod = self._coord([self.SHORT, self.LONG, "998877"])
+        calls = {"n": 0}
+
+        def _entries(registry, entry_id):
+            calls["n"] += 1
+            return [_FakeRegistryEntry(self.SHORT, disabled_by="user")]
+
+        monkeypatch.setattr(coord_mod.er, "async_get", lambda hass: MagicMock())
+        monkeypatch.setattr(coord_mod.er, "async_entries_for_config_entry", _entries)
+
+        coord._devices_with_all_entities_disabled()
+
+        assert calls["n"] == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4351,3 +4351,181 @@ class TestPerDeviceFetchIsolation:
 
         assert result[self.DEVICE_A].source == "api"
         assert result[self.DEVICE_B].source == "api"
+
+
+class _FakeRegistryEntry:
+    """Minimal stand-in for an entity registry entry."""
+
+    def __init__(self, unique_id: str, disabled_by: object = None) -> None:
+        self.unique_id = unique_id
+        self.disabled_by = disabled_by
+
+
+class TestSkipFullyDisabledDevices:
+    """Devices with every entity disabled must not cost a poll request.
+
+    Govee documents 10,000 requests/day. A house that migrated a batch of
+    bulbs to another protocol and disabled them here was still paying for
+    them on every cycle, for a result no entity would ever display.
+    """
+
+    ACTIVE = "AA:BB:CC:DD:EE:FF:00:11"
+    DISABLED = "AA:BB:CC:DD:EE:FF:00:22"
+
+    def _coord(self, device_ids):
+        import custom_components.govee.coordinator as coord_mod
+
+        hass = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        config_entry.options = {}
+        coord = coord_mod.GoveeCoordinator(
+            hass=hass,
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=None,
+            poll_interval=60,
+        )
+        caps = (
+            GoveeCapability(
+                type=CAPABILITY_ON_OFF, instance=INSTANCE_POWER, parameters={}
+            ),
+        )
+        for dev_id in device_ids:
+            coord._devices[dev_id] = GoveeDevice(
+                device_id=dev_id,
+                sku="H6008",
+                name=f"Bulb {dev_id[-2:]}",
+                device_type="devices.types.light",
+                capabilities=caps,
+                is_group=False,
+            )
+            coord._states[dev_id] = GoveeDeviceState.create_empty(dev_id)
+        coord.async_set_updated_data = MagicMock()
+        return coord, coord_mod
+
+    def _with_registry(self, coord_mod, monkeypatch, entries):
+        """Point the coordinator's registry lookup at a fixed entry list."""
+        monkeypatch.setattr(coord_mod.er, "async_get", lambda hass: MagicMock())
+        monkeypatch.setattr(
+            coord_mod.er,
+            "async_entries_for_config_entry",
+            lambda registry, entry_id: entries,
+        )
+
+    def test_all_entities_disabled_is_skipped(self, monkeypatch):
+        coord, coord_mod = self._coord([self.DISABLED])
+        self._with_registry(
+            coord_mod,
+            monkeypatch,
+            [
+                _FakeRegistryEntry(self.DISABLED, disabled_by="user"),
+                _FakeRegistryEntry(f"{self.DISABLED}_brightness", disabled_by="user"),
+            ],
+        )
+
+        assert coord._entities_all_disabled(self.DISABLED) is True
+
+    def test_one_enabled_entity_keeps_the_device_polled(self, monkeypatch):
+        coord, coord_mod = self._coord([self.ACTIVE])
+        self._with_registry(
+            coord_mod,
+            monkeypatch,
+            [
+                _FakeRegistryEntry(self.ACTIVE, disabled_by="user"),
+                _FakeRegistryEntry(f"{self.ACTIVE}_brightness", disabled_by=None),
+            ],
+        )
+
+        assert coord._entities_all_disabled(self.ACTIVE) is False
+
+    def test_device_with_no_entities_is_not_skipped(self, monkeypatch):
+        """First setup: entities don't exist yet and discovery must not stall."""
+        coord, coord_mod = self._coord([self.ACTIVE])
+        self._with_registry(coord_mod, monkeypatch, [])
+
+        assert coord._entities_all_disabled(self.ACTIVE) is False
+
+    def test_registry_failure_falls_back_to_polling(self, monkeypatch):
+        """A registry problem must never silently stop the poll."""
+        coord, coord_mod = self._coord([self.ACTIVE])
+
+        def _boom(hass):
+            raise RuntimeError("registry gone")
+
+        monkeypatch.setattr(coord_mod.er, "async_get", _boom)
+
+        assert coord._entities_all_disabled(self.ACTIVE) is False
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_disabled_device_and_keeps_the_rest(self, monkeypatch):
+        coord, coord_mod = self._coord([self.ACTIVE, self.DISABLED])
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(coord, "_async_maybe_rediscover_devices", _noop)
+        monkeypatch.setattr(coord, "_async_maybe_rescan_lan", _noop)
+        monkeypatch.setattr(coord, "_refresh_lan_reads", _noop)
+        monkeypatch.setattr(coord._ble_handler, "enroll_from_cache", lambda: None)
+
+        self._with_registry(
+            coord_mod,
+            monkeypatch,
+            [
+                _FakeRegistryEntry(self.ACTIVE, disabled_by=None),
+                _FakeRegistryEntry(self.DISABLED, disabled_by="user"),
+            ],
+        )
+
+        fetched: list[str] = []
+
+        async def _fetch(device_id, device):
+            fetched.append(device_id)
+            fresh = GoveeDeviceState.create_empty(device_id)
+            fresh.power_state = True
+            fresh.source = "api"
+            return fresh
+
+        monkeypatch.setattr(coord, "_fetch_device_state", _fetch)
+
+        result = await coord._async_update_data()
+
+        # Only the active device cost a request.
+        assert fetched == [self.ACTIVE]
+        assert result[self.ACTIVE].source == "api"
+        # The skipped device keeps its previous state rather than being dropped.
+        assert self.DISABLED in result
+        assert result[self.DISABLED].power_state is not True
+
+    @pytest.mark.asyncio
+    async def test_all_devices_disabled_makes_no_requests(self, monkeypatch):
+        coord, coord_mod = self._coord([self.ACTIVE, self.DISABLED])
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        monkeypatch.setattr(coord, "_async_maybe_rediscover_devices", _noop)
+        monkeypatch.setattr(coord._ble_handler, "enroll_from_cache", lambda: None)
+        self._with_registry(
+            coord_mod,
+            monkeypatch,
+            [
+                _FakeRegistryEntry(self.ACTIVE, disabled_by="user"),
+                _FakeRegistryEntry(self.DISABLED, disabled_by="user"),
+            ],
+        )
+
+        called = False
+
+        async def _fetch(device_id, device):
+            nonlocal called
+            called = True
+            return GoveeDeviceState.create_empty(device_id)
+
+        monkeypatch.setattr(coord, "_fetch_device_state", _fetch)
+
+        result = await coord._async_update_data()
+
+        assert called is False
+        assert result is coord._states

--- a/tests/test_rate_limit_sensor.py
+++ b/tests/test_rate_limit_sensor.py
@@ -1,0 +1,64 @@
+"""Tests for the API rate-limit diagnostic sensor."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.govee.const import GOVEE_DAILY_REQUEST_LIMIT
+from custom_components.govee.sensor import GoveeRateLimitSensor
+
+
+def _sensor(**overrides):
+    """A rate-limit sensor wired to a stub coordinator."""
+    coordinator = MagicMock()
+    coordinator.api_rate_limit_remaining = overrides.get("remaining", 87)
+    coordinator.api_rate_limit_total = overrides.get("total", 100)
+    coordinator.api_rate_limit_reset = overrides.get("reset", 1_700_000_000)
+    coordinator.api_requests_today = overrides.get("today", 4210)
+    coordinator.api_requests_last_24h = overrides.get("last_24h", 35112)
+    coordinator.api_requests_per_hour = overrides.get("per_hour", 1463.0)
+
+    sensor = object.__new__(GoveeRateLimitSensor)
+    sensor.coordinator = coordinator
+    return sensor
+
+
+class TestRateLimitSensorValue:
+    """The sensor's own value stays the per-minute allowance."""
+
+    def test_native_value_is_remaining(self):
+        assert _sensor(remaining=87).native_value == 87
+
+
+class TestRateLimitSensorAttributes:
+    """Daily spend is measured locally; Govee never reports it.
+
+    Without these attributes an install can only infer its daily usage from
+    arithmetic, which is how a house ends up ~3.5x over the documented cap
+    without anything surfacing it.
+    """
+
+    def test_keeps_existing_attributes(self):
+        attrs = _sensor().extra_state_attributes
+
+        assert attrs["total_limit"] == 100
+        assert attrs["reset_time"] == 1_700_000_000
+
+    def test_exposes_daily_spend(self):
+        attrs = _sensor(today=4210, last_24h=35112, per_hour=1463.0).extra_state_attributes
+
+        assert attrs["requests_today"] == 4210
+        assert attrs["requests_last_24h"] == 35112
+        assert attrs["requests_per_hour"] == 1463.0
+
+    def test_publishes_the_documented_cap_to_compare_against(self):
+        """A number is only actionable next to the limit it is measured against."""
+        attrs = _sensor().extra_state_attributes
+
+        assert attrs["daily_limit"] == GOVEE_DAILY_REQUEST_LIMIT
+        assert attrs["daily_limit"] == 10000
+
+    def test_over_cap_is_visible_from_the_attributes_alone(self):
+        attrs = _sensor(last_24h=35112).extra_state_attributes
+
+        assert attrs["requests_last_24h"] > attrs["daily_limit"]


### PR DESCRIPTION
Three related changes to the state-poll loop, from a cloud-API-only install with 55 devices.
Happy to split into separate PRs if you'd prefer — they're presented together because they touch
the same block and the second builds on the first.

## 1. Bound each device's poll separately

`_async_update_data` wrapped the whole `asyncio.gather` in one timeout scaled to device count
(`min(max(STATE_FETCH_TIMEOUT, n*2), 120)`). When it fired, **every** device's result was discarded
and the method returned the previous state — so one unreachable bulb cost the entire house its
update for that cycle.

Each fetch now carries its own `STATE_FETCH_TIMEOUT` deadline and returns the exception rather than
raising, so a device that never answers costs only its own slot.

**Note a behaviour change:** the effective window per device tightens from up to 88s at this device
count to a flat 30s. A device that answered in 45s used to succeed and now will not. That seemed
right for a REST call, but it is deliberate rather than incidental.

## 2. Don't poll devices whose entities are all disabled

The poll iterated every device with no reference to the entity registry. Polling a device whose
entities are all disabled buys nothing — no entity will ever show the result — while spending a
request against the documented 10,000/day budget every cycle.

The common cause is a device a better transport took over: moved to Matter, or controlled locally by
another integration, whose cloud twin was then disabled here rather than removed. Those twins stay
in the account device list forever, so on a mature install they can outnumber the devices still in
use. On the install this came from, **24 of 55 devices are disabled** — measured, not estimated.

Two deliberate guards: a device with no registry entries is still polled (that is normal during
first setup, and skipping would stall discovery), and a registry lookup failure falls back to
polling rather than silently stopping it. Skipped devices keep their last state rather than
vanishing from the returned mapping.

Entities are attributed to a device by exact match or `device_id + "_"`, not by prefix — group
devices have purely numeric ids, which collide by prefix far more readily than MAC-shaped ones.

## 3. Count requests against the daily cap

The per-minute allowance comes back in response headers; the documented 10,000/day one does not, so
there is no way for an install to know what it actually spends. Added a rolling counter on the
existing rate-limit sensor: requests today (UTC), a rolling 24h figure, and a mean per hour.

Hourly buckets rather than per-request timestamps — 24 small entries. Counted in `_handle_response`,
which is the funnel all REST call sites pass through; 429s are counted too, since a rejected request
still consumed the allowance. Documented as a lower bound, because transport-level failures never
reach that point.

## Tests

2075 passing, up from a 2044 baseline. Each test was verified to fail without its change. The
assertions are on the effect rather than the mechanism — that a request was *not* made, that a
slow device does not void the others, that the registry is walked once per poll regardless of
device count. flake8 clean; mypy clean apart from a pre-existing guarded import in `sensor.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
