### PR TITLE
feat(mqtt): add configurable MQTT status re-query interval

### DIFF
--- a/custom_components/govee/api/mqtt.py
+++ b/custom_components/govee/api/mqtt.py
@@ -1211,6 +1211,68 @@ class GoveeAwsIotClient:
             _LOGGER.error("Failed to publish %s: %s", cmd, err)
             return False
 
+    async def async_publish_status_query(
+        self,
+        device_topic: str | None,
+        *,
+        cmd_version: int = 2,
+    ) -> bool:
+        """Publish a status query to a device's own MQTT topic.
+
+        Mirrors the Govee Android app's own status request (``Cmd4Status`` /
+        ``Iot.A()``), which the app's device-list screen sends to every device
+        roughly every 30-60s while it is on screen. Reverse-engineering found
+        that devices in general are not reliably autonomous pushers — most
+        account-topic "status" traffic is a *reply* to this exact query, from
+        whoever last asked. Calling this periodically is what keeps every
+        MQTT-controlled device's state fresh without the Govee app open, not
+        just devices whose fields happen to have no REST poll fallback.
+
+        Deliberately not built on ``async_publish_command``: a status query
+        uses ``type: 0`` (query) with no ``data`` key, while that method
+        hardcodes ``type: 1`` (control) and always includes one — reusing it
+        here would publish a malformed request.
+
+        Args:
+            device_topic: Device-specific MQTT topic to query. Required for
+                          AWS IoT - obtained from undocumented API.
+            cmd_version: Command version. 2 matches the app's own default for
+                         status requests.
+
+        Returns:
+            True if publish succeeded, False otherwise.
+        """
+        if not self._connected or self._client is None:
+            _LOGGER.debug("Cannot publish status query: MQTT not connected")
+            return False
+
+        if not device_topic:
+            _LOGGER.debug("Cannot publish status query: No device topic available")
+            return False
+
+        payload = {
+            "msg": {
+                "cmd": "status",
+                "cmdVersion": cmd_version,
+                "transaction": f"v_{int(time.time() * 1000)}",
+                "type": 0,
+            }
+        }
+
+        try:
+            await self._client.publish(
+                device_topic, json.dumps(payload), qos=1, timeout=ACK_TIMEOUT
+            )
+            _LOGGER.debug("Published status query to %s...", device_topic[:30])
+            return True
+        except Exception as err:
+            _LOGGER.debug(
+                "Failed to publish status query to %s...: %s",
+                device_topic[:30],
+                err,
+            )
+            return False
+
     async def async_publish_ptreal(
         self,
         device_id: str,

--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_ENABLE_SCENES,
     CONF_EXPOSE_TRANSPORT_ENTITIES,
     CONF_LAN_TARGETS,
+    CONF_MQTT_STATUS_INTERVAL,
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
     CONF_PROBE_POLL_INTERVAL,
@@ -54,6 +55,7 @@ from .const import (
     DEFAULT_ENABLE_SCENES,
     DEFAULT_EXPOSE_TRANSPORT_ENTITIES,
     DEFAULT_LAN_TARGETS,
+    DEFAULT_MQTT_STATUS_INTERVAL,
     DEFAULT_POLL_INTERVAL,
     DEFAULT_PROBE_POLL_INTERVAL,
     DEFAULT_SEGMENT_MODE,
@@ -61,8 +63,10 @@ from .const import (
     DOMAIN,
     KEY_IOT_CREDENTIALS,
     KEY_IOT_LOGIN_FAILED,
+    MAX_MQTT_STATUS_INTERVAL,
     MAX_PROBE_POLL_INTERVAL,
     MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_MQTT_STATUS_INTERVAL,
     MIN_PROBE_POLL_INTERVAL,
     MIN_WATER_DETECTOR_POLL_INTERVAL,
     SEGMENT_MODE_BOTH,
@@ -456,6 +460,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
                     DEFAULT_WATER_DETECTOR_POLL_INTERVAL
                 ),
                 CONF_PROBE_POLL_INTERVAL: DEFAULT_PROBE_POLL_INTERVAL,
+                CONF_MQTT_STATUS_INTERVAL: DEFAULT_MQTT_STATUS_INTERVAL,
             },
         )
 
@@ -791,6 +796,19 @@ class GoveeOptionsFlow(OptionsFlow):
                         vol.Range(
                             min=MIN_PROBE_POLL_INTERVAL,
                             max=MAX_PROBE_POLL_INTERVAL,
+                        ),
+                    ),
+                    vol.Optional(
+                        CONF_MQTT_STATUS_INTERVAL,
+                        default=source.get(
+                            CONF_MQTT_STATUS_INTERVAL,
+                            DEFAULT_MQTT_STATUS_INTERVAL,
+                        ),
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(
+                            min=MIN_MQTT_STATUS_INTERVAL,
+                            max=MAX_MQTT_STATUS_INTERVAL,
                         ),
                     ),
                     vol.Optional(

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -25,6 +25,16 @@ CONF_ENABLE_MQTT_CONTROL: Final = "enable_mqtt_control"
 CONF_WATER_DETECTOR_POLL_INTERVAL: Final = "water_detector_poll_interval"
 CONF_PROBE_POLL_INTERVAL: Final = "probe_poll_interval"
 
+# Interval (seconds) for re-querying every MQTT-controlled device's own status
+# over AWS IoT. Reverse-engineering the Govee Android app found that
+# account-topic "status" pushes are overwhelmingly *replies* to an explicit
+# per-device status query the app's device-list screen sends every ~30-60s
+# while it is on screen (`AbsOnlyIotModel.checkIotOnline()`/`Iot.A()`) —
+# devices are not reliably autonomous pushers. Without ever asking, this
+# integration could go quiet the moment the Govee app was closed. Configurable
+# so accounts with many devices can back off from the app's own cadence.
+CONF_MQTT_STATUS_INTERVAL: Final = "mqtt_status_interval"
+
 # Extra LAN discovery targets for devices the local multicast scan can't reach —
 # e.g. Govee devices on a different VLAN/subnet than Home Assistant (issue #57).
 # Free-text list (comma / newline / space separated) of device IPs, broadcast
@@ -184,6 +194,11 @@ DEFAULT_WATER_DETECTOR_POLL_INTERVAL: Final = 120  # seconds (2 minutes)
 # update rate while cooking. 30 s keeps a roast legible without hammering
 # the device; the poll only runs while its live-polling switch is on.
 DEFAULT_PROBE_POLL_INTERVAL: Final = 30  # seconds
+# Slower than the Govee app's own ~30-60s cadence on purpose: this integration
+# queries every eligible device on every tick (the app only queries whatever
+# is currently on screen), so a lower default would multiply request volume
+# with device count. 5 minutes keeps most devices fresh without that.
+DEFAULT_MQTT_STATUS_INTERVAL: Final = 300  # seconds (5 minutes)
 
 # Bounds for the configurable water-detector poll interval (seconds). The lower
 # bound keeps the unverified account-API rate limit at arm's length; the upper
@@ -192,6 +207,12 @@ MIN_WATER_DETECTOR_POLL_INTERVAL: Final = 60
 MAX_WATER_DETECTOR_POLL_INTERVAL: Final = 3600
 MIN_PROBE_POLL_INTERVAL: Final = 10
 MAX_PROBE_POLL_INTERVAL: Final = 600
+
+# Bounds for the configurable MQTT status-poll interval (seconds). The lower
+# bound matches the fastest cadence observed from the Govee app itself, so
+# this integration can never out-poll what the app already does routinely.
+MIN_MQTT_STATUS_INTERVAL: Final = 60
+MAX_MQTT_STATUS_INTERVAL: Final = 3600
 
 # Optimistic state handling
 # Grace window (seconds) during which API polls do NOT overwrite optimistic

--- a/custom_components/govee/coordinator.py
+++ b/custom_components/govee/coordinator.py
@@ -73,11 +73,13 @@ from .const import (
     CONF_EMAIL,
     CONF_ENABLE_MQTT_CONTROL,
     CONF_LAN_TARGETS,
+    CONF_MQTT_STATUS_INTERVAL,
     CONF_PASSWORD,
     CONF_PROBE_POLL_INTERVAL,
     CONF_WATER_DETECTOR_POLL_INTERVAL,
     DEFAULT_API_TEMPERATURE_UNIT,
     DEFAULT_ENABLE_MQTT_CONTROL,
+    DEFAULT_MQTT_STATUS_INTERVAL,
     DEFAULT_PROBE_POLL_INTERVAL,
     DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DEVICE_REDISCOVERY_INTERVAL,
@@ -91,8 +93,10 @@ from .const import (
     LAN_WRITE_CONFIRM_TIMEOUT,
     LAN_WRITE_SUPPRESS_SECONDS,
     LAN_WRITE_SUPPRESS_THRESHOLD,
+    MAX_MQTT_STATUS_INTERVAL,
     MAX_PROBE_POLL_INTERVAL,
     MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_MQTT_STATUS_INTERVAL,
     MIN_PROBE_POLL_INTERVAL,
     MIN_WATER_DETECTOR_POLL_INTERVAL,
     OPTIMISTIC_GRACE_CAP_SECONDS,
@@ -450,6 +454,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # its live-polling switch on, so an idle thermometer is left alone.
         self._probe_poll_unsub: CALLBACK_TYPE | None = None
         self._probe_polling_enabled: set[str] = set()
+        # Periodic per-device MQTT status re-query (see async_publish_status_query
+        # docstring) — devices don't reliably push spontaneously; this is what the
+        # Govee app itself does while its device list is on screen.
+        self._status_poll_unsub: CALLBACK_TYPE | None = None
         # Last seen lastTime per detector — warnMessage is only called when the
         # device has freshly reported (or is currently wet), keeping the account
         # API request count low.
@@ -1056,6 +1064,16 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
             await self._run_startup_step(
                 self._fetch_device_topics(), "fetch device topics"
             )
+            # Devices are largely poll-triggered responders on their own MQTT
+            # topic, not autonomous pushers (see async_publish_status_query).
+            # The initial query itself is fired from _on_mqtt_connected, not
+            # here: _start_mqtt only spawns the connection-loop task and
+            # returns immediately, so a query attempted at this point would
+            # see client.connected still False (the TLS handshake and
+            # CONNACK/SUBACK haven't completed yet) and silently no-op. Arm
+            # the recurring timer here regardless, as a backstop independent
+            # of when the connection actually lands.
+            self._schedule_status_poll()
 
         # OpenAPI event subscription — needs only the API key (no account
         # login), so it runs regardless of IoT credentials. Failure-isolated:
@@ -3062,6 +3080,73 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
                     device_id, device.sku, build_limits_read_packet(probe)
                 )
 
+    @property
+    def _mqtt_status_poll_interval(self) -> int:
+        """Configured MQTT status-poll interval (seconds), clamped to bounds.
+
+        Read per tick so the value is picked up on the reload that follows an
+        options change. Out-of-range or non-numeric values (e.g. hand-edited
+        options) fall back to the default rather than arming a bad timer.
+        """
+        raw = self._config_entry.options.get(
+            CONF_MQTT_STATUS_INTERVAL, DEFAULT_MQTT_STATUS_INTERVAL
+        )
+        try:
+            interval = int(raw)
+        except (TypeError, ValueError):
+            return DEFAULT_MQTT_STATUS_INTERVAL
+        if not (MIN_MQTT_STATUS_INTERVAL <= interval <= MAX_MQTT_STATUS_INTERVAL):
+            return DEFAULT_MQTT_STATUS_INTERVAL
+        return interval
+
+    @property
+    def _mqtt_status_poll_targets(self) -> list[str]:
+        """Device IDs eligible for the periodic MQTT status re-query.
+
+        Any device with a known device-specific MQTT topic — anything the
+        coordinator could also publish a command to. Groups have no topic of
+        their own and are excluded.
+        """
+        return [
+            device_id
+            for device_id, device in self._devices.items()
+            if not device.is_group and device_id in self._device_topics
+        ]
+
+    def _schedule_status_poll(self) -> None:
+        """Schedule the next MQTT status re-query, replacing any pending timer."""
+        if self._status_poll_unsub:
+            self._status_poll_unsub()
+        self._status_poll_unsub = async_call_later(
+            self.hass, self._mqtt_status_poll_interval, self._status_poll_callback
+        )
+
+    async def _status_poll_callback(self, _now: Any = None) -> None:
+        """Periodic callback: re-query every eligible device, then re-arm."""
+        await self._poll_mqtt_status()
+        self._schedule_status_poll()
+
+    async def _poll_mqtt_status(self) -> None:
+        """Publish a status query to every device's own MQTT topic.
+
+        See ``GoveeAwsIotClient.async_publish_status_query`` for why this
+        exists — without it, devices that don't autonomously push (most of
+        them, per the Android app reverse-engineering) go stale the moment
+        nobody has asked in a while. Queries go out sequentially, one device
+        at a time, rather than in parallel: the interval already trades update
+        latency for request volume, so there is no reason to burst all of them
+        at once.
+        """
+        client = self._mqtt_client
+        if client is None or not client.connected:
+            return
+
+        for device_id in self._mqtt_status_poll_targets:
+            topic = self._device_topics.get(device_id)
+            if not topic:
+                continue
+            await client.async_publish_status_query(topic)
+
     async def async_set_probe_limits(
         self,
         device_id: str,
@@ -3334,6 +3419,18 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         # The MQTT status sensor and per-device connection-mode sensors read
         # the client; nudge them now rather than on the next poll.
         self.async_set_updated_data(self._states)
+        # Devices are poll-triggered responders (see async_publish_status_query)
+        # — query every device now that a session is actually confirmed live,
+        # rather than waiting up to a full _mqtt_status_poll_interval. This is
+        # the initial query for a fresh connection (a query attempted during
+        # _async_setup would race the handshake and lose — see the comment
+        # there) and also covers every later reconnect, so a drop-and-recover
+        # doesn't leave state stale for up to the full interval either.
+        self._config_entry.async_create_background_task(
+            self.hass,
+            self._poll_mqtt_status(),
+            name="govee_mqtt_connected_status_poll",
+        )
 
     @callback
     def _on_mqtt_disconnected(self) -> None:
@@ -4963,6 +5060,10 @@ class GoveeCoordinator(DataUpdateCoordinator[dict[str, GoveeDeviceState]]):
         if self._probe_poll_unsub:
             self._probe_poll_unsub()
             self._probe_poll_unsub = None
+        # Cancel periodic MQTT status re-query
+        if self._status_poll_unsub:
+            self._status_poll_unsub()
+            self._status_poll_unsub = None
 
         # Disconnect all BLE devices
         for ble_device in self._ble_devices.values():

--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -24,5 +24,5 @@
     "bleak-retry-connector>=3.0.0",
     "cryptography>=41.0.0"
   ],
-  "version": "2026.9.3"
+  "version": "2026.9.4"
 }

--- a/custom_components/govee/sensor.py
+++ b/custom_components/govee/sensor.py
@@ -104,6 +104,13 @@ async def async_setup_entry(
         # last data received and last command sent (directional freshness).
         entities.append(GoveeAllDataLastUpdatedSensor(coordinator, device))
         entities.append(GoveeLastCommandSentSensor(coordinator, device))
+        # "Last Update Received" above is the max across every transport, so a
+        # healthy Cloud API poll keeps it looking fresh even when MQTT
+        # specifically has been silent for hours — misleading for diagnosing
+        # devices whose state depends entirely on MQTT (no capability or poll
+        # fallback for some fields). This is the MQTT-only signal.
+        if coordinator.mqtt_client is not None:
+            entities.append(GoveeMqttLastReceivedPerDeviceSensor(coordinator, device))
         # Probe thermometers get dedicated per-probe entities instead of the
         # generic temperature sensor: one reading per probe and channel
         # cannot be expressed by a single sensorTemperature value.
@@ -705,6 +712,36 @@ class GoveeLastCommandSentSensor(GoveeEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:
         return self.coordinator.device_last_command_sent(self._device.device_id)
+
+
+class GoveeMqttLastReceivedPerDeviceSensor(GoveeEntity, SensorEntity):
+    """When this specific device last received an inbound MQTT push.
+
+    "Last Update Received" (``GoveeAllDataLastUpdatedSensor``) is the max
+    across every transport, so a healthy Cloud API poll (default every 60s)
+    keeps it looking fresh even when MQTT specifically has gone quiet for a
+    long time — misleading for diagnosing devices whose state depends
+    entirely on MQTT with no capability or poll fallback. This sensor
+    isolates the MQTT-only signal instead.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "mqtt_last_received_device"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:cloud-sync-outline"
+
+    def __init__(
+        self,
+        coordinator: GoveeCoordinator,
+        device: GoveeDevice,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.device_id}_mqtt_last_received"
+
+    @property
+    def native_value(self) -> datetime | None:
+        return self.coordinator.mqtt_last_receive_for(self._device.device_id)
 
 
 class GoveeConnectionModeSensor(GoveeEntity, SensorEntity):

--- a/custom_components/govee/strings.json
+++ b/custom_components/govee/strings.json
@@ -81,6 +81,7 @@
           "poll_interval": "Polling interval (seconds)",
           "water_detector_poll_interval": "Leak sensor polling interval (seconds)",
           "probe_poll_interval": "Probe thermometer polling interval (seconds)",
+          "mqtt_status_interval": "MQTT status re-query interval (seconds)",
           "api_temperature_unit": "Temperature unit from Govee API (thermometers)",
           "enable_groups": "Enable group devices",
           "enable_scenes": "Enable scene selector",
@@ -93,6 +94,7 @@
           "api_temperature_unit": "Auto (default) converts known Fahrenheit-reporting thermometers (e.g. H5179, H5109, H5110, H5111, H5053, H5075, H5100) automatically. Choose Fahrenheit if another thermometer reads about 1.8× too high (e.g. 74 instead of 23), or Celsius to force no conversion. Govee's API omits unit metadata, so the value can't always be auto-detected.",
           "water_detector_poll_interval": "How often standalone Govee water/leak detectors (e.g. H5054) are checked for a leak. These RF-only sensors have no push channel, so a leak surfaces with up to this much delay. Lower reacts faster but makes more account API calls; raise it if you have many detectors. Range 60–3600 seconds, default 120. Requires email/password login; ignored if you have no such detectors.",
           "probe_poll_interval": "How often an armed probe (cooking) thermometer such as the H5192 is read over AWS IoT while its Live polling switch is on. These devices never volunteer a reading, so this interval is the update rate. Costs battery rather than API quota. Range 10–600 seconds, default 30. Requires email/password login.",
+          "mqtt_status_interval": "How often every MQTT-connected device is asked for its current status over AWS IoT. Devices are largely poll-triggered responders, not autonomous pushers — this mirrors what the Govee app itself does while its device list is on screen, so state keeps updating without the app open. Lower reacts faster but publishes more per device; raise it if you have many devices. Range 60–3600 seconds, default 300. Requires email/password login (MQTT credentials); ignored when MQTT is unavailable.",
           "enable_groups": "Surfaces the device groups you created in the Govee app as single light entities. A command to a group is sent once and synced to all members by Govee's cloud, so it syncs better than grouping the lights with Home Assistant helpers. State is best-effort (groups can't be polled), and group lights only support power/brightness/color.",
           "enable_mqtt_control": "Routes power/brightness/color commands through Govee's MQTT channel instead of the REST cloud API, reducing latency and bypassing REST rate limits. Requires email/password login (MQTT credentials). Falls back to REST automatically when MQTT is unavailable. Experimental — uses an undocumented channel; leave off if commands behave unexpectedly.",
           "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network. Advanced: if a device still isn't found because its scan reply can't cross the VLAN, pin it with device_id=ip (AA:BB:CC:DD:EE:FF:00:11=10.20.0.51) to skip discovery for that device. Add a trailing ! (=10.20.0.51!) only for firmware that accepts LAN commands but never answers a status read — that turns off every LAN health check for the device, so a wrong IP will look like it is working while the device never responds."
@@ -268,6 +270,9 @@
       },
       "last_command_sent": {
         "name": "Last Command Sent"
+      },
+      "mqtt_last_received_device": {
+        "name": "Last MQTT Received"
       },
       "leak_battery": {
         "name": "Battery"

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -81,6 +81,7 @@
           "poll_interval": "Polling interval (seconds)",
           "water_detector_poll_interval": "Leak sensor polling interval (seconds)",
           "probe_poll_interval": "Probe thermometer polling interval (seconds)",
+          "mqtt_status_interval": "MQTT status re-query interval (seconds)",
           "api_temperature_unit": "Temperature unit from Govee API (thermometers)",
           "enable_groups": "Enable group devices",
           "enable_scenes": "Enable scene selector",
@@ -93,6 +94,7 @@
           "api_temperature_unit": "Auto (default) converts known Fahrenheit-reporting thermometers (e.g. H5179, H5109, H5110, H5111, H5053, H5075, H5100) automatically. Choose Fahrenheit if another thermometer reads about 1.8× too high (e.g. 74 instead of 23), or Celsius to force no conversion. Govee's API omits unit metadata, so the value can't always be auto-detected.",
           "water_detector_poll_interval": "How often standalone Govee water/leak detectors (e.g. H5054) are checked for a leak. These RF-only sensors have no push channel, so a leak surfaces with up to this much delay. Lower reacts faster but makes more account API calls; raise it if you have many detectors. Range 60–3600 seconds, default 120. Requires email/password login; ignored if you have no such detectors.",
           "probe_poll_interval": "How often an armed probe (cooking) thermometer such as the H5192 is read over AWS IoT while its Live polling switch is on. These devices never volunteer a reading, so this interval is the update rate. Costs battery rather than API quota. Range 10–600 seconds, default 30. Requires email/password login.",
+          "mqtt_status_interval": "How often every MQTT-connected device is asked for its current status over AWS IoT. Devices are largely poll-triggered responders, not autonomous pushers — this mirrors what the Govee app itself does while its device list is on screen, so state keeps updating without the app open. Lower reacts faster but publishes more per device; raise it if you have many devices. Range 60–3600 seconds, default 300. Requires email/password login (MQTT credentials); ignored when MQTT is unavailable.",
           "enable_groups": "Surfaces the device groups you created in the Govee app as single light entities. A command to a group is sent once and synced to all members by Govee's cloud, so it syncs better than grouping the lights with Home Assistant helpers. State is best-effort (groups can't be polled), and group lights only support power/brightness/color.",
           "enable_mqtt_control": "Routes power/brightness/color commands through Govee's MQTT channel instead of the REST cloud API, reducing latency and bypassing REST rate limits. Requires email/password login (MQTT credentials). Falls back to REST automatically when MQTT is unavailable. Experimental — uses an undocumented channel; leave off if commands behave unexpectedly.",
           "lan_targets": "Only needed when LAN-enabled Govee devices are on a different subnet/VLAN than Home Assistant, so the local discovery scan can't reach them. Enter a comma-separated list of device IPs (10.20.0.51), broadcast addresses (10.20.0.255), and/or subnets in CIDR (10.20.0.0/24, /24 or smaller). Subnets are scanned device-by-device since most routers drop cross-VLAN broadcasts. Leave blank if all devices share Home Assistant's network. Advanced: if a device still isn't found because its scan reply can't cross the VLAN, pin it with device_id=ip (AA:BB:CC:DD:EE:FF:00:11=10.20.0.51) to skip discovery for that device. Add a trailing ! (=10.20.0.51!) only for firmware that accepts LAN commands but never answers a status read — that turns off every LAN health check for the device, so a wrong IP will look like it is working while the device never responds."
@@ -268,6 +270,9 @@
       },
       "last_command_sent": {
         "name": "Last Command Sent"
+      },
+      "mqtt_last_received_device": {
+        "name": "Last MQTT Received"
       },
       "leak_battery": {
         "name": "Battery"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,16 +20,20 @@ from custom_components.govee.const import (
     CONF_ENABLE_GROUPS,
     CONF_ENABLE_SCENES,
     CONF_LAN_TARGETS,
+    CONF_MQTT_STATUS_INTERVAL,
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
     CONF_WATER_DETECTOR_POLL_INTERVAL,
     DEFAULT_ENABLE_DIY_SCENES,
     DEFAULT_ENABLE_GROUPS,
     DEFAULT_ENABLE_SCENES,
+    DEFAULT_MQTT_STATUS_INTERVAL,
     DEFAULT_POLL_INTERVAL,
     DEFAULT_WATER_DETECTOR_POLL_INTERVAL,
     DOMAIN,
+    MAX_MQTT_STATUS_INTERVAL,
     MAX_WATER_DETECTOR_POLL_INTERVAL,
+    MIN_MQTT_STATUS_INTERVAL,
     MIN_WATER_DETECTOR_POLL_INTERVAL,
 )
 
@@ -430,6 +434,55 @@ class TestWaterDetectorPollIntervalOption:
         with pytest.raises(vol.Invalid):
             result["data_schema"](
                 {CONF_POLL_INTERVAL: 60, CONF_WATER_DETECTOR_POLL_INTERVAL: value}
+            )
+
+
+class TestMqttStatusIntervalOption:
+    """The MQTT status re-query interval is exposed and bounded in the options
+    flow, matching the leak-poll interval's pattern.
+    """
+
+    @pytest.mark.asyncio
+    async def test_field_defaults_to_constant(self):
+        flow, entry = _options_flow()
+        result = await _run_init(flow, entry, None)
+        key = next(
+            k for k in result["data_schema"].schema if k == CONF_MQTT_STATUS_INTERVAL
+        )
+        assert key.default() == DEFAULT_MQTT_STATUS_INTERVAL
+
+    @pytest.mark.asyncio
+    async def test_field_seeded_from_saved_option(self):
+        flow, entry = _options_flow()
+        entry.options = {CONF_MQTT_STATUS_INTERVAL: 900}
+        result = await _run_init(flow, entry, None)
+        key = next(
+            k for k in result["data_schema"].schema if k == CONF_MQTT_STATUS_INTERVAL
+        )
+        assert key.default() == 900
+
+    @pytest.mark.asyncio
+    async def test_value_is_saved(self):
+        flow, entry = _options_flow()
+        result = await _run_init(
+            flow,
+            entry,
+            {CONF_POLL_INTERVAL: 60, CONF_MQTT_STATUS_INTERVAL: 600},
+        )
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_MQTT_STATUS_INTERVAL] == 600
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "value",
+        [MIN_MQTT_STATUS_INTERVAL - 1, MAX_MQTT_STATUS_INTERVAL + 1],
+    )
+    async def test_out_of_range_rejected_by_schema(self, value):
+        flow, entry = _options_flow()
+        result = await _run_init(flow, entry, None)
+        with pytest.raises(vol.Invalid):
+            result["data_schema"](
+                {CONF_POLL_INTERVAL: 60, CONF_MQTT_STATUS_INTERVAL: value}
             )
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2144,6 +2144,247 @@ class TestWaterDetectorPollInterval:
         assert seen["delay"] == 300
 
 
+class TestMqttStatusPollInterval:
+    """The MQTT status re-query interval is a user-configurable option.
+
+    Devices are largely poll-triggered responders rather than autonomous
+    pushers (see async_publish_status_query) — this is what keeps every
+    MQTT-controlled device's state fresh without the Govee app open.
+    """
+
+    def _coord_with_options(self, options):
+        import custom_components.govee.coordinator as coord_mod
+
+        config_entry = MagicMock()
+        config_entry.entry_id = "test_entry"
+        config_entry.options = options
+        return coord_mod.GoveeCoordinator(
+            hass=MagicMock(),
+            config_entry=config_entry,
+            api_client=MagicMock(),
+            iot_credentials=MagicMock(token="tok"),
+            poll_interval=60,
+        )
+
+    @staticmethod
+    def _device(device_id, is_group=False):
+        return GoveeDevice(
+            device_id=device_id,
+            sku="H6001",
+            name=device_id,
+            device_type="devices.types.light",
+            capabilities=(),
+            is_group=is_group,
+        )
+
+    def test_default_when_option_unset(self):
+        coord = self._coord_with_options({})
+        assert coord._mqtt_status_poll_interval == const.DEFAULT_MQTT_STATUS_INTERVAL
+
+    def test_configured_value_is_used(self):
+        coord = self._coord_with_options({const.CONF_MQTT_STATUS_INTERVAL: 600})
+        assert coord._mqtt_status_poll_interval == 600
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            const.MIN_MQTT_STATUS_INTERVAL - 1,
+            const.MAX_MQTT_STATUS_INTERVAL + 1,
+            "not-a-number",
+            None,
+        ],
+    )
+    def test_out_of_range_or_bad_value_falls_back(self, value):
+        """Hand-edited options must not arm a bad timer."""
+        coord = self._coord_with_options({const.CONF_MQTT_STATUS_INTERVAL: value})
+        assert coord._mqtt_status_poll_interval == const.DEFAULT_MQTT_STATUS_INTERVAL
+
+    def test_schedule_uses_configured_interval(self, monkeypatch):
+        import custom_components.govee.coordinator as coord_mod
+
+        coord = self._coord_with_options({const.CONF_MQTT_STATUS_INTERVAL: 90})
+        seen = {}
+
+        def _capture(hass, delay, callback):
+            seen["delay"] = delay
+            return lambda: None
+
+        monkeypatch.setattr(coord_mod, "async_call_later", _capture)
+        coord._schedule_status_poll()
+
+        assert seen["delay"] == 90
+
+    def test_schedule_cancels_a_pending_timer_first(self, monkeypatch):
+        """Rescheduling (e.g. after an options change) must not leak timers."""
+        import custom_components.govee.coordinator as coord_mod
+
+        coord = self._coord_with_options({})
+        monkeypatch.setattr(coord_mod, "async_call_later", lambda *a, **k: MagicMock())
+
+        coord._schedule_status_poll()
+        pending = coord._status_poll_unsub
+        coord._schedule_status_poll()
+
+        pending.assert_called_once()
+
+    def test_reschedules_after_each_callback(self, monkeypatch):
+        """The timer re-arms itself so polling continues indefinitely."""
+        import custom_components.govee.coordinator as coord_mod
+
+        coord = self._coord_with_options({})
+        calls: list[int] = []
+
+        def _capture(hass, delay, callback):
+            calls.append(delay)
+            return lambda: None
+
+        monkeypatch.setattr(coord_mod, "async_call_later", _capture)
+
+        async def _noop():
+            return None
+
+        coord._poll_mqtt_status = _noop
+        asyncio.get_event_loop().run_until_complete(coord._status_poll_callback())
+
+        assert calls == [const.DEFAULT_MQTT_STATUS_INTERVAL]
+
+    def test_poll_targets_exclude_groups_and_topicless_devices(self):
+        coord = self._coord_with_options({})
+        coord._devices = {
+            "A": self._device("A"),
+            "B": self._device("B", is_group=True),
+            "C": self._device("C"),
+        }
+        coord._device_topics = {"A": "GD/a"}  # B has no topic; C never got one
+
+        assert coord._mqtt_status_poll_targets == ["A"]
+
+    @pytest.mark.asyncio
+    async def test_poll_queries_every_eligible_device(self):
+        coord = self._coord_with_options({})
+        coord._devices = {
+            "A": self._device("A"),
+            "B": self._device("B"),
+        }
+        coord._device_topics = {"A": "GD/a", "B": "GD/b"}
+        mqtt_client = MagicMock()
+        mqtt_client.connected = True
+        mqtt_client.async_publish_status_query = AsyncMock(return_value=True)
+        coord._mqtt_client = mqtt_client
+
+        await coord._poll_mqtt_status()
+
+        from unittest.mock import call
+
+        assert mqtt_client.async_publish_status_query.await_args_list == [
+            call("GD/a"),
+            call("GD/b"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_a_target_with_a_falsy_topic(self):
+        """Defensive: a target is only reachable via _device_topics, but an
+        empty-string topic (rather than a missing key) must still be skipped
+        rather than published to.
+        """
+        coord = self._coord_with_options({})
+        coord._devices = {"A": self._device("A")}
+        coord._device_topics = {"A": ""}
+        mqtt_client = MagicMock()
+        mqtt_client.connected = True
+        mqtt_client.async_publish_status_query = AsyncMock(return_value=True)
+        coord._mqtt_client = mqtt_client
+
+        await coord._poll_mqtt_status()
+
+        mqtt_client.async_publish_status_query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_poll_is_a_no_op_without_a_connected_client(self):
+        coord = self._coord_with_options({})
+        coord._devices = {"A": self._device("A")}
+        coord._device_topics = {"A": "GD/a"}
+        coord._mqtt_client = None
+
+        await coord._poll_mqtt_status()  # must not raise
+
+        mqtt_client = MagicMock()
+        mqtt_client.connected = False
+        mqtt_client.async_publish_status_query = AsyncMock()
+        coord._mqtt_client = mqtt_client
+
+        await coord._poll_mqtt_status()
+
+        mqtt_client.async_publish_status_query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_async_setup_schedules_without_polling_immediately(self, monkeypatch):
+        """_async_setup must NOT attempt an immediate query itself.
+
+        Regression test: _start_mqtt only spawns the connection-loop task and
+        returns before the TLS handshake/CONNACK/SUBACK complete, so a query
+        attempted here would see client.connected still False and silently
+        no-op — state would stay empty until the first scheduled tick, up to
+        a full interval later. The initial query is instead fired from
+        _on_mqtt_connected (see the test below), once a session is actually
+        confirmed live. Setup only needs to arm the recurring timer.
+        """
+        import custom_components.govee.coordinator as coord_mod
+
+        coord = self._coord_with_options({})
+
+        async def _noop():
+            return None
+
+        monkeypatch.setattr(coord, "_discover_devices", _noop)
+        monkeypatch.setattr(coord, "_start_mqtt", _noop)
+        monkeypatch.setattr(coord, "_fetch_device_topics", _noop)
+        monkeypatch.setattr(coord, "_start_openapi_events", _noop)
+        monkeypatch.setattr(coord, "_discover_leak_sensors", _noop)
+        monkeypatch.setattr(coord, "_discover_bff_thermometers", _noop)
+        monkeypatch.setattr(coord, "_async_setup_lan", _noop)
+
+        poll_called = False
+
+        async def _poll():
+            nonlocal poll_called
+            poll_called = True
+
+        scheduled = False
+
+        def _schedule():
+            nonlocal scheduled
+            scheduled = True
+
+        monkeypatch.setattr(coord, "_poll_mqtt_status", _poll)
+        monkeypatch.setattr(coord, "_schedule_status_poll", _schedule)
+        monkeypatch.setattr(coord_mod, "async_call_later", lambda *a, **k: None)
+
+        await coord._async_setup()
+
+        assert scheduled is True
+        assert poll_called is False
+
+    def test_on_mqtt_connected_polls_status_in_the_background(self):
+        """A confirmed-live session is the reliable trigger for the initial
+        (and every reconnect's) status query — see the regression test above
+        for why _async_setup itself cannot do this reliably.
+        """
+        coord = self._coord_with_options({})
+        coord._config_entry = MagicMock()
+        seen: dict[str, Any] = {}
+
+        def _capture(hass, coro, name=None):
+            seen[name] = coro
+            coro.close()  # avoid an "never awaited" warning; call site is what's under test
+
+        coord._config_entry.async_create_background_task = _capture
+
+        coord._on_mqtt_connected()
+
+        assert "govee_mqtt_connected_status_poll" in seen
+
+
 class _AsyncCM:
     """Minimal async context manager yielding a configured inner mock."""
 
@@ -2944,6 +3185,19 @@ class TestLanLifecycle:
 
         unsub.assert_called_once()
         assert coord._probe_poll_unsub is None
+
+    @pytest.mark.asyncio
+    async def test_async_shutdown_cancels_status_poll_timer(self, monkeypatch):
+        """The MQTT status-poll timer must not outlive the entry either."""
+        coord, _ = self._coord()
+        coord._api_client.close = _make_async(None)
+        unsub = MagicMock()
+        coord._status_poll_unsub = unsub
+
+        await coord.async_shutdown()
+
+        unsub.assert_called_once()
+        assert coord._status_poll_unsub is None
 
     @pytest.mark.asyncio
     async def test_setup_lan_runs_last_in_async_setup(self, monkeypatch):

--- a/tests/test_diagnostic_entities.py
+++ b/tests/test_diagnostic_entities.py
@@ -13,7 +13,10 @@ from unittest.mock import MagicMock, patch
 
 from custom_components.govee.binary_sensor import GoveeDeviceConnectivity
 from custom_components.govee.models import TransportHealth
-from custom_components.govee.sensor import GoveeLastCommandSentSensor
+from custom_components.govee.sensor import (
+    GoveeLastCommandSentSensor,
+    GoveeMqttLastReceivedPerDeviceSensor,
+)
 
 
 def _device() -> MagicMock:
@@ -49,6 +52,54 @@ class TestLastCommandSentSensor:
         entity._device = device
         assert entity.native_value == ts
         coordinator.device_last_command_sent.assert_called_once_with(device.device_id)
+
+
+class TestMqttLastReceivedPerDeviceSensor:
+    """Isolates the MQTT-only freshness signal from "Last Update Received"
+    (the max across every transport), which stays "just now" from a healthy
+    Cloud API poll alone even when MQTT specifically has gone quiet.
+    """
+
+    def test_native_value_delegates(self):
+        ts = datetime(2026, 9, 11, tzinfo=timezone.utc)
+        coordinator = MagicMock()
+        coordinator.mqtt_last_receive_for.return_value = ts
+        device = _device()
+        with patch.object(
+            GoveeMqttLastReceivedPerDeviceSensor,
+            "__init__",
+            lambda self, *a, **k: None,
+        ):
+            entity = GoveeMqttLastReceivedPerDeviceSensor.__new__(
+                GoveeMqttLastReceivedPerDeviceSensor
+            )
+        entity.coordinator = coordinator
+        entity._device = device
+        assert entity.native_value == ts
+        coordinator.mqtt_last_receive_for.assert_called_once_with(device.device_id)
+
+    def test_native_value_none_before_any_mqtt_push(self):
+        coordinator = MagicMock()
+        coordinator.mqtt_last_receive_for.return_value = None
+        device = _device()
+        with patch.object(
+            GoveeMqttLastReceivedPerDeviceSensor,
+            "__init__",
+            lambda self, *a, **k: None,
+        ):
+            entity = GoveeMqttLastReceivedPerDeviceSensor.__new__(
+                GoveeMqttLastReceivedPerDeviceSensor
+            )
+        entity.coordinator = coordinator
+        entity._device = device
+        assert entity.native_value is None
+
+    def test_unique_id_is_scoped_to_the_device(self):
+        """The real __init__ (unpatched), for the unique_id it sets."""
+        coordinator = MagicMock()
+        device = _device()
+        entity = GoveeMqttLastReceivedPerDeviceSensor(coordinator, device)
+        assert entity.unique_id == f"{device.device_id}_mqtt_last_received"
 
 
 class TestDeviceConnectivity:

--- a/tests/test_mqtt_connection.py
+++ b/tests/test_mqtt_connection.py
@@ -226,6 +226,68 @@ class TestPublish:
         assert await client.async_publish_command("GD/topic", "turn", {"val": 1}) is False
 
 
+class TestPublishStatusQuery:
+    """The periodic per-device status re-query (mirrors the Govee app's own
+    Cmd4Status / Iot.A() request) — distinct envelope from async_publish_command:
+    type 0, no data key.
+    """
+
+    @pytest.mark.asyncio
+    async def test_builds_type_0_query_with_no_data_key(self):
+        client = GoveeAwsIotClient(_creds(), on_state_update=MagicMock())
+        client._connected = True
+        client._client = MagicMock()
+        client._client.publish = AsyncMock()
+
+        assert await client.async_publish_status_query("GD/topic") is True
+
+        args, kwargs = client._client.publish.call_args
+        assert args[0] == "GD/topic"
+        msg = json.loads(args[1])["msg"]
+        assert msg["cmd"] == "status"
+        assert msg["type"] == 0
+        assert msg["cmdVersion"] == 2
+        assert "data" not in msg
+        assert kwargs == {"qos": 1, "timeout": mqtt_mod.ACK_TIMEOUT}
+
+    @pytest.mark.asyncio
+    async def test_cmd_version_override(self):
+        client = GoveeAwsIotClient(_creds(), on_state_update=MagicMock())
+        client._connected = True
+        client._client = MagicMock()
+        client._client.publish = AsyncMock()
+
+        await client.async_publish_status_query("GD/topic", cmd_version=0)
+
+        args, _ = client._client.publish.call_args
+        assert json.loads(args[1])["msg"]["cmdVersion"] == 0
+
+    @pytest.mark.asyncio
+    async def test_not_connected_returns_false(self):
+        client = GoveeAwsIotClient(_creds(), on_state_update=MagicMock())
+        client._connected = False
+
+        assert await client.async_publish_status_query("GD/topic") is False
+
+    @pytest.mark.asyncio
+    async def test_no_topic_returns_false(self):
+        client = GoveeAwsIotClient(_creds(), on_state_update=MagicMock())
+        client._connected = True
+        client._client = MagicMock()
+
+        assert await client.async_publish_status_query(None) is False
+        assert await client.async_publish_status_query("") is False
+
+    @pytest.mark.asyncio
+    async def test_publish_failure_returns_false(self):
+        client = GoveeAwsIotClient(_creds(), on_state_update=MagicMock())
+        client._connected = True
+        client._client = MagicMock()
+        client._client.publish = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        assert await client.async_publish_status_query("GD/topic") is False
+
+
 class TestRestart:
     @pytest.mark.asyncio
     async def test_same_material_is_a_no_op(self):

--- a/tests/test_sweep_followups_2026_09b.py
+++ b/tests/test_sweep_followups_2026_09b.py
@@ -228,6 +228,12 @@ class TestDisconnectHook:
         coord = GoveeCoordinator.__new__(GoveeCoordinator)
         coord.hass = MagicMock()
         coord._config_entry = MagicMock()
+        # _on_mqtt_connected also schedules a background status-poll query;
+        # a bare MagicMock never awaits the coroutine it's handed, which
+        # leaks it and trips "coroutine was never awaited" under this
+        # project's filterwarnings=error. Close it instead of letting a
+        # real coordinator (with no devices/client set up) run it.
+        coord._config_entry.async_create_background_task = lambda hass, coro, name=None: coro.close()
         coord._states = {}
         coord.async_set_updated_data = MagicMock()
 


### PR DESCRIPTION
## Problem

This integration's core selling point is its IoT class: `cloud_push` — real-time device state over AWS IoT MQTT instead of slow polling. That promise silently breaks the moment MQTT hasn't heard from a device in a while: this integration only ever *listens* on the account topic, it never *asks* — so once a device stops volunteering pushes on its own, nothing brings it back. The impact splits into two failure modes depending on the field:

- **Fields with no Developer-API poll fallback at all freeze permanently, with no signal anything is wrong.** This isn't a corner case — it's already load-bearing in this codebase's own comments: H5127 occupancy (`bodyAppearedEvent`, "the developer poll returns only `online`... issue #124"), the entire H1310/H1370 ceiling-fan-combo state — on/off, speed, reverse, swing, named-light toggles ("the Developer poll returns `""` for every one of them... issue #181") — and (the case that surfaced this investigation) the H7152 dehumidifier's pump-fault flag, tank-vs-hose mode, and live temperature/humidity. Every one of these can sit on a stale value indefinitely: an occupancy sensor stuck "detected", a fan entity showing *on* when it's physically off, a pump fault that cleared hours ago still showing as active — with zero error, zero repair issue, nothing in the logs to point at why.
- **Fields that do have a poll fallback silently degrade** from "real-time push" to "whatever the ~60s poll cycle catches," with no way for a user to know they lost the responsiveness this integration advertises as its reason to prefer MQTT over polling in the first place.

Either way, any automation built on "the moment X happens, do Y" — exactly the use case a push architecture exists for — quietly stops being real-time, or stops updating at all, the moment nothing is asking. The only fix that actually closes this is for the integration to ask itself, on its own schedule, instead of depending entirely on unprompted pushes it cannot control or predict.

## Solution

- `GoveeAwsIotClient.async_publish_status_query()`: publishes a status query (`type: 0`, no `data` key) to a device's own MQTT topic — distinct from `async_publish_command`, which hardcodes `type: 1` and always includes a data payload; that envelope shape is documented in `docs/govee-protocol-reference.md`'s Command Envelope Details table.
- Coordinator-level periodic poll, mirroring the existing water-detector poll pattern: queries every device with a known MQTT topic.
- The initial query fires from `_on_mqtt_connected` (once a session is actually confirmed live via CONNACK+SUBACK), not from `_async_setup`: `_start_mqtt` only spawns the connection-loop task and returns immediately, so a query attempted during setup would see `client.connected` still `False` and silently no-op. This also means every later reconnect gets an immediate re-query too, not just the first connect.
- New options-flow field `mqtt_status_interval`: default 300s, range 60-3600s, matching the water-detector/probe-interval option pattern.
- New per-device "Last MQTT Received" diagnostic sensor: the existing "Last Update Received" sensor is the max timestamp across every transport, so a healthy Cloud API poll keeps it reading "just now" even when MQTT specifically has gone silent — misleading for diagnosing exactly the devices this PR is about. This isolates the MQTT-only signal so the problem stays visible and verifiable going forward, not just fixed once and forgotten.

## Compliance checklist (per `CONTRIBUTING.md`)

- [x] Conventional commit with scope (`feat(mqtt): ...`)
- [x] `black --line-length 119` clean
- [x] `flake8 --max-line-length 119` clean
- [x] `mypy` clean (no issues)
- [x] Google-style docstrings on new methods
- [x] Type hints on all new code
- [x] Respects existing architecture layering (protocol/publish logic in `api/mqtt.py`, orchestration in `coordinator.py`, options in `config_flow.py`/`const.py`, entity in `sensor.py`)
- [x] New tests covering the status-query envelope, the poll scheduling/targeting logic, the connect-triggered (not setup-triggered) initial query, the options-flow field, and the new sensor
- [x] `manifest.json` version bumped (`2026.9.3` → `2026.9.4`)

## Test plan

- [x] `pytest` — full suite 2073/2073 passing
- [x] 100% line coverage of every line this PR adds/touches (verified against `--cov-report=term-missing`, not just the aggregate percentage)
- [x] `black --line-length 119 --check --diff` — clean
- [x] `flake8 --max-line-length 119` — clean
- [x] `mypy` — Success, no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti2pwAMMVhFyZGwoNXZ2Xh